### PR TITLE
chore(F3): CATALOG_OWNERSHIP_BOOTSTRAP escape hatch + render.yaml durability mismatch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,5 +58,12 @@ STELLAR_NETWORK=testnet
 # SPONSOR_HARD_FLOOR_STROOPS=100000000
 # SPONSOR_BALANCE_INTERVAL_MS=60000
 
+# ESCAPE HATCH — leave unset. Derives ownership bindings from an existing catalog
+# file when the companion <CATALOG_FILE>.ownership store is absent, and DISABLES
+# the fail-closed protection while set. Grants no more trust than that file
+# already had. Set for ONE boot to migrate a pre-existing catalog, then remove.
+# Warns loudly on every boot while set. See docs/security-audit.md (F3).
+# CATALOG_OWNERSHIP_BOOTSTRAP=1
+
 # PORT=4100
 # HOST=0.0.0.0

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -398,6 +398,45 @@ first bite whenever someone sets `STELLAR_NETWORK=pubnet`. Revisit before that.
 | Per-IP rate limit | **60 / min** | `/health` exempt so the Render health check cannot trip. Keyed via `trustProxy: 1` — exactly one hop, because `true` is client-spoofable (RA-4). |
 | Body limit | **32 KiB** | Derived, not picked: largest real settlement envelope measured on-chain is 3,400 base64 chars (~2.5 KB), giving ~9.6x margin. |
 
+## Deployment posture — deliberate choices, not oversights
+
+### `VERIFICATION_API_URL` is deliberately UNCONFIGURED
+
+The hosted instance serves `"unknown"` for every trust verdict. **This is a
+decision, not a gap.** Configuring it makes that API a trust root — a compromised
+or merely wrong endpoint can assert `verified` — and two preconditions are
+unresolved:
+
+1. **Named precondition: the per-record timestamp.** The response carries no
+   timestamp, so "newest record" falls back to `records[0]`. A stale `verified`
+   can be read for a contract whose latest run actually failed. The consumer side
+   is already forward-compatible (`newestRecord()` sorts by `timestamp` /
+   `verifiedAt` / `createdAt` the moment any appears).
+2. The response is **unauthenticated** — no signature, no mTLS.
+
+`"unknown"` is the honest degrade. Enable it once (1) lands; do not enable it
+because it looks unset by accident.
+
+### `CATALOG_OWNERSHIP_BOOTSTRAP` is an escape hatch, not a feature
+
+Setting it derives ownership bindings from an existing catalog file when the
+companion ownership store is absent, and **disables the fail-closed protection**
+against a missing or deleted ownership store while set. It grants no more trust
+than that file already had — if an attacker wrote the file, they choose the
+owners.
+
+It is intentionally **absent from `render.yaml`**, off by default, and warns
+loudly on **every** boot while set (not only when exercised), on the same
+standard as the sibling repo's `ALLOW_INMEMORY`. Set it for a single boot to
+migrate a pre-existing catalog, then remove it.
+
+The trap it exists for: `render.yaml` points `CATALOG_FILE` at `/var/data`, but
+`plan: free` has no persistent disk — so today nothing survives and the
+fail-closed path never triggers. The first boot **after a disk is attached**
+finds a catalog with no ownership store and comes up healthy while serving an
+empty discovery catalog. `render.yaml` now carries that warning at the point of
+change.
+
 ## Still open
 
 | ID | Finding | Why |

--- a/render.yaml
+++ b/render.yaml
@@ -30,7 +30,31 @@ services:
       - key: MAX_TX_FEE_STROOPS
         value: "500000"
       # Bazaar catalog persistence (single-instance file store).
+      #
+      # NOTE: `plan: free` has NO persistent disk, so /var/data does NOT survive
+      # a restart or redeploy. This path therefore implies a durability that
+      # does not currently exist: the catalog is effectively in-memory and
+      # re-populates from the next settled payment. That is the documented
+      # free-tier behaviour, not a fault.
+      #
+      # BEFORE ATTACHING A DISK, read this. Once the files DO persist, the first
+      # boot after upgrading finds a catalog file with no companion
+      # `<CATALOG_FILE>.ownership` store — indistinguishable from an attacker
+      # deleting it — so the catalog FAILS CLOSED: it comes up healthy, serves
+      # settlements, and returns an EMPTY discovery catalog, signalled only by
+      # `catalogFrozen: "ownership-unreadable"` on /health.
+      #
+      # To migrate an existing catalog once, set CATALOG_OWNERSHIP_BOOTSTRAP=1 in
+      # the Render dashboard for a single boot, then REMOVE it. It is
+      # deliberately not declared here: it derives ownership from a file an
+      # attacker could have written, and it disables the fail-closed protection
+      # while set. It warns loudly on every boot.
       - key: CATALOG_FILE
         value: "/var/data/bazaar-catalog.json"
