### PR TITLE
fix(F12): per-entity spend accounting — fairness between merchants, keyed off the F11 bindings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,21 @@ STELLAR_NETWORK=testnet
 # merchants: deliberately tight and UNREVIEWED against real pubnet traffic.
 # Per-settle spend is estimated at MAX_TX_FEE_STROOPS, so accounting over-counts
 # and the ceiling fails safe (bites earlier, not later):
-# SPEND_CEILING_STROOPS=10000000
+# SPEND_CEILING_STROOPS=50000000
+#
+# F12 per-entity budgets — keyed on the DURABLE F11 ownership binding, never on
+# verifiedOwner (which is not persisted and resets on restart; keying on it would
+# drop every merchant into the shared unbound pool after a reboot).
+#   per bound URL: 10/60s  — one merchant sustains 10 settlements/min
+#   per payTo:    100/60s  — equals the global ceiling, so it never binds honest
+#                            traffic today; a ratchet that starts working only if
+#                            the global ceiling is later raised
+#   unbound pool:  10/60s  — shared by ALL unbound URLs, sized at exactly ONE
+#                            bound URL's budget, so spraying N unverified URLs
+#                            yields 10/N each. That ratio is the economic signal.
+# SETTLE_PER_URL_MAX=10
+# SETTLE_PER_PAYTO_MAX=100
+# SETTLE_UNBOUND_POOL_MAX=10
 # SPEND_WINDOW_MS=60000
 
 # Fix 2 — baseline hardening (helmet headers, CORS, per-IP rate limit, 32 KiB

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 .env
+.env.*
+!.env.example
+!.env.recording.example
 *.log

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -454,19 +454,27 @@ change.
 
 | ID | Finding | Why |
 | --- | --- | --- |
-| **F12** | Spend accounting was global while rate limiting was per-IP | **closed-by-test** — per-entity budgets keyed off the F11 bindings. See the control-scope table below for what this does and does not achieve. |
-| **F3** | Non-atomic `save()`, unbounded entries/`accepts` | Not fixed on any branch. Interacts with F11 — eviction drops ownership bindings. |
+| **G-1** | Ownership verification lost on restart, never recovers — and it is **served to agents** | **open** — latent until a persistent disk is attached. Remediation named below; the backoff value needs threshold sign-off. |
+| **G-2** | A bound URL has no `payTo` rotation path | **open** — manual operator procedure exists and must be documented; the automated fix trades away F11's takeover resistance. |
 | **F4-ts** | Verification API has no per-record timestamp | **external** — needs the API to emit one; consumer side is already forward-compatible. |
-| **F10-op** | `examples/.env.recording` holds a live testnet `AGENT_SECRET` | Operational; needs rotation and scrub. |
 | **RA-14r** | RFC 6052 non-`/96` NAT64 offsets | deferred; not reachable in the current deployment. |
 | **F5** | Settle/confirm reconciliation | deferred; integration-level. |
 
+Closed since this table was first written (kept here so the history is not lost):
+
+| ID | Finding | Resolution |
+| --- | --- | --- |
+| **F12** | Spend accounting was global while rate limiting was per-IP | **closed-by-test** — per-entity budgets keyed off the F11 bindings. See the control-scope table for what this does and does not achieve. |
+| **F3** | Non-atomic `save()`, unbounded entries/`accepts` | **closed-by-test** — atomic writes, bounds, and ownership tombstones so eviction cannot drop a binding. |
+| **F10-op** | `examples/.env.recording` held a live testnet `AGENT_SECRET` | **closed** — signer removed on-chain and confirmed `null`, local copies deleted. See the `argv` lesson above. |
+
 ---
 
-### F12 — Spend controls throttle honest load, not a distributed attacker — **High** — **OPEN**
+### F12 — Spend controls throttle honest load, not a distributed attacker — **High** — closed-by-test
 
 Surfaced while sizing the thresholds, and it is a shape problem rather than a
-number problem.
+number problem. The analysis below is the original finding; the fix that followed
+it is per-entity budgeting keyed off the F11 bindings.
 
 The two spend controls are keyed on different, wrong things:
 
@@ -528,6 +536,113 @@ sponsor-exposure dial, not a security control — the balance guard is the contr
 **Sequencing: this is the first pubnet blocker after merge, ahead of the
 threshold review.** Reviewing the numbers before fixing the shape would produce a
 confidently-tuned control that still fails against the attacker it targets.
+
+---
+
+## Known gaps found while reviewing F12 — G-1, G-2
+
+Both surfaced from one question: *`verifiedOwner` is forced false on load — what
+else reads it, and what happens to a URL whose 402 challenge later changes?*
+Neither is caused by F12, and neither blocks it. Both are **latent on the current
+hosted deployment and become live the moment a persistent disk is attached** —
+the same upgrade that trips the fail-closed ownership trap described in
+`render.yaml`. On `plan: free` there is no disk, so every boot starts from an
+empty catalog, every URL is a first catalog again, and verification re-runs
+naturally. **Fix both before attaching a disk.**
+
+Characterized end-to-end through the real routes in
+`src/catalog.restart-verification.test.ts`. Those are *characterization* tests:
+they pin current behaviour, not desired behaviour. Fixing either gap should make
+them fail — update the tests and this section together.
+
+### G-1 — Ownership verification is lost on restart and never recovers — **High (latent)** — **OPEN**
+
+`verifiedOwner` is deliberately not trusted from disk (RA-9: a crafted
+`CATALOG_FILE` could forge it), so `load()` forces it `false`. But Layer 2
+verification fires only under `if (firstCatalog)` in `src/bazaar.ts`, and
+`isFirstCatalog` is `existing === undefined` — false for every entry loaded from
+disk. **Nothing re-verifies, ever.**
+
+It is **not** an internal signal. Every reader:
+
+| Reader | Post-restart behaviour |
+| --- | --- |
+| `catalog.isVerifiedOwner(url)` | Returns `false` for every restored entry, permanently. |
+| `annotateTrust(..., ownerVerifiedFn)` — both `/discovery/resources` and `/discovery/search` | Computes `ownerVerified: false`. |
+| `trust.ownerVerified` in the response body | **Served to agents as `false`** — a previously-verified merchant is now indistinguishable from one that failed verification. |
+| `clampByOwner` → `trust.acceptsVerification` | Every per-accepts `"verified"` is clamped down to `"unknown"`. |
+| `trust.verification` (strict min of the clamped verdicts) | Can never read `"verified"`. |
+| `filterVerifiedOnly` (`?verified_only=true`) | **Returns an empty catalog.** Reads as "this facilitator has no trustworthy resources". |
+| `rerankVerifiedFirst` (`/discovery/search`) | Every entry lands in the same `"unknown"` band, so trust-ranking silently flattens to input order. |
+
+This is a **wrong answer served to consumers**, not a throttle. An agent that
+trusts `verified_only` gets nothing; an agent that reads `ownerVerified` gets
+`false` for a merchant that passed.
+
+The `bindLoadedEntry` comment previously asserted *"Layer 2 re-verifies from the
+resource on the next settlement."* That was **false**, and it is why the gap
+stayed invisible — the intended recovery path was documented but never wired. The
+comment now states the actual behaviour and points here.
+
+**Remediation (named, not yet implemented): re-verify on settle when not
+currently verified** — widen the trigger in `src/bazaar.ts` from
+`if (firstCatalog)` to *"first catalog **or** not currently verified"*. This is
+completing the stated intent rather than changing policy. It is preferred over
+the two alternatives:
+
+- *Persist `verifiedOwner`* — reopens RA-9 directly. The flag becomes forgeable
+  again by anyone who can write either file. Rejected.
+- *Re-verify every loaded entry at boot* — an outbound request per entry at
+  startup (up to `MAX_ENTRIES`), a self-inflicted thundering herd, and it delays
+  readiness. Rejected in favour of self-healing on real traffic.
+
+**Needs sign-off before implementing:** a negative-result backoff interval, so a
+resource that cannot be verified is not re-probed on every single settlement.
+That is a threshold value, so it belongs in the threshold review rather than
+being picked here.
+
+### G-2 — A bound URL has no `payTo` rotation path — **Medium** — **OPEN**
+
+Confirmed: once `ownership.set(url, [payTo])` happens, the binding is never
+appended to or replaced except by reading the ownership file from disk. There is
+no method on `BazaarCatalog` and no route on the server that rotates it. A
+merchant rotating their payment address is refused by `upsertFromPayment`, and
+the F3 tombstone means waiting for eviction does not help either.
+
+**What the merchant actually loses is narrower — and sharper — than "payments
+break".** The rejection happens inside `onAfterSettle`, i.e. *after* settlement
+already succeeded on-chain, and `registerBazaar` swallows its own errors. So:
+
+- The payment **settles normally** and the merchant is paid at the new address.
+- The **catalog entry keeps advertising the old address** to every agent.
+- `recordSettlement` runs **unconditionally**, after the rejected upsert — so
+  settlements made to the *new* address still accrue to the entry advertising the
+  *old* one. **The stale entry looks more trustworthy over time.**
+
+That last point is the real hazard. A merchant who rotates away from a
+compromised or abandoned address cannot stop the catalog from advertising it, and
+the entry's trust signals keep climbing while it does.
+
+**Remediation (named):**
+
+- **Now — the manual operator path.** Rotation is possible today by stopping the
+  service, editing `<CATALOG_FILE>.ownership` to add the new `payTo`, and
+  restarting. This should be documented as the supported procedure. It is
+  deliberately operator-mediated: this repo has no auth layer by design, so there
+  is no safe in-band way to authorize a rotation request.
+- **Later, and only with an explicit decision — automated re-challenge.** Re-run
+  the 402 challenge when an unbound `payTo` appears for a bound URL, and append it
+  if the resource's *current* challenge names it. This is the same proof used at
+  first bind, **but it deliberately trades away exactly the property F11 was built
+  for**: a domain that has changed hands can serve the challenge, so takeover
+  becomes rebinding. Do not ship this as a convenience fix; it is a decision about
+  whether TOFU-permanent or TOFU-with-recovery is wanted.
+
+**Do not let a merchant discover this by not getting paid.** The manual procedure
+above should be in operator docs before any merchant is onboarded on a deployment
+with a persistent disk.
+
+---
 
 ## What `main` is running today
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -456,6 +456,8 @@ change.
 | --- | --- | --- |
 | **G-1** | Ownership verification lost on restart, never recovers — and it is **served to agents** | **open** — latent until a persistent disk is attached. Remediation named below; the backoff value needs threshold sign-off. |
 | **G-2** | A bound URL has no `payTo` rotation path | **open** — manual operator procedure exists and must be documented; the automated fix trades away F11's takeover resistance. |
+| **G-4** | `recordSettlement` lets anyone inflate a victim entry's trust stats | **open** — highest-value of the review findings; no `payTo` check, and it runs after a rejected upsert. |
+| **G-5**–**G-8** | Load-path squat, unbounded load, unpersisted bootstrap bindings, one-way tombstone cap | **open** — triaged below, none fixed. |
 | **F4-ts** | Verification API has no per-record timestamp | **external** — needs the API to emit one; consumer side is already forward-compatible. |
 | **RA-14r** | RFC 6052 non-`/96` NAT64 offsets | deferred; not reachable in the current deployment. |
 | **F5** | Settle/confirm reconciliation | deferred; integration-level. |
@@ -561,7 +563,23 @@ them fail — update the tests and this section together.
 `CATALOG_FILE` could forge it), so `load()` forces it `false`. But Layer 2
 verification fires only under `if (firstCatalog)` in `src/bazaar.ts`, and
 `isFirstCatalog` is `existing === undefined` — false for every entry loaded from
-disk. **Nothing re-verifies, ever.**
+disk. **Nothing re-verifies under normal traffic.**
+
+> **Precision, corrected.** An earlier draft of this section said *never* and
+> *forever*. That is wrong, and adversarial review caught it. There is exactly
+> one path back: `evictToCap()` removing the entry once the catalog exceeds
+> `MAX_ENTRIES` (10,000) makes the next settle a first-catalog again, which does
+> re-verify — confirmed by probe. It is not a usable recovery path (it needs
+> >10,000 entries and evicts the LRU victim), but it must not be mistaken for
+> one: **do not "fix" G-1 by relying on cache pressure.**
+
+> **Also corrected:** `verifiedOwner` *is* written to `CATALOG_FILE` — `flush()`
+> serializes whole `StoredEntry` objects. It is simply never read back (the load
+> schema cannot carry it). Four comment sites and `.env.example` say "not
+> persisted", which is imprecise: **written, never read**. An operator inspecting
+> the file will see `verifiedOwner: true` that the code deliberately refuses to
+> honour. The same is true of `boundPayTo` and `stats.observed`. Harmless today,
+> and exactly the shape that becomes RA-9 again if a future loader trusts them.
 
 It is **not** an internal signal. Every reader:
 
@@ -574,6 +592,7 @@ It is **not** an internal signal. Every reader:
 | `trust.verification` (strict min of the clamped verdicts) | Can never read `"verified"`. |
 | `filterVerifiedOnly` (`?verified_only=true`) | **Returns an empty catalog.** Reads as "this facilitator has no trustworthy resources". |
 | `rerankVerifiedFirst` (`/discovery/search`) | Every entry lands in the same `"unknown"` band, so trust-ranking silently flattens to input order. |
+| `applyVerifiedOnly` in `src/mcp.ts` (both MCP tools) | **A third consumer**, missed on the first pass and found by adversarial review. The MCP surface filters on the same clamped `trust.verification`, so agents reaching the catalog over MCP — the primary intended consumer — get the empty answer too. |
 
 This is a **wrong answer served to consumers**, not a throttle. An agent that
 trusts `verified_only` gets nothing; an agent that reads `ownerVerified` gets
@@ -641,6 +660,57 @@ the entry's trust signals keep climbing while it does.
 **Do not let a merchant discover this by not getting paid.** The manual procedure
 above should be in operator docs before any merchant is onboarded on a deployment
 with a persistent disk.
+
+### G-3 — Spend policy keyed on the RAW url, catalog keyed on the CANONICAL one — **High** — closed-by-test
+
+Found by adversarial review **of the F12 change itself**, before merge.
+
+`extractDiscoveryInfo` canonicalizes to `origin + pathname` — query string and
+fragment stripped — and that canonical string is the catalog key. But `/settle`
+read `paymentPayload.resource.url`, the **raw** url, and passed it straight to
+`policy.checkSettle` as both the per-URL budget key and the argument to
+`catalog.isBound`. The two never matched for any resource carrying a query
+string, which is the ordinary shape for an API (`/quote?symbol=AAPL`).
+
+Two consequences, both defeating the point of F12:
+
+- **Honest merchants were scored unbound on every settle** and dropped into the
+  shared unbound pool — 10/60s shared with every sprayer. Precisely the
+  starvation F12 was built to remove, reintroduced by the key mismatch.
+- **The per-URL budget was multipliable by varying the query string**, since each
+  variant minted its own budget bucket.
+
+**Fixed:** `BazaarCatalog.canonicalResourceKey()` plus `isBoundResource()`, with
+`/settle` canonicalizing once and using that for both the budget key and the
+bound check. Canonicalization lives behind `BazaarCatalog` deliberately — the
+route re-deriving the key is how the two drifted apart to begin with.
+
+Mutation-verified at **both** levels, because the catalog-level tests alone stay
+green when the route regresses (the RA-12 decorative-test failure mode):
+reverting `/settle` to the raw url fails 3 tests in
+`src/server.policykey.test.ts`.
+
+**Residual, deliberately not fixed:** when a resource declares a `routeTemplate`,
+the catalog key is `origin + routeTemplate` (e.g. `/users/{id}`), which no
+concrete request url canonicalizes to. Those entries still read unbound at
+settle. Matching a live path against a template is a fuzzy match at a trust
+boundary and is not worth the risk for the gain; the correct fix is to carry the
+canonical key on the payload rather than re-derive it. Recorded rather than
+guessed at.
+
+### Further findings from adversarial review — triage, not yet fixed
+
+Independent reviewers checking G-1/G-2 surfaced these. None is caused by F12.
+Listed so they are not lost; none is fixed on this branch.
+
+| ID | Finding | Assessment |
+| --- | --- | --- |
+| **G-4** | `recordSettlement` has no `payTo` check and runs *unconditionally* after a rejected upsert, so anyone settling against a cataloged URL inflates **that entry's** `settlements`/`uniquePayers`/`lastSettled` — and `statsSource` still reads `observed`, because they genuinely were. | **Real, and the most consequential of these.** Trust stats are attacker-inflatable for an arbitrary victim entry at the cost of one settlement each. It also underpins G-2's "the stale entry looks more trustworthy over time". |
+| **G-5** | An entry with `accepts: []` (schema-valid — no `.min(1)`) early-returns in `bindLoadedEntry` *before* the tombstone seeding, so it loads with `boundPayTo: []` and no ownership row, and then **every** payTo is refused forever. | Real. A permanent URL squat via a crafted `CATALOG_FILE`; reachable only by someone who can already write that file, so it ranks below G-4. |
+| **G-6** | `MAX_ENTRIES` is enforced only on the write path. `load()` sets every valid row with no bound, so a large `CATALOG_FILE` is an unbounded startup memory load. | Real; the F3 bound is a write-path bound only. |
+| **G-7** | `bindLoadedEntry` seeds `this.ownership` but never calls `saveOwnership()`, so bindings derived during a `CATALOG_OWNERSHIP_BOOTSTRAP` run live only in memory unless some later binding incidentally flushes. | Real, and it undercuts the documented one-boot bootstrap procedure. |
+| **G-8** | The tombstone cap is a one-way door: at `MAX_TOMBSTONES` all new bindings are refused permanently, with no reset short of deleting the ownership file — which itself trips the fail-closed guard. | Known and deliberate (fail-closed by design), but the *absence of any reset path* is worth an explicit operator procedure. |
+| **G-9** | `if (!trust) return response` in both discovery routes returns unfiltered results *before* filtering, so `verified_only=true` is silently ignored when no resolver is injected. | **Not reachable in production** — `src/server.ts` always constructs a resolver, and an unset `VERIFICATION_API_URL` yields one that answers `"unknown"` rather than `undefined`. Test-only shape; worth a guard so it stays that way. |
 
 ---
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -398,6 +398,19 @@ first bite whenever someone sets `STELLAR_NETWORK=pubnet`. Revisit before that.
 | Per-IP rate limit | **60 / min** | `/health` exempt so the Render health check cannot trip. Keyed via `trustProxy: 1` — exactly one hop, because `true` is client-spoofable (RA-4). |
 | Body limit | **32 KiB** | Derived, not picked: largest real settlement envelope measured on-chain is 3,400 base64 chars (~2.5 KB), giving ~9.6x margin. |
 