+      # Deliberately NOT set: VERIFICATION_API_URL. Unset, every trust verdict
+      # degrades to "unknown", which is the honest default. Configuring it makes
+      # that API a trust root, and its response still carries no per-record
+      # timestamp (so "newest" falls back to array order) and is unauthenticated.
+      # See docs/security-audit.md (F4) for the precondition before enabling.
       - key: SPONSOR_SECRET_KEY
         sync: false

--- a/src/config.bootstrap.test.ts
+++ b/src/config.bootstrap.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadConfig } from "./config.js";
+
+const SECRET = "SBJP6HHFTABK2GXVVFAKY6C4B7DDNB5PIEQXKUNL2ZAOBPWFOUOSTLVNMA";
+
+// CATALOG_OWNERSHIP_BOOTSTRAP is an ESCAPE HATCH, not a feature. It derives
+// ownership bindings from a catalog file an attacker could have written, so it
+// must announce itself on every boot — the same standard as the sibling repo's
+// ALLOW_INMEMORY. A one-line note in a doc loses to muscle memory months later.
+describe("CATALOG_OWNERSHIP_BOOTSTRAP escape hatch", () => {
+  it("defaults to off", () => {
+    const c = loadConfig({ SPONSOR_SECRET_KEY: SECRET });
+    expect(c.catalogOwnershipBootstrap).toBe(false);
+  });
+
+  it("warns LOUDLY at boot whenever it is set — even if never used", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadConfig({ SPONSOR_SECRET_KEY: SECRET, CATALOG_OWNERSHIP_BOOTSTRAP: "1" });
+    const said = warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(said).toMatch(/CATALOG_OWNERSHIP_BOOTSTRAP/);
+    // The log must state exactly what trust it grants: none beyond the file.
+    expect(said).toMatch(/no more trust than that file already had|grants no/i);
+    // And that it is meant to be temporary.
+    expect(said).toMatch(/remove|once|temporar/i);
+    warn.mockRestore();
+  });
+
+  it("does not warn when unset", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadConfig({ SPONSOR_SECRET_KEY: SECRET });
+    const said = warn.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(said).not.toMatch(/CATALOG_OWNERSHIP_BOOTSTRAP/);
+    warn.mockRestore();
+  });
+
+  it("treats only an explicit truthy value as enabled", () => {
+    for (const v of ["0", "false", "", "no"]) {
+      expect(
+        loadConfig({ SPONSOR_SECRET_KEY: SECRET, CATALOG_OWNERSHIP_BOOTSTRAP: v }).catalogOwnershipBootstrap,
+        `value ${JSON.stringify(v)} must not enable the hatch`,
+      ).toBe(false);
+    }
+    for (const v of ["1", "true", "TRUE"]) {
+      expect(
+        loadConfig({ SPONSOR_SECRET_KEY: SECRET, CATALOG_OWNERSHIP_BOOTSTRAP: v }).catalogOwnershipBootstrap,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,13 @@ export interface FacilitatorConfig {
     /** Global spend window in ms (default 60_000). */
     windowMs: number;
   };
+  /**
+   * ESCAPE HATCH (F3). Permits deriving ownership bindings from an existing
+   * catalog file when the companion ownership store is absent — the state a
+   * first upgrade produces, and equally the state a tamperer produces. Off by
+   * default; must be set deliberately and removed once the upgrade is done.
+   */
+  catalogOwnershipBootstrap: boolean;
   /** Fix 3 sponsor balance guard floors, in stroops. */
   balance: {
     /** Warn below this (default 10 XLM). */
@@ -92,8 +99,24 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
     );
   }
 
+  // Announce the escape hatch on EVERY boot while it is set, not only when it
+  // is exercised. A quiet flag that silently downgrades a security control is
+  // how "temporary" becomes permanent.
+  const catalogOwnershipBootstrap = /^(1|true)$/i.test(env.CATALOG_OWNERSHIP_BOOTSTRAP ?? "");
+  if (catalogOwnershipBootstrap) {
+    console.warn(
+      "[config] CATALOG_OWNERSHIP_BOOTSTRAP is SET. On boot, if the catalog file exists without its " +
+        "companion ownership store, ownership bindings will be DERIVED FROM THAT CATALOG FILE. " +
+        "It grants no more trust than that file already had — if an attacker wrote the file, they " +
+        "choose the owners. This exists only to migrate a pre-existing catalog once; REMOVE IT " +
+        "immediately afterwards. While it is set, the fail-closed protection against a missing or " +
+        "deleted ownership store is DISABLED.",
+    );
+  }
+
   return {
     port: Number(env.PORT ?? 4100),
+    catalogOwnershipBootstrap,
     host: env.HOST ?? "0.0.0.0",
     network,
     rpcUrl: env.STELLAR_RPC_URL,

--- a/src/hardening.test.ts
+++ b/src/hardening.test.ts
@@ -21,6 +21,7 @@ const testConfig = {
   verificationApiUrl: undefined,
   spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
+  catalogOwnershipBootstrap: false,
 };
 
 function requirements(): PaymentRequirements {

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -20,6 +20,7 @@ const testConfig = {
   verificationApiUrl: undefined,
   spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
+  catalogOwnershipBootstrap: false,
 };
 
 // A structurally VALID transaction envelope. /settle now shreds unparseable XDR

--- a/src/server.ts
+++ b/src/server.ts
@@ -284,7 +284,9 @@ function isParseableTransactionXdr(payload: PaymentPayload): boolean {
 const isDirectRun = process.argv[1]?.endsWith("server.ts") || process.argv[1]?.endsWith("server.js");
 if (isDirectRun) {
   const config = loadConfig();
-  const catalog = new BazaarCatalog(config.catalogFile);
+  const catalog = new BazaarCatalog(config.catalogFile, {
+    bootstrapOwnership: config.catalogOwnershipBootstrap,
+  });
   const { createTrustResolver } = await import("./trust.js");
   const trust = createTrustResolver({
     verificationApiUrl: config.verificationApiUrl,


### PR DESCRIPTION
Follow-up to #1. Closes the operator escape hatch the F3 fail-closed path needed, and fixes a config file that implies durability it doesn't have.

**Reordered ahead of F12 deliberately:** the frozen-catalog state does not crash. It comes up healthy, serves settlements normally, and returns an empty discovery catalog — so it gets noticed weeks later or not at all. "Do this before attaching a disk" is a rule living in a doc, and the person attaching the disk will be doing what feels like an infra task, months from now.

## The gap

`bootstrapOwnership` existed as a constructor option but **nothing set it**. An operator meeting `catalogFrozen: "ownership-unreadable"` had no supported way out except deleting the catalog file.

## Escape hatch, not a feature

`CATALOG_OWNERSHIP_BOOTSTRAP` is held to the same standard as the sibling repo's `ALLOW_INMEMORY`:

- **Off by default**; only an explicit `1`/`true` enables it
- **Warns loudly at every boot while set** — not only when exercised, because a quiet flag that silently downgrades a security control is how "temporary" becomes permanent
- The log states exactly what trust it grants: **none beyond what the catalog file already had.** If an attacker wrote the file, they choose the owners. It also states that the fail-closed protection is **disabled while set**, and that it must be removed after the single migration boot
- **Deliberately absent from `render.yaml`**

## The `render.yaml` mismatch

`CATALOG_FILE` pointed at `/var/data` as though it persists, while `plan: free` has no disk. Now documented at the point of change, including the part that matters: the first boot **after a disk is attached** is exactly what triggers the frozen state, and how to migrate through it once.

## Also recorded

`VERIFICATION_API_URL` is **deliberately unconfigured**, with the per-record timestamp as the named precondition — so nobody switches it on believing it was an oversight. Pointing at an unauthenticated API with an unresolved ordering contract would make it a trust root before it's ready.

## Verification

Tested end to end, not reasoned about: frozen without the hatch, migrated with it, both warnings emitted. **181 tests**, typecheck clean.

## Next

F12 (per-payTo / per-bound-URL spend accounting) is the first pubnet blocker after this — raising the ceiling doesn't fix the shape.