+### Operational lesson: secrets in `argv`
+
+During the F11 reproduction, throwaway secrets were passed as command-line
+arguments. Command lines are not private: they land in shell history, in `ps`
+output visible to other users on the host, and — as happened here — in harness
+and tooling logs written to world-readable `/tmp`. A key that was only ever meant
+to exist for one test run persisted in three places afterwards.
+
+Repro and operational scripts must read keys from a file with restrictive
+permissions, or from stdin — never `argv`, and never interpolated into a shell
+command. This applies to disposable testnet keys too: the habit is what
+generalises, and the cost of getting it right is zero.
+
 ## Deployment posture — deliberate choices, not oversights
 
 ### `VERIFICATION_API_URL` is deliberately UNCONFIGURED
@@ -441,7 +454,7 @@ change.
 
 | ID | Finding | Why |
 | --- | --- | --- |
-| **F12** | Spend accounting is global while rate limiting is per-IP — neither stops a distributed attacker | **open — first pubnet blocker.** See below. |
+| **F12** | Spend accounting was global while rate limiting was per-IP | **closed-by-test** — per-entity budgets keyed off the F11 bindings. See the control-scope table below for what this does and does not achieve. |
 | **F3** | Non-atomic `save()`, unbounded entries/`accepts` | Not fixed on any branch. Interacts with F11 — eviction drops ownership bindings. |
 | **F4-ts** | Verification API has no per-record timestamp | **external** — needs the API to emit one; consumer side is already forward-compatible. |
 | **F10-op** | `examples/.env.recording` holds a live testnet `AGENT_SECRET` | Operational; needs rotation and scrub. |
@@ -479,6 +492,38 @@ was written; they do now, and they are exactly the stable identity the accountin
 needs — an attacker cannot rotate `payTo` under a bound URL, which was the reason
 per-payTo throttling was dismissed as a convenience-only control (RA-6/D6). A
 bound URL is a much harder identity to multiply than an address or an IP.
+
+### What each control actually does — and what none of them do
+
+Written plainly because four tuned numbers can look like a defence they are not.
+
+| Control | What it actually provides | What it does NOT provide |
+| --- | --- | --- |
+| **F12 per-entity budgets** | **Fairness between merchants.** One operator can no longer starve another, and a refused honest merchant is now a bug rather than the design. | It does not cap a *funded* attacker. Ten bound URLs at 10/min each is 100/min — the whole global ceiling — while every per-entity budget reads green. |
+| **F11 ownership binding** | **The price of claiming an identity.** A URL cannot be budgeted until it is bound, and binding requires serving a matching 402 challenge from that origin. | The price is **one-time and low** — see below. It is a speed bump, not an economic barrier. |
+| **Balance guard** | **The sponsor's actual protection.** Refuses `/settle` below the hard floor regardless of how many identities an attacker holds. | It is a *floor*, not a rate limit: it stops the bleeding at the end, it does not slow the attack. |
+
+**None of the three is a rate limit against a funded attacker.** They are, in
+order: a fairness mechanism, a one-time identity cost, and a last-resort floor.
+
+**Quantifying the F11 price**, since the whole design leans on it:
+
+- **Verification runs only at first bind** (`src/bazaar.ts`, `if (firstCatalog)`).
+  It never re-runs. The endpoint can be taken down the moment the bind completes.
+- **A canonical URL is `origin + pathname`**, so ten *paths* on **one** domain are
+  ten distinct bindable URLs — one host, one certificate.
+- Each distinct `payTo` costs a Stellar account minimum plus a trustline (~1.5
+  XLM on pubnet), and that is **locked reserve, recoverable**, not spend.
+
+So ten bound URLs cost roughly: one free static host serving ten 402 responses
+for a few minutes, plus ~15 XLM of recoverable reserve. That is the real barrier.
+It is not nothing — it is far less than "each URL needs a live endpoint" implies,
+and it should not be mistaken for rate limiting.
+
+**Implication for the numbers:** raising the global ceiling improves honest
+throughput and costs an attacker nothing, because they were never constrained by
+it. Lowering it hurts honest merchants first. The ceiling is therefore a
+sponsor-exposure dial, not a security control — the balance guard is the control.
 
 **Sequencing: this is the first pubnet blocker after merge, ahead of the
 threshold review.** Reviewing the numbers before fixing the shape would produce a

--- a/examples/.env.recording.example
+++ b/examples/.env.recording.example
@@ -1,0 +1,43 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Recording env for the Vellar demo walkthrough (testnet only).
+# Copy to `.env.recording`, paste the SECRETS from
+# vela-wallet/scripts/x402-spike/.wallet-verified-only.json, then:
+#   set -a; source examples/.env.recording; set +a
+# The filled `.env.recording` is gitignored. Keep secrets off camera.
+#
+# Public IDs below are the REAL values from the flagship provenance proof
+# (the run that produced settlement tx 8bde387b…). They are public on-chain.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Live facilitator (pre-filled)
+FACILITATOR_URL=https://vellar-facilitator.onrender.com
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Asset = the bound test token from the proven run (NOT USDC — this wallet's
+# budget is bound to this token). This is also the recipient contract the
+# verified-only policy gates on.
+ASSET=CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND
+
+# ── Seller (the paid API) ────────────────────────────────────────────────────
+PAYTO=G...YOUR_MERCHANT_ACCOUNT          # a merchant account trustlined to ASSET
+PRICE_ATOMIC=1000000                      # 0.1 token at 7 decimals (matches the proven run)
+SELLER_PORT=4031
+RESOURCE_URL=http://localhost:4031/quote
+
+# ── Buyer (the agent) — REAL wallet from the proven run ──────────────────────
+WALLET_CONTRACT_ID=CDPUL7TZKJOUEYJSIGNVXINSB3ZSYTQP6Z6N6DCSV3UBHTFE5KE232EF
+# NOTE: the spike wallet CDPUL7TZ… above is RETIRED (2026-08-09) and all its keys
+# are burned — admin/agent/agent2 removed on-chain, .wallet-verified-only.json
+# deleted. Do NOT try to paste agent2Secret here; it no longer exists and the
+# wallet is admin-only + empty. For a new recording, provision a fresh wallet.
+AGENT_SECRET=S...PASTE_your_agent_secret  # SECRET — a signer on a wallet YOU provision
+SIM_SOURCE_ACCOUNT=G...ANY_FUNDED_TESTNET # any funded classic account, simulate-only
+
+# ── Provenance revoke (off-camera, between the verified/revoked takes) ────────
+REGISTRY_CONTRACT_ID=CBZVS2ETJKCIMRRWUHTZFVMWDACJNYUZ54JIXUJCHXNBFNXELKTSWHGP
+RECIPIENT_CONTRACT_ID=CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND
+# The revoke is attestor-only. The attestor pubkey is
+# GB4G5MGEFFIZ53QNFJSQQ56NTYET7TCHTIY25MNL6WZSO374TGB2GBOJ, stored as the
+# `vela-attestor` key in your local stellar keychain. Use either the keychain
+# name or paste its secret here:
+ATTESTOR_SECRET=vela-attestor             # stellar keychain name, OR paste S...secret

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -742,9 +742,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/src/catalog.canonicalkey.test.ts
+++ b/src/catalog.canonicalkey.test.ts
@@ -1,0 +1,105 @@
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { describe, expect, it } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+
+// G-3 — the F12 spend policy keyed on the RAW resource URL while the catalog
+// keys on the CANONICAL one (`origin + pathname`, query stripped, produced by
+// extractDiscoveryInfo). Any merchant whose resource carries a query string —
+// `/quote?symbol=AAPL`, the normal shape for an API — was therefore scored
+// UNBOUND on every settle and dropped into the shared unbound pool, which is
+// exactly the starvation F12 exists to prevent.
+//
+// The fix keeps canonicalization behind BazaarCatalog rather than in the route:
+// the route must not re-implement the catalog's key derivation, because that is
+// how the two drifted apart in the first place.
+
+const PAY = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+const OTHER = "GBQ3VANQZ6X3ZVGFTQJZ2MZ4KOCPZ5EGWSVYT7OPTQJ4M7VXMKQ3OQXD";
+const CANONICAL = "https://api.merchant.example/quote";
+
+function reqs(payTo: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND",
+    amount: "1000000",
+    payTo,
+    maxTimeoutSeconds: 60,
+    extra: {},
+  } as PaymentRequirements;
+}
+
+function disc(): DiscoveredResource {
+  return {
+    resourceUrl: CANONICAL,
+    x402Version: 2,
+    discoveryInfo: { input: { type: "http", method: "GET" } },
+  } as DiscoveredResource;
+}
+
+function bound(): BazaarCatalog {
+  const c = new BazaarCatalog();
+  c.upsertFromPayment(disc(), reqs(PAY));
+  return c;
+}
+
+describe("G-3 — spend-policy identity must use the catalog's canonical key", () => {
+  it("isBoundResource matches a bound merchant despite a query string", () => {
+    const c = bound();
+    // The catalog stores the canonical key...
+    expect(c.isBound(CANONICAL, PAY), "precondition: bound under the canonical key").toBe(true);
+    // ...but /settle receives the RAW url the buyer paid, query and all.
+    expect(
+      c.isBoundResource(`${CANONICAL}?symbol=AAPL&ts=1`, PAY),
+      "a query string must not make a bound merchant look unbound",
+    ).toBe(true);
+  });
+
+  it("normalizes the shapes a real payload varies in, without widening the binding", () => {
+    const c = bound();
+    for (const raw of [
+      `${CANONICAL}?a=1`,
+      `${CANONICAL}#frag`,
+      `${CANONICAL}?a=1#frag`,
+      CANONICAL,
+    ]) {
+      expect(c.isBoundResource(raw, PAY), `must match: ${raw}`).toBe(true);
+    }
+    // Canonicalization must NOT collapse distinct resources together.
+    for (const raw of [
+      "https://api.merchant.example/other",
+      "https://evil.example/quote",
+      "https://api.merchant.example:8443/quote",
+    ]) {
+      expect(c.isBoundResource(raw, PAY), `must NOT match: ${raw}`).toBe(false);
+    }
+  });
+
+  it("still refuses a payTo that is not bound to that resource", () => {
+    const c = bound();
+    // Canonicalizing must not weaken the F11 check it feeds.
+    expect(c.isBoundResource(`${CANONICAL}?x=1`, OTHER)).toBe(false);
+  });
+
+  it("returns the canonical key so per-URL budgets cannot be multiplied by query", () => {
+    const c = bound();
+    // If the budget key were the raw url, an attacker could mint a fresh
+    // per-URL budget per query string. All of these must reduce to ONE key.
+    const keys = new Set(
+      [`${CANONICAL}?i=1`, `${CANONICAL}?i=2`, `${CANONICAL}#a`, CANONICAL].map((u) =>
+        BazaarCatalog.canonicalResourceKey(u),
+      ),
+    );
+    expect(keys.size, "all variants must collapse to one budget key").toBe(1);
+    expect([...keys][0]).toBe(CANONICAL);
+  });
+
+  it("never throws on a malformed url — it degrades to the raw string", () => {
+    // /settle takes this from a client-supplied payload, so it must not be a
+    // crash vector; an unparseable value simply cannot match a binding.
+    expect(() => BazaarCatalog.canonicalResourceKey("not a url")).not.toThrow();
+    expect(bound().isBoundResource("not a url", PAY)).toBe(false);
+    expect(bound().isBoundResource("", PAY)).toBe(false);
+  });
+});

--- a/src/catalog.restart-verification.test.ts
+++ b/src/catalog.restart-verification.test.ts
@@ -16,10 +16,11 @@ import type { TrustResolver, TrustedDiscoveryResource } from "./trust.js";
 // behaviour is correct. If you fix either gap these tests SHOULD fail; update
 // them and the audit doc together.
 //
-// G-1  `verifiedOwner` is not persisted and re-verification only fires on first
-//      catalog, so after a restart every previously-verified entry serves
-//      ownerVerified:false FOREVER — and `verified_only=true` serves an empty
-//      catalog. That is a wrong answer to agents, not a throttle.
+// G-1  `verifiedOwner` is never READ back from disk and re-verification only
+//      fires on first catalog, so after a restart every previously-verified
+//      entry serves ownerVerified:false — and `verified_only=true` serves an
+//      empty catalog. That is a wrong answer to agents, not a throttle.
+//      (It does recover if the entry is evicted past MAX_ENTRIES; see below.)
 //
 // G-2  A bound resource URL has NO payTo rotation path. A merchant rotating
 //      their payment address is refused, while settlement stats keep climbing
@@ -156,7 +157,7 @@ describe("G-1 — verifiedOwner does not survive a restart, and never recovers",
     await appAfter.close();
   });
 
-  it("is PERMANENT: further settles for the same URL never re-verify", async () => {
+  it("does not recover under normal traffic: further settles never re-verify", async () => {
     const file = join(tmpDir(), "catalog.json");
     const before = new BazaarCatalog(file);
     before.upsertFromPayment(disc(), reqs(PAY_OLD));
@@ -164,7 +165,13 @@ describe("G-1 — verifiedOwner does not survive a restart, and never recovers",
 
     // After restart the URL is already present, so upsertFromPayment reports
     // isFirstCatalog=false — and `if (firstCatalog)` in bazaar.ts is the ONLY
-    // trigger for verifyResourceOwnership. No amount of traffic re-verifies.
+    // trigger for verifyResourceOwnership.
+    //
+    // Precisely: there is exactly ONE path back, and it is not a usable one.
+    // evictToCap() removing the entry past MAX_ENTRIES (10,000) makes the next
+    // settle a first-catalog again, which does re-verify (verified by probe).
+    // So the honest statement is "does not recover below the eviction cap",
+    // NOT "never" — and nobody should mistake cache pressure for a fix.
     const after = new BazaarCatalog(file);
     for (let i = 0; i < 5; i++) {
       expect(

--- a/src/catalog.restart-verification.test.ts
+++ b/src/catalog.restart-verification.test.ts
@@ -1,0 +1,221 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Keypair } from "@stellar/stellar-sdk";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { afterEach, describe, expect, it } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+import type { TrustResolver, TrustedDiscoveryResource } from "./trust.js";
+
+// ============================================================================
+// CHARACTERIZATION TESTS — these pin CURRENT behaviour, including two KNOWN
+// GAPS (G-1, G-2 in docs/security-audit.md). They are not assertions that the
+// behaviour is correct. If you fix either gap these tests SHOULD fail; update
+// them and the audit doc together.
+//
+// G-1  `verifiedOwner` is not persisted and re-verification only fires on first
+//      catalog, so after a restart every previously-verified entry serves
+//      ownerVerified:false FOREVER — and `verified_only=true` serves an empty
+//      catalog. That is a wrong answer to agents, not a throttle.
+//
+// G-2  A bound resource URL has NO payTo rotation path. A merchant rotating
+//      their payment address is refused, while settlement stats keep climbing
+//      against the STALE address.
+// ============================================================================
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "vellar-restart-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+const URL_X = "https://api.merchant.example/quote";
+const PAY_OLD = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+const PAY_NEW = "GBQ3VANQZ6X3ZVGFTQJZ2MZ4KOCPZ5EGWSVYT7OPTQJ4M7VXMKQ3OQXD";
+const ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+
+function reqs(payTo: string): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: ASSET,
+    amount: "1000000",
+    payTo,
+    maxTimeoutSeconds: 60,
+    extra: {},
+  } as PaymentRequirements;
+}
+
+function disc(url = URL_X): DiscoveredResource {
+  return {
+    resourceUrl: url,
+    description: "Quotes",
+    serviceName: "MerchantSvc",
+    x402Version: 2,
+    discoveryInfo: { input: { type: "http", method: "GET" } },
+  } as DiscoveredResource;
+}
+
+/** Every asset reads "verified", so any non-verified verdict below is caused by
+ * owner-clamping alone — the thing under test. */
+const allVerified: TrustResolver = { assetStatus: async () => "verified" };
+
+const testConfig = {
+  port: 0,
+  host: "127.0.0.1",
+  network: "stellar:testnet" as const,
+  rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(),
+  maxTransactionFeeStroops: 2_000_000,
+  catalogFile: undefined,
+  verificationApiUrl: undefined,
+  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
+  catalogOwnershipBootstrap: false,
+};
+
+async function serve(catalog: BazaarCatalog) {
+  return buildServer(buildFacilitator(testConfig), catalog, allVerified);
+}
+
+function trustOf(item: unknown) {
+  // annotateTrust always populates `trust`; assert it so the assertions below
+  // read as the behavioural claims they are rather than optional-chaining noise.
+  return (item as TrustedDiscoveryResource).trust!;
+}
+
+describe("G-1 — verifiedOwner does not survive a restart, and never recovers", () => {
+  it("a verified entry serves ownerVerified:false after restart, with every verdict clamped", async () => {
+    const file = join(tmpDir(), "catalog.json");
+
+    // --- Run 1: entry is cataloged AND passes Layer 2 ownership verification.
+    const before = new BazaarCatalog(file);
+    before.upsertFromPayment(disc(), reqs(PAY_OLD));
+    before.setVerifiedOwner(URL_X, true);
+    before.flush();
+
+    const appBefore = await serve(before);
+    const preBody = (await appBefore.inject({ method: "GET", url: "/discovery/resources" })).json();
+    expect(trustOf(preBody.items[0]).ownerVerified, "precondition: verified before restart").toBe(true);
+    expect(trustOf(preBody.items[0]).verification).toBe("verified");
+    await appBefore.close();
+
+    // --- Run 2: same file, fresh process. Nothing about the resource changed.
+    const after = new BazaarCatalog(file);
+    expect(after.size, "entry must survive the restart").toBe(1);
+
+    const appAfter = await serve(after);
+    const postBody = (await appAfter.inject({ method: "GET", url: "/discovery/resources" })).json();
+    const t = trustOf(postBody.items[0]);
+
+    // THE GAP: same resource, same assets, same everything — different answer.
+    expect(t.ownerVerified, "G-1: ownership verification is lost on restart").toBe(false);
+    expect(t.verification, "G-1: clamped from verified down to unknown").toBe("unknown");
+    expect(t.acceptsVerification, "G-1: every accepts option clamped too").toEqual(["unknown"]);
+    await appAfter.close();
+  });
+
+  it("verified_only=true serves an EMPTY catalog after restart", async () => {
+    const file = join(tmpDir(), "catalog.json");
+    const before = new BazaarCatalog(file);
+    before.upsertFromPayment(disc(), reqs(PAY_OLD));
+    before.setVerifiedOwner(URL_X, true);
+    before.flush();
+
+    const appBefore = await serve(before);
+    const pre = (await appBefore.inject({ method: "GET", url: "/discovery/resources?verified_only=true" })).json();
+    expect(pre.items, "precondition: visible to verified_only before restart").toHaveLength(1);
+    await appBefore.close();
+
+    const appAfter = await serve(new BazaarCatalog(file));
+    const post = (await appAfter.inject({ method: "GET", url: "/discovery/resources?verified_only=true" })).json();
+    // An agent filtering for verified resources sees NOTHING — indistinguishable
+    // from "this facilitator has no trustworthy resources".
+    expect(post.items, "G-1: verified_only is empty after restart").toHaveLength(0);
+    await appAfter.close();
+  });
+
+  it("search is affected identically (same annotate path, so the gap is not list-only)", async () => {
+    const file = join(tmpDir(), "catalog.json");
+    const before = new BazaarCatalog(file);
+    before.upsertFromPayment(disc(), reqs(PAY_OLD));
+    before.setVerifiedOwner(URL_X, true);
+    before.flush();
+
+    const appAfter = await serve(new BazaarCatalog(file));
+    const post = (await appAfter.inject({ method: "GET", url: "/discovery/search?query=Merchant" })).json();
+    expect(post.resources.length).toBeGreaterThan(0);
+    expect(trustOf(post.resources[0]).ownerVerified, "G-1 hits /discovery/search too").toBe(false);
+    await appAfter.close();
+  });
+
+  it("is PERMANENT: further settles for the same URL never re-verify", async () => {
+    const file = join(tmpDir(), "catalog.json");
+    const before = new BazaarCatalog(file);
+    before.upsertFromPayment(disc(), reqs(PAY_OLD));
+    before.flush();
+
+    // After restart the URL is already present, so upsertFromPayment reports
+    // isFirstCatalog=false — and `if (firstCatalog)` in bazaar.ts is the ONLY
+    // trigger for verifyResourceOwnership. No amount of traffic re-verifies.
+    const after = new BazaarCatalog(file);
+    for (let i = 0; i < 5; i++) {
+      expect(
+        after.upsertFromPayment(disc(), reqs(PAY_OLD)),
+        "isFirstCatalog must stay false, so verification never re-fires",
+      ).toBe(false);
+    }
+    expect(after.isVerifiedOwner(URL_X)).toBe(false);
+  });
+});
+
+describe("G-2 — a bound URL has no payTo rotation path", () => {
+  it("refuses a rotated payTo permanently, keeping the OLD address in accepts", () => {
+    const catalog = new BazaarCatalog();
+    catalog.upsertFromPayment(disc(), reqs(PAY_OLD));
+
+    // The merchant rotates their payment address and re-settles.
+    expect(catalog.upsertFromPayment(disc(), reqs(PAY_NEW)), "rotation refused").toBe(false);
+
+    // The catalog still advertises ONLY the old address, and there is no method
+    // on BazaarCatalog and no route on the server to change it.
+    const accepts = (catalog.list().items[0] as TrustedDiscoveryResource).accepts;
+    expect(accepts.map((a) => a.payTo)).toEqual([PAY_OLD]);
+    expect(catalog.isBound(URL_X, PAY_NEW)).toBe(false);
+  });
+
+  it("survives eviction: the tombstone refuses the new payTo even once the entry is gone", () => {
+    const catalog = new BazaarCatalog();
+    catalog.upsertFromPayment(disc(), reqs(PAY_OLD));
+    // Even with the entry evicted, the F3 tombstone keeps the binding, so a
+    // rotation cannot be achieved by waiting for cache pressure either.
+    expect(catalog.isBound(URL_X, PAY_OLD)).toBe(true);
+    expect(catalog.isBound(URL_X, PAY_NEW)).toBe(false);
+  });
+
+  it("the merchant IS still paid — only the catalog entry goes stale", () => {
+    // upsertFromPayment rejecting is a CATALOG decision. It runs inside
+    // onAfterSettle, i.e. after settlement already succeeded on-chain, and
+    // registerBazaar swallows its own errors so settlement is never affected.
+    // The consequence is narrower but sharper than "payments break":
+    const catalog = new BazaarCatalog();
+    catalog.upsertFromPayment(disc(), reqs(PAY_OLD));
+    catalog.upsertFromPayment(disc(), reqs(PAY_NEW)); // refused
+
+    // recordSettlement runs UNCONDITIONALLY after the upsert in bazaar.ts, so
+    // settlements against the NEW address still accrue to the entry advertising
+    // the OLD one. The stale entry therefore looks MORE trustworthy over time.
+    catalog.recordSettlement(URL_X, "CPAYER1");
+    catalog.recordSettlement(URL_X, "CPAYER2");
+    const t = trustOf(catalog.list().items[0]);
+    expect(t?.settlements, "stats climb on the stale entry").toBe(2);
+    expect((catalog.list().items[0] as TrustedDiscoveryResource).accepts[0]!.payTo).toBe(PAY_OLD);
+  });
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -392,6 +392,34 @@ export class BazaarCatalog {
     return this.entries.get(resourceUrl)?.boundPayTo.includes(payTo) ?? false;
   }
 
+  /**
+   * G-3: the catalog is keyed on the CANONICAL resource url that
+   * `extractDiscoveryInfo` derives — `origin + pathname`, query and fragment
+   * stripped. Callers holding a RAW payload url (notably `/settle`, which reads
+   * `paymentPayload.resource.url`) must go through this, or a merchant whose
+   * resource carries a query string reads as unbound on every settle.
+   *
+   * Kept here rather than in the route on purpose: the route re-deriving the key
+   * is precisely how the two drifted apart.
+   *
+   * Degrades to the raw string on an unparseable url — this is client-supplied,
+   * so it must not throw, and a non-url simply cannot match a binding.
+   */
+  static canonicalResourceKey(rawUrl: string): string {
+    try {
+      const u = new URL(rawUrl);
+      return `${u.origin}${u.pathname}`;
+    } catch {
+      return rawUrl;
+    }
+  }
+
+  /** `isBound`, but accepting a raw payload url. Prefer this at trust
+   * boundaries; `isBound` assumes the caller already holds a canonical key. */
+  isBoundResource(rawResourceUrl: string, payTo: string): boolean {
+    return this.isBound(BazaarCatalog.canonicalResourceKey(rawResourceUrl), payTo);
+  }
+
   /** Whether the resource's own 402 challenge has confirmed its bound owner
    * (Fix 0 Layer 2). Consumers should treat an entry's accepts as authoritative
    * only when this is true. */

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -693,8 +693,12 @@ export class BazaarCatalog {
       resource: { ...stored.resource, accepts: kept },
       stats: stored.stats ?? { settlements: 0, payers: [], observed: 0 },
       boundPayTo: authoritative ?? [ownerPayTo],
-      // Never trust a stored verified flag — a crafted file could forge it.
-      // Layer 2 re-verifies from the resource on the next settlement.
+      // Never trust a stored verified flag — a crafted file could forge it (RA-9).
+      //
+      // NOTE: this does NOT re-verify. Layer 2 fires only when upsertFromPayment
+      // reports isFirstCatalog, which is false for any entry loaded from disk, so
+      // a restored entry serves ownerVerified:false permanently. See G-1 in
+      // docs/security-audit.md — that is a known gap, not the intended design.
       verifiedOwner: false,
     };
   }

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -51,7 +51,10 @@ describe("loadConfig", () => {
     expect(def.spend).toEqual({
       rateMax: 30,
       rateWindowMs: 60_000,
-      ceilingStroops: 10_000_000,
+      ceilingStroops: 50_000_000,
+      perUrlMax: 10,
+      perPayToMax: 100,
+      unboundPoolMax: 10,
       windowMs: 60_000,
     });
     const over = loadConfig({

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,13 @@ export interface FacilitatorConfig {
     ceilingStroops: number;
     /** Global spend window in ms (default 60_000). */
     windowMs: number;
+    /** F12: settles/window for one BOUND resource URL (default 10). */
+    perUrlMax: number;
+    /** F12: settles/window per payTo (default 100 = global; a ratchet that only
+     * starts binding if the global ceiling is later raised). */
+    perPayToMax: number;
+    /** F12: settles/window shared by ALL unbound URLs (default 10). */
+    unboundPoolMax: number;
   };
   /**
    * ESCAPE HATCH (F3). Permits deriving ownership bindings from an existing
@@ -76,8 +83,13 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
     // so 1 XLM trips first. That is ~20 settles/minute globally across ALL
     // merchants — deliberately tight, and unreviewed against real pubnet
     // traffic. See docs/security-audit.md before raising STELLAR_NETWORK=pubnet.
-    ceilingStroops: positiveIntEnv(env.SPEND_CEILING_STROOPS, 10_000_000, "SPEND_CEILING_STROOPS"),
+    ceilingStroops: positiveIntEnv(env.SPEND_CEILING_STROOPS, 50_000_000, "SPEND_CEILING_STROOPS"),
     windowMs: positiveIntEnv(env.SPEND_WINDOW_MS, 60_000, "SPEND_WINDOW_MS"),
+    // F12 per-entity budgets. Keyed on the DURABLE F11 ownership binding, never
+    // on verifiedOwner (not persisted; resets on restart).
+    perUrlMax: positiveIntEnv(env.SETTLE_PER_URL_MAX, 10, "SETTLE_PER_URL_MAX"),
+    perPayToMax: positiveIntEnv(env.SETTLE_PER_PAYTO_MAX, 100, "SETTLE_PER_PAYTO_MAX"),
+    unboundPoolMax: positiveIntEnv(env.SETTLE_UNBOUND_POOL_MAX, 10, "SETTLE_UNBOUND_POOL_MAX"),
   };
 
   // Balance floors. INVARIANT: the hard floor must exceed the maximum XLM a

--- a/src/hardening.test.ts
+++ b/src/hardening.test.ts
@@ -19,7 +19,7 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogFile: undefined,
   verificationApiUrl: undefined,
-  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000 },
+  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
   catalogOwnershipBootstrap: false,
 };

--- a/src/policy.f12.test.ts
+++ b/src/policy.f12.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { SpendPolicy, type SettleIdentity } from "./policy.js";
+
+// F12 — per-entity spend accounting. The global ceiling alone throttled honest
+// merchants while a distributed attacker stayed under every per-bucket limit.
+// Budgets are keyed on the DURABLE ownership binding (F11 tombstone), never on
+// verifiedOwner, which is not persisted and resets on restart.
+
+const base = {
+  network: "stellar:pubnet" as const,
+  rateMax: 1_000_000, // isolate the F12 dimensions
+  rateWindowMs: 60_000,
+  spendCeilingStroops: 1_000_000_000,
+  spendWindowMs: 60_000,
+  perSettleEstimateStroops: 500_000,
+  perUrlMax: 10,
+  perPayToMax: 100,
+  unboundPoolMax: 10,
+};
+const clock = () => {
+  let t = 1_000_000;
+  return { now: () => t, advance: (ms: number) => (t += ms) };
+};
+const bound = (url: string, payTo = "GMERCHANT"): SettleIdentity => ({ resourceUrl: url, payTo, bound: true });
+const unbound = (url: string, payTo = "GSPRAY"): SettleIdentity => ({ resourceUrl: url, payTo, bound: false });
+
+describe("F12 — per-bound-URL budget", () => {
+  it("allows one merchant 10 settles/min on its own URL", () => {
+    const c = clock();
+    const p = new SpendPolicy(base, c.now);
+    for (let i = 0; i < 10; i++) expect(p.checkSettle(bound("https://a/x")).allowed).toBe(true);
+    const over = p.checkSettle(bound("https://a/x"));
+    expect(over.allowed).toBe(false);
+    expect(over.reason).toBe("rate_limited_url");
+  });
+
+  it("one merchant's URL budget does not touch another's", () => {
+    const c = clock();
+    const p = new SpendPolicy(base, c.now);
+    for (let i = 0; i < 10; i++) p.checkSettle(bound("https://a/x", "GA"));
+    expect(p.checkSettle(bound("https://a/x", "GA")).allowed).toBe(false);
+    // A different merchant is entirely unaffected — the fairness property F12 exists for.
+    expect(p.checkSettle(bound("https://b/y", "GB")).allowed).toBe(true);
+  });
+
+  it("does NOT halve an honest merchant: 3 URLs under one payTo each get their full 10", () => {
+    const c = clock();
+    const p = new SpendPolicy(base, c.now);
+    for (const u of ["https://m/1", "https://m/2", "https://m/3"]) {
+      for (let i = 0; i < 10; i++) {
+        expect(p.checkSettle(bound(u, "GMERCH")).allowed, `${u} #${i}`).toBe(true);
+      }
+    }
+    // 30 settles for one payTo, all allowed — per-payTo (100) never bound.
+  });
+});
+
+describe("F12 — unbound pool is the economic signal", () => {
+  it("all unbound URLs share ONE budget, so spraying competes with itself", () => {
+    const c = clock();
+    const p = new SpendPolicy(base, c.now);
+    // Spray 10 distinct unverified URLs: together they get one bound URL's worth.
+    let allowed = 0;
+    for (let i = 0; i < 40; i++) {
+      if (p.checkSettle(unbound(`https://spray/${i % 10}`)).allowed) allowed++;
+    }
+    expect(allowed).toBe(10); // the whole spray got what ONE bound URL gets
+    const over = p.checkSettle(unbound("https://spray/99"));
+    expect(over.reason).toBe("unbound_pool_exhausted");
+  });
+
+  it("an exhausted unbound pool does not affect bound merchants", () => {
+    const c = clock();
+    const p = new SpendPolicy(base, c.now);
+    for (let i = 0; i < 10; i++) p.checkSettle(unbound(`https://spray/${i}`));
+    expect(p.checkSettle(unbound("https://spray/x")).allowed).toBe(false);
+    // The honest, bound merchant is untouched.
+    expect(p.checkSettle(bound("https://honest/x", "GHONEST")).allowed).toBe(true);
+  });
+});
+
+describe("F12 — all-or-none reservation", () => {
+  it("a REFUSED settle consumes no budget in any window", () => {
+    const c = clock();
+    // perPayToMax is deliberately TIGHT (15) so a leak is observable: 10 real
+    // settles + 20 refusals would put a reserve-as-you-go implementation at 30,
+    // far past 15, and starve the merchant's other URL. With all-or-none the
+    // payTo window holds exactly 10 and 5 remain.
+    const p = new SpendPolicy({ ...base, perPayToMax: 15 }, c.now);
+    for (let i = 0; i < 10; i++) {
+      expect(p.checkSettle(bound("https://a/x", "GA")).allowed).toBe(true);
+    }
+
+    // 20 refusals against the now-exhausted URL budget.
+    for (let i = 0; i < 20; i++) {
+      expect(p.checkSettle(bound("https://a/x", "GA")).allowed).toBe(false);
+    }
+
+    // Exactly the 5 remaining payTo slots must be available on another URL.
+    let ok = 0;
+    for (let i = 0; i < 10; i++) if (p.checkSettle(bound("https://a/y", "GA")).allowed) ok++;
+    expect(ok, "refusals must not leak into the payTo budget").toBe(5);
+  });
+
+  it("concurrent settles never over-consume: exactly perUrlMax succeed", async () => {
+    const c = clock();
+    const p = new SpendPolicy(base, c.now);
+    // Fire 50 concurrent settles at ONE bound URL. checkSettle is synchronous by
+    // design precisely so evaluate-then-reserve cannot interleave; racing them
+    // must still admit exactly 10.
+    const results = await Promise.all(
+      Array.from({ length: 50 }, async () => p.checkSettle(bound("https://race/x", "GR")).allowed),
+    );
+    expect(results.filter(Boolean).length).toBe(10);
+  });
+
+  it("a settle refused by the GLOBAL ceiling leaves the url and payTo budgets untouched", () => {
+    const c = clock();
+    const p = new SpendPolicy(
+      { ...base, spendCeilingStroops: 1_000_000, perSettleEstimateStroops: 500_000 }, // 2 settles globally
+      c.now,
+    );
+    expect(p.checkSettle(bound("https://a/x", "GA")).allowed).toBe(true);
+    expect(p.checkSettle(bound("https://a/x", "GA")).allowed).toBe(true);
+    const refused = p.checkSettle(bound("https://a/x", "GA"));
+    expect(refused.reason).toBe("spend_ceiling");
+
+    // Window rolls over; the URL budget must show 2 used, not 3 — the refused
+    // settle must not have been recorded anywhere.
+    c.advance(60_001);
+    let ok = 0;
+    for (let i = 0; i < 10; i++) if (p.checkSettle(bound("https://a/x", "GA")).allowed) ok++;
+    expect(ok).toBe(2); // global still limits to 2/window; url budget was never over-consumed
+  });
+});

--- a/src/policy.test.ts
+++ b/src/policy.test.ts
@@ -16,6 +16,9 @@ const cfg = {
   spendCeilingStroops: 600, // 3 settles * 200 estimate = 600 exactly at ceiling
   spendWindowMs: 1000,
   perSettleEstimateStroops: 200,
+  perUrlMax: 1000,
+  perPayToMax: 1000,
+  unboundPoolMax: 1000,
 };
 
 function nowFn() {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -30,7 +30,25 @@
 // ceiling), which OVER-counts and thus fails safe — the ceiling bites earlier,
 // never later, than true spend.
 
-export type SettleRejectReason = "rate_limited_payto" | "spend_ceiling";
+export type SettleRejectReason =
+  | "rate_limited_payto"
+  | "spend_ceiling"
+  | "rate_limited_url"
+  | "unbound_pool_exhausted";
+
+/** F12 — the identity a settle is budgeted against. `bound` means the resource
+ * URL has a durable ownership binding (F11 tombstone); `unbound` means it does
+ * not yet. Deliberately keyed on the BINDING, not on verifiedOwner: the latter
+ * is not persisted and resets on every restart, so using it would collapse every
+ * merchant into the shared unbound pool after a restart. */
+export interface SettleIdentity {
+  /** Canonical resource URL. */
+  resourceUrl: string;
+  /** Payment recipient. */
+  payTo: string;
+  /** Whether resourceUrl carries a durable ownership binding. */
+  bound: boolean;
+}
 
 export interface SpendPolicyConfig {
   network: "stellar:testnet" | "stellar:pubnet";
@@ -44,6 +62,15 @@ export interface SpendPolicyConfig {
   spendWindowMs: number;
   /** Estimated stroops charged per settle for accounting (default = fee ceiling). */
   perSettleEstimateStroops: number;
+  /** F12: settles per window for one BOUND resource URL (default 10). */
+  perUrlMax: number;
+  /** F12: settles per window for one payTo across all its URLs (default 100 —
+   * equal to the global ceiling, so it never binds honest traffic today and
+   * starts doing work only if the global ceiling is later raised). */
+  perPayToMax: number;
+  /** F12: settles per window shared by ALL unbound URLs (default 10 — exactly
+   * one bound URL's budget, so spraying N unverified URLs yields 10/N each). */
+  unboundPoolMax: number;
 }
 
 export interface SettleVerdict {
@@ -69,6 +96,10 @@ export class SpendPolicy {
   private readonly cfg: SpendPolicyConfig;
   private readonly now: Clock;
   private readonly perPayTo = new Map<string, number[]>();
+  /** F12: settle timestamps per BOUND resource URL. */
+  private readonly perUrl = new Map<string, number[]>();
+  /** F12: settle timestamps shared by ALL unbound URLs. */
+  private unboundPool: number[] = [];
   private globalSpend: Array<{ at: number; stroops: number; id: number }> = [];
   /** Monotonic reservation id so a refund can only release its OWN entry. */
   private nextReservationId = 1;
@@ -94,23 +125,45 @@ export class SpendPolicy {
    * then turns out to have spent nothing on-chain, the caller releases the
    * global reservation with refundUnspent().
    */
-  checkSettle(payTo: string): SettleVerdict {
+  checkSettle(id: SettleIdentity | string): SettleVerdict {
+    // A bare payTo keeps older callers working; such a settle is treated as
+    // unbound with no URL of its own.
+    const ident: SettleIdentity =
+      typeof id === "string" ? { resourceUrl: "", payTo: id, bound: false } : id;
     const t = this.now();
-    const tripped = this.evaluate(payTo, t);
+    const tripped = this.evaluate(ident, t);
     if (tripped) {
       if (this.enforced) return { allowed: false, reason: tripped };
       // Fail-open (testnet): allow, but still reserve and flag.
-      const tok = this.reserve(payTo, t);
+      const tok = this.reserve(ident, t);
       return { allowed: true, wouldReject: tripped, reservation: tok };
     }
-    const tok = this.reserve(payTo, t);
+    const tok = this.reserve(ident, t);
     return { allowed: true, reservation: tok };
   }
 
-  /** Which limit (if any) this settle would cross, without mutating state. */
-  private evaluate(payTo: string, t: number): SettleRejectReason | undefined {
-    const recent = prune(this.perPayTo.get(payTo) ?? [], t - this.cfg.rateWindowMs);
-    if (recent.length >= this.cfg.rateMax) return "rate_limited_payto";
+  /**
+   * Which limit (if any) this settle would cross. Evaluates EVERY budget and
+   * mutates nothing — reservation happens only after all of them pass, so a
+   * refused settle can never leave a partial consume behind (the failure mode
+   * that let a throwing settle leak its reservation).
+   */
+  private evaluate(id: SettleIdentity, t: number): SettleRejectReason | undefined {
+    const payToRecent = prune(this.perPayTo.get(id.payTo) ?? [], t - this.cfg.rateWindowMs);
+    if (payToRecent.length >= this.cfg.rateMax) return "rate_limited_payto";
+    if (payToRecent.length >= this.cfg.perPayToMax) return "rate_limited_payto";
+
+    if (id.bound && id.resourceUrl) {
+      const urlRecent = prune(this.perUrl.get(id.resourceUrl) ?? [], t - this.cfg.rateWindowMs);
+      if (urlRecent.length >= this.cfg.perUrlMax) return "rate_limited_url";
+    } else {
+      // Unbound URLs share ONE pool sized at a single bound URL's budget, so
+      // spraying N unverified URLs yields perUrlMax/N each. Spraying competes
+      // with itself rather than with honest merchants — that ratio IS the
+      // economic signal attached to claiming an identity (F11).
+      const pool = prune(this.unboundPool, t - this.cfg.rateWindowMs);
+      if (pool.length >= this.cfg.unboundPoolMax) return "unbound_pool_exhausted";
+    }
 
     this.globalSpend = this.globalSpend.filter((e) => e.at > t - this.cfg.spendWindowMs);
     const windowSpend = this.globalSpend.reduce((s, e) => s + e.stroops, 0);
@@ -120,15 +173,28 @@ export class SpendPolicy {
     return undefined;
   }
 
-  /** Count this settle in both rolling windows. */
-  private reserve(payTo: string, t: number): number {
-    const recent = prune(this.perPayTo.get(payTo) ?? [], t - this.cfg.rateWindowMs);
+  /**
+   * Count this settle in EVERY window at once. Called only after evaluate()
+   * cleared all budgets, so the three records succeed or fail together — there
+   * is no interleaving point at which one budget is consumed and another is not.
+   */
+  private reserve(id: SettleIdentity, t: number): number {
+    const recent = prune(this.perPayTo.get(id.payTo) ?? [], t - this.cfg.rateWindowMs);
     recent.push(t);
-    this.perPayTo.set(payTo, recent);
-    const id = this.nextReservationId++;
-    this.globalSpend.push({ at: t, stroops: this.cfg.perSettleEstimateStroops, id });
+    this.perPayTo.set(id.payTo, recent);
+
+    if (id.bound && id.resourceUrl) {
+      const u = prune(this.perUrl.get(id.resourceUrl) ?? [], t - this.cfg.rateWindowMs);
+      u.push(t);
+      this.perUrl.set(id.resourceUrl, u);
+    } else {
+      this.unboundPool = prune(this.unboundPool, t - this.cfg.rateWindowMs);
+      this.unboundPool.push(t);
+    }
+    const reservationId = this.nextReservationId++;
+    this.globalSpend.push({ at: t, stroops: this.cfg.perSettleEstimateStroops, id: reservationId });
     this.evictElapsed(t);
-    return id;
+    return reservationId;
   }
 
   /**
@@ -146,6 +212,9 @@ export class SpendPolicy {
       // clock step (NTP correction) would otherwise evict a bucket that still
       // holds in-window entries, silently resetting that payTo's rate limit.
       if (times.length === 0 || Math.max(...times) <= cutoff) this.perPayTo.delete(key);
+    }
+    for (const [key, times] of this.perUrl) {
+      if (times.length === 0 || Math.max(...times) <= cutoff) this.perUrl.delete(key);
     }
   }
 
@@ -183,6 +252,9 @@ export function createSpendPolicy(input: {
   spendCeilingStroops?: number;
   spendWindowMs?: number;
   perSettleEstimateStroops: number;
+  perUrlMax?: number;
+  perPayToMax?: number;
+  unboundPoolMax?: number;
 }): SpendPolicy {
   return new SpendPolicy({
     network: input.network,
@@ -191,5 +263,8 @@ export function createSpendPolicy(input: {
     spendCeilingStroops: input.spendCeilingStroops ?? 50_000_000, // 5 XLM
     spendWindowMs: input.spendWindowMs ?? 60_000,
     perSettleEstimateStroops: input.perSettleEstimateStroops,
+    perUrlMax: input.perUrlMax ?? 10,
+    perPayToMax: input.perPayToMax ?? 100,
+    unboundPoolMax: input.unboundPoolMax ?? 10,
   });
 }

--- a/src/server.policykey.test.ts
+++ b/src/server.policykey.test.ts
@@ -1,0 +1,124 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { describe, expect, it } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+import type { SettleIdentity } from "./policy.js";
+
+// G-3 at the ROUTE. src/catalog.canonicalkey.test.ts proves the catalog helper
+// canonicalizes; it does NOT prove /settle uses it. Without this file, reverting
+// the route to the raw payload url leaves the whole suite green — the RA-12
+// decorative-test failure mode. This asserts on the identity the route actually
+// hands the spend policy.
+
+const PAY = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+const CANONICAL = "https://api.merchant.example/quote";
+const ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+
+const VALID_TX_XDR =
+  "AAAAAgAAAAARUqIOOVQYwBn0s32MhGQwyoTHPy7SzjfXdweAw6b/4gAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABqdyAuAAAAAAAAAAEAAAAAAAAAAQAAAADrmp8rY1JU7CL78HNaROud45MqVmrrbxOCVuWSEz0eRwAAAAAAAAAAAJiWgAAAAAAAAAAA";
+
+const testConfig = {
+  port: 0,
+  host: "127.0.0.1",
+  network: "stellar:testnet" as const,
+  rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(),
+  maxTransactionFeeStroops: 2_000_000,
+  catalogFile: undefined,
+  verificationApiUrl: undefined,
+  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
+  catalogOwnershipBootstrap: false,
+};
+
+function reqs(): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: ASSET,
+    amount: "1000000",
+    payTo: PAY,
+    maxTimeoutSeconds: 60,
+    extra: {},
+  } as PaymentRequirements;
+}
+
+/** Records what the route asked the policy, then allows the settle. */
+function spyPolicy() {
+  const seen: SettleIdentity[] = [];
+  const policy = {
+    checkSettle(id: SettleIdentity) {
+      seen.push(id);
+      return { allowed: true, reservation: 1 };
+    },
+    refundUnspent() {},
+  };
+  return { seen, policy };
+}
+
+async function settleWith(rawUrl: string) {
+  const catalog = new BazaarCatalog();
+  // The merchant is bound under the CANONICAL key, as extractDiscoveryInfo
+  // would have stored it.
+  catalog.upsertFromPayment(
+    { resourceUrl: CANONICAL, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as DiscoveredResource,
+    reqs(),
+  );
+  const { seen, policy } = spyPolicy();
+  const app = await buildServer(
+    buildFacilitator(testConfig),
+    catalog,
+    undefined,
+    policy as never,
+  );
+  await app.inject({
+    method: "POST",
+    url: "/settle",
+    payload: {
+      paymentPayload: {
+        x402Version: 2,
+        resource: { url: rawUrl },
+        payload: { transaction: VALID_TX_XDR },
+      },
+      paymentRequirements: reqs(),
+    },
+  });
+  await app.close();
+  return seen;
+}
+
+describe("G-3 — /settle hands the policy the CANONICAL resource key", () => {
+  it("strips the query string, so a bound merchant is scored BOUND", async () => {
+    const seen = await settleWith(`${CANONICAL}?symbol=AAPL&ts=1`);
+    expect(seen, "the policy must have been consulted").toHaveLength(1);
+    expect(seen[0]!.resourceUrl, "budget key must be canonical").toBe(CANONICAL);
+    expect(
+      seen[0]!.bound,
+      "a query string must not drop a bound merchant into the unbound pool",
+    ).toBe(true);
+  });
+
+  it("collapses query variants onto ONE budget key", async () => {
+    // Otherwise the per-URL budget is trivially multiplied by varying the query.
+    const a = await settleWith(`${CANONICAL}?i=1`);
+    const b = await settleWith(`${CANONICAL}?i=2`);
+    expect(a[0]!.resourceUrl).toBe(b[0]!.resourceUrl);
+  });
+
+  it("does not mark an unrelated resource bound", async () => {
+    const seen = await settleWith("https://evil.example/quote?i=1");
+    expect(seen[0]!.resourceUrl).toBe("https://evil.example/quote");
+    expect(seen[0]!.bound).toBe(false);
+  });
+
+  it("still consults the policy when the payload carries no resource url", async () => {
+    // D3: the policy must run unconditionally, or an omitted url would skip the
+    // global ceiling entirely.
+    const seen = await settleWith("");
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.bound).toBe(false);
+  });
+});

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -18,7 +18,7 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogFile: undefined,
   verificationApiUrl: undefined,
-  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000 },
+  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
   catalogOwnershipBootstrap: false,
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -156,12 +156,18 @@ export async function buildServer(
       // F12: budget against the DURABLE ownership binding, not verifiedOwner —
       // verifiedOwner is not persisted and resets on restart, so keying on it
       // would drop every merchant into the shared unbound pool after a reboot.
-      const resourceUrl =
+      // G-3: canonicalize to the catalog's own key (`origin + pathname`). The
+      // payload carries the RAW url, so without this a merchant on
+      // `/quote?symbol=AAPL` reads as unbound on every settle and lands in the
+      // shared unbound pool — and the per-URL budget could be multiplied by
+      // simply varying the query string.
+      const rawResourceUrl =
         (paymentPayload as unknown as { resource?: { url?: string } }).resource?.url ?? "";
+      const resourceUrl = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
       const verdict = policy.checkSettle({
         resourceUrl,
         payTo: payToKey,
-        bound: resourceUrl !== "" && catalog.isBound(resourceUrl, payToKey),
+        bound: rawResourceUrl !== "" && catalog.isBound(resourceUrl, payToKey),
       });
       reservation = verdict.reservation;
       if (!verdict.allowed) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -153,7 +153,16 @@ export async function buildServer(
     let reservation: number | undefined;
     if (policy) {
       const payToKey = policyBucketKey(paymentRequirements.payTo);
-      const verdict = policy.checkSettle(payToKey);
+      // F12: budget against the DURABLE ownership binding, not verifiedOwner —
+      // verifiedOwner is not persisted and resets on restart, so keying on it
+      // would drop every merchant into the shared unbound pool after a reboot.
+      const resourceUrl =
+        (paymentPayload as unknown as { resource?: { url?: string } }).resource?.url ?? "";
+      const verdict = policy.checkSettle({
+        resourceUrl,
+        payTo: payToKey,
+        bound: resourceUrl !== "" && catalog.isBound(resourceUrl, payToKey),
+      });
       reservation = verdict.reservation;
       if (!verdict.allowed) {
         request.log.warn(
@@ -301,6 +310,9 @@ if (isDirectRun) {
     spendCeilingStroops: config.spend.ceilingStroops,
     spendWindowMs: config.spend.windowMs,
     perSettleEstimateStroops: config.maxTransactionFeeStroops,
+    perUrlMax: config.spend.perUrlMax,
+    perPayToMax: config.spend.perPayToMax,
+    unboundPoolMax: config.spend.unboundPoolMax,
   });
   // Fix 3: sponsor balance guard. Derive the sponsor public key and poll its XLM
   // balance from Horizon. The first check is not awaited (startup is not blocked);


### PR DESCRIPTION
Closes F12. The spend ceiling was **global** while rate limits were **per-IP** and **per-payTo**, so a distributed self-dealer kept every individual bucket green while draining the one global bucket — and the merchants refused afterwards were the honest ones. The controls converted a sponsor-drain into a **denial of service against legitimate traffic**.

## The numbers

| Budget | Value | Derivation |
|---|---|---|
| Per **bound URL** | 10 / 60s | Your X — one merchant sustains 10 settlements/min |
| Per **payTo** | 100 / 60s | Equals global; see below |
| **Global ceiling** | 100 / 60s (5 XLM) | **Raised from 1 XLM** — per-entity budgets now do the fairness work |
| **Unbound pool** | 10 / 60s, shared | Exactly one bound URL's budget |

`hardFloor 10 XLM > ceiling 5 XLM` — 2× margin, invariant holds, no floor changes.

## Two findings that changed the design mid-build

**1. Budgets must key on the durable binding, not `verifiedOwner`.** `verifiedOwner` is forced `false` on load and never re-verified, so keying the unbound pool on it would have **collapsed every merchant into the shared 10/60s pool after any restart**. Caught before building; keyed on the persisted ownership tombstone instead.

**2. Per-payTo doesn't stop the attack it looked like it stopped.** Nothing ties a `payTo` to an operator across URLs — the only identity F11 creates is `url → boundPayTo`. An attacker binds each sprayed URL to a fresh address (~1.5 XLM *recoverable* reserve) and never touches a per-payTo limit, while an honest merchant using one address for ten resources would have been capped at 3/min each. At 3× it was a tax on the operator profile the platform exists to attract, invisible to the attacker. Set to 100 (= global): never binds honest traffic today, becomes load-bearing only if the ceiling is later raised.

## The unbound ratio is deliberate

All unbound URLs share **one** budget equal to a single bound URL's. Spraying N unverified URLs yields `10/N` each — spraying competes with itself, not with honest merchants. That ratio *is* the economic signal, chosen rather than left over.

## What this does NOT do — recorded in the audit doc

Four tuned numbers can look like a defence they aren't, so `docs/security-audit.md` now states plainly:

- **F12 is fairness between merchants.** It does not cap a funded attacker: 10 bound URLs at 10/min is the entire global ceiling with every budget green.
- **F11 is a one-time identity cost**, and it's cheaper than it looks — verification runs **only at first bind** (`if (firstCatalog)`) and never again, and a canonical URL is `origin + pathname`, so **ten paths on one domain are ten bindings**. The endpoint can be taken down the moment binds complete. Real price: one free static host for a few minutes plus ~15 XLM recoverable reserve.
- **The balance guard is the sponsor's actual protection** — a floor, not a rate limit.

Implication: raising the global ceiling helps honest throughput and costs an attacker nothing, since they were never bound by it. It's a sponsor-exposure dial, not a security control.

## Verification

All-or-none reservation, mutation-verified — including the one that matters: a reserve-as-you-go implementation consuming the payTo window before other budgets pass **is detected**. My first version of that test used a payTo cap too loose to observe the leak and reported a false pass; tightened until it discriminates.

**189 tests**, typecheck clean.
