### PR TITLE
fix(G-1): re-verify ownership on the bound owner's next settlement

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -130,6 +130,29 @@ memory and will overwrite a live hand-edit.
 
 3. Confirm the refusal log lines from the Symptom section have stopped.
 
+### What agents see while this is unresolved
+
+Once the facilitator re-checks the resource (it does so on the bound owner's next
+settlement — G-1), the entry's live 402 challenge will no longer name its bound
+address, and the entry is marked **unverified**: `trust.ownerVerified: false`,
+every verdict clamped to at most `"unknown"`, and the entry **disappears from
+`verified_only=true`** on `/discovery/*` and over MCP.
+
+**That is the same thing agents see for a domain that was taken over.** The wire
+carries a plain `false` — deliberately, because a three-state signal would be one
+an attacker could force onto a victim's entry. So:
+
+> **A merchant who rotated and a domain that changed hands are indistinguishable
+> to agents, and indistinguishable from the log line.** Only an operator, doing
+> the out-of-band confirmation in *Confirm it is a rotation and not a hijack*
+> above, can tell them apart. That confirmation is not a formality — it is the
+> only place in the system where the two cases are ever separated.
+
+The facilitator will not re-check a mismatching resource more than once every 24
+hours, so after you complete the rotation below the badge returns on the
+merchant's next settlement *after* that window — not instantly. Settlement,
+payment, and the merchant's money are unaffected throughout.
+
 ### Do NOT automate this
 
 > There is an obvious-looking improvement here: when an unbound `payTo` shows up

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -60,9 +60,17 @@ code. Pre-fix `HIJACKED`; post-fix `BLOCKED`. Settle #2 **succeeded on-chain in
 both runs**, so "blocked" means the catalog refused it, not that the payment
 failed.
 
-Documented limitation: the TOFU binding is in-memory / on an ephemeral disk, so
-it resets on restart and every URL becomes claimable again until durable storage
-exists. Layer 2 is the control that survives a restart.
+Documented limitation: on the current free-tier deployment there is no persistent
+disk, so the TOFU binding resets on restart and every URL becomes claimable again
+until durable storage exists.
+
+> **Correction.** This section used to end "Layer 2 is the control that survives a
+> restart." That was **backwards**, and G-1 is the consequence. Layer **1** is what
+> survives: the `.ownership` tombstone file is durable once a disk exists. Layer 2
+> was the control that did *not* survive — `verifiedOwner` is never read back from
+> disk (RA-9) and re-verification fired only on first catalog, so it was lost at
+> every restart and never recovered. Since G-1 it recovers on the bound owner's
+> next settlement.
 
 ### F2 — Unauthenticated sponsor drain — **High** — closed-by-test
 
@@ -454,7 +462,6 @@ change.
 
 | ID | Finding | Why |
 | --- | --- | --- |
-| **G-1** | Ownership verification lost on restart, never recovers — and it is **served to agents** | **open** — latent until a persistent disk is attached. Remediation named below; the backoff value needs threshold sign-off. |
 | **G-2** | A bound URL has no `payTo` rotation path | **open** — manual operator procedure exists and must be documented; the automated fix trades away F11's takeover resistance. |
 | **G-4** | `recordSettlement` lets anyone inflate a victim entry's trust stats | **open** — highest-value of the review findings; no `payTo` check, and it runs after a rejected upsert. |
 | **G-5**–**G-8** | Load-path squat, unbounded load, unpersisted bootstrap bindings, one-way tombstone cap | **open** — triaged below, none fixed. |
@@ -469,6 +476,7 @@ Closed since this table was first written (kept here so the history is not lost)
 | **F12** | Spend accounting was global while rate limiting was per-IP | **closed-by-test** — per-entity budgets keyed off the F11 bindings. See the control-scope table for what this does and does not achieve. |
 | **F3** | Non-atomic `save()`, unbounded entries/`accepts` | **closed-by-test** — atomic writes, bounds, and ownership tombstones so eviction cannot drop a binding. |
 | **F10-op** | `examples/.env.recording` held a live testnet `AGENT_SECRET` | **closed** — signer removed on-chain and confirmed `null`, local copies deleted. See the `argv` lesson above. |
+| **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement; settle-triggered only, cooldowns asserted in outbound fetches. |
 
 ---
 
@@ -557,7 +565,77 @@ Characterized end-to-end through the real routes in
 they pin current behaviour, not desired behaviour. Fixing either gap should make
 them fail — update the tests and this section together.
 
-### G-1 — Ownership verification is lost on restart and never recovers — **High (latent)** — **OPEN**
+### G-1 — Ownership verification is lost on restart — **High (latent)** — closed-by-test
+
+**Fixed** by `BazaarCatalog.reverify()`: Layer 2 now re-runs on the **bound
+owner's next settlement** while an entry is unverified, not only on first
+catalog. This is the path `bindLoadedEntry`'s comment always claimed existed; the
+comment is now asserted by test rather than merely asserted.
+
+Three design decisions, taken before implementing:
+
+- **Settle-triggered only — no background prober.** A timer that re-probes would
+  grant `verified` on *current domain control* with no contemporaneous payment,
+  which is the same inference refused for automated rotation (runbook §1). Every
+  fetch stays anchored to a real settlement. **The price, accepted explicitly:** a
+  zero-traffic resource stays unverified, so `verified_only` remains incomplete
+  after a restart until each merchant next settles.
+- **State is in-memory only** — never persisted (RA-9 stays closed) and never on
+  the wire, so there is no verification signal an attacker can force onto a
+  victim's entry.
+- **`mismatch` and `unverifiable` do not share a retry floor.** A mismatch is a
+  *definite* answer (24h, effectively terminal but still self-healing after a
+  legitimate rotation); an unverifiable is *uncertain* (15min).
+
+**The amplification rationale, corrected.** The first version of this design
+claimed the bound-owner gate *removes* the amplification vector. That is false,
+and red-teaming caught it: under TOFU the bound owner is whoever **settled
+first**, not whoever controls the endpoint — which is precisely why Layer 2
+exists. An attacker who settles once against a victim's URL becomes its bound
+owner and can then cause one probe per settlement. The gate yields **1:1, not
+zero**. The cooldowns, not the gate, are the brake — so they are asserted by
+**counting outbound fetches**, not by reading the bookkeeping field. 50
+settlements against a mismatching resource produce exactly **one** fetch.
+
+**Guards, each with a no-fetch test:** unbound settling payTo, empty binding
+(`bindLoadedEntry`'s no-accepts branch — passing no address read back as a false
+`mismatch`), `routeTemplate` keys (the canonical key is a literal
+`origin + /quote/:symbol`, which is not fetchable), uncataloged resources,
+already-verified entries, and in-flight duplicates.
+
+**The binding is never exposed.** `entry.boundPayTo` *is* the ownership tombstone
+array — red-teaming proved that one `.push()` on it reaches the ownership file on
+disk and survives a restart, which would be full takeover-rebinding. So the
+catalog owns `reverify` and hands the verifier a **copy**. A test mutates what
+the verifier receives and asserts the binding is unmoved.
+
+**No verdict can rebind.** Independently confirmed: `setVerifiedOwner` is the only
+catalog mutation a re-verify performs, the ownership map has no `delete`/`clear`
+anywhere in the file, and a tampered entry file cannot move a binding because the
+load schema strips `boundPayTo`. A test snapshots the ownership store, runs every
+verdict repeatedly across cooldown windows, and asserts it is byte-identical.
+
+**Hot path preserved, and the reason is now written down.** `@x402/core` *awaits*
+the afterSettle hook, so `void` + `.catch()` is load-bearing rather than
+stylistic. Two tests cover it: a verifier that never resolves must not delay
+settlement, and one that throws must not fail it.
+
+Mutation-verified: removing the cooldown, giving `mismatch` the 15-minute floor,
+dropping the bound-owner gate, handing out the real binding array, awaiting
+inside the hook, and removing the already-verified skip are all detected.
+*Reported honestly:* making the write unconditional (`setVerifiedOwner(key,
+verdict === "match")`) is **not** detected — it is an equivalent mutant, since a
+verified entry is never re-probed, so that write can only ever set `false` on an
+already-`false` entry, which `setVerifiedOwner` early-returns on.
+
+**What remains open:** a merchant who rotates (G-2) now reads as *unverified*
+rather than *stale-but-trusted*, which is the safe direction but still
+indistinguishable to agents from a domain takeover. Only the operator can
+separate them — see runbook §1, *What agents see while this is unresolved*.
+
+<details>
+<summary>Original finding (pre-fix)</summary>
+
 
 `verifiedOwner` is deliberately not trusted from disk (RA-9: a crafted
 `CATALOG_FILE` could forge it), so `load()` forces it `false`. But Layer 2
@@ -619,6 +697,8 @@ the two alternatives:
 resource that cannot be verified is not re-probed on every single settlement.
 That is a threshold value, so it belongs in the threshold review rather than
 being picked here.
+
+</details>
 
 ### G-2 — A bound URL has no `payTo` rotation path — **Medium** — **OPEN**
 

--- a/src/bazaar.ownership.test.ts
+++ b/src/bazaar.ownership.test.ts
@@ -154,7 +154,10 @@ describe("registerBazaar — Layer 2 async ownership verification", () => {
     // Let the fire-and-forget microtask settle.
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(verify).toHaveBeenCalledWith("https://api.example.com/weather", requirements().payTo);
+    // G-1: the catalog now drives verification and passes the resource's whole
+    // BOUND set (a copy — the array aliases the ownership tombstone), so a
+    // rotated merchant with two bound addresses is settled in one fetch.
+    expect(verify).toHaveBeenCalledWith("https://api.example.com/weather", [requirements().payTo]);
     expect(catalog.isVerifiedOwner("https://api.example.com/weather")).toBe(true);
   });
 

--- a/src/bazaar.ts
+++ b/src/bazaar.ts
@@ -4,7 +4,9 @@ import type { BazaarCatalog } from "./catalog.js";
 import { verifyResourceOwnership, type OwnershipVerdict } from "./ownership.js";
 
 /** Injectable for tests; production uses the SSRF-guarded 402-challenge fetch. */
-type OwnershipVerifier = (resourceUrl: string, payTo: string) => Promise<OwnershipVerdict>;
+/** G-1: takes the resource's whole BOUND set, so a merchant with a rotated
+ * address (runbook §1 appends rather than replaces) is settled in one fetch. */
+type OwnershipVerifier = (resourceUrl: string, payTos: string[]) => Promise<OwnershipVerdict>;
 
 export interface RegisterBazaarOptions {
   /** Layer 2 verifier. Defaults to the real SSRF-guarded fetch; unset in tests
@@ -43,7 +45,7 @@ export function registerBazaar(
       if (!result.success) return;
       const discovered = extractDiscoveryInfo(paymentPayload, requirements);
       if (!discovered) return;
-      const firstCatalog = catalog.upsertFromPayment(discovered, requirements);
+      catalog.upsertFromPayment(discovered, requirements);
       // Settlement ground truth (trust layer): count the settlement and the
       // distinct payer against the cataloged resource.
       //
@@ -53,28 +55,32 @@ export function registerBazaar(
       // the ordering here is no longer load-bearing for correctness.
       catalog.recordSettlement(discovered.resourceUrl, result.payer, requirements.payTo);
 
-      // Fix 0 Layer 2: on the FIRST catalog of a URL, verify ownership against
-      // the resource's own 402 challenge — asynchronously, fire-and-forget.
-      // Settlement has already been recorded above and returns immediately; the
-      // verification never blocks, delays, or fails it (§ "off the hot path").
-      if (firstCatalog) {
-        const { resourceUrl } = discovered;
-        const { payTo } = requirements;
-        void verifyOwnership(resourceUrl, payTo)
-          .then((verdict) => {
-            catalog.setVerifiedOwner(resourceUrl, verdict === "match");
-            if (verdict === "mismatch") {
-              console.warn(
-                `[bazaar] ownership MISMATCH for ${resourceUrl}: settled payTo ${payTo} not in ` +
-                  `the resource's 402 challenge — accepts left non-authoritative (F11 Layer 2)`,
-              );
-            }
-          })
-          .catch((err) => {
-            // Verification errors degrade to unverified, never surface.
-            console.warn(`[bazaar] ownership verification failed for ${resourceUrl}:`, err);
-          });
-      }
+      // Fix 0 Layer 2, extended by G-1: verify ownership against the resource's
+      // own 402 challenge — on the first catalog of a URL, AND on any later
+      // settlement by the bound owner while the entry is still unverified.
+      //
+      // The second case is the one bindLoadedEntry's comment always claimed
+      // existed: `verifiedOwner` is never restored from disk (RA-9), so without
+      // it a restored entry served ownerVerified:false forever and
+      // verified_only=true returned an empty catalog.
+      //
+      // FIRE-AND-FORGET IS LOAD-BEARING, not stylistic: @x402/core AWAITS this
+      // hook (facilitator/index.mjs `await hook(resultContext)`), so anything
+      // awaited here delays the settle response. Settlement must never wait on,
+      // nor fail because of, a merchant's endpoint. `void` + `.catch()` is what
+      // guarantees that; do not "clean it up" into an await.
+      //
+      // All gating (bound-owner check, cooldowns, in-flight dedupe, templated
+      // and empty-binding skips) lives in catalog.reverify, which reads the
+      // binding internally. The binding is deliberately NOT passed in or handed
+      // out — entry.boundPayTo aliases the ownership tombstone, so exposing it
+      // would put a durable rebinding primitive one `.push()` away.
+      void catalog
+        .reverify(discovered.resourceUrl, requirements.payTo, verifyOwnership)
+        .catch((err) => {
+          // Verification problems degrade to unverified, never surface.
+          console.warn(`[bazaar] ownership verification failed for ${discovered.resourceUrl}:`, err);
+        });
     } catch (err) {
       console.error("[bazaar] cataloging failed (settlement unaffected):", err);
     }

--- a/src/catalog.reverify.test.ts
+++ b/src/catalog.reverify.test.ts
@@ -1,0 +1,334 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { x402Facilitator } from "@x402/core/facilitator";
+import type { PaymentPayload, PaymentRequirements, SchemeNetworkFacilitator } from "@x402/core/types";
+import { declareDiscoveryExtension } from "@x402/extensions/bazaar";
+import { afterEach, describe, expect, it } from "vitest";
+import { registerBazaar } from "./bazaar.js";
+import { BazaarCatalog, ownershipPathFor } from "./catalog.js";
+import type { OwnershipVerdict } from "./ownership.js";
+
+// G-1 — re-verify on settle.
+//
+// verifiedOwner is deliberately not trusted from disk (RA-9), and Layer 2 fired
+// only under `if (firstCatalog)`, so a restored entry served ownerVerified:false
+// and verified_only=true returned an empty catalog. bindLoadedEntry's comment
+// claimed "Layer 2 re-verifies from the resource on the next settlement" — that
+// path did not exist. These tests assert the behaviour the comment described, so
+// the comment becomes true and stays true.
+//
+// DESIGN (decided before implementing):
+//  - Settle-triggered ONLY. No timer, no prober. A prober would grant "verified"
+//    on current domain control with no contemporaneous payment — the same
+//    inference refused for automated rotation (runbook procedure 1). The price
+//    is that a zero-traffic resource stays unverified; that is the correct price.
+//  - Verification state is in-memory ONLY: never persisted (RA-9 stays closed)
+//    and never on the wire (no attacker-forceable signal for consumers).
+//  - mismatch is a DEFINITE answer, unverifiable an UNCERTAIN one, so they do
+//    not share a retry floor: 24h vs 15min.
+//
+// The 24h cooldown is the brake on amplification, so it is asserted by COUNTING
+// OUTBOUND FETCHES, not by reading the bookkeeping field.
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "vellar-rev-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+const URL_X = "https://api.merchant.example/quote";
+const OWNER = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+const OTHER = "GBQ3VANQZ6X3ZVGFTQJZ2MZ4KOCPZ5EGWSVYT7OPTQJ4M7VXMKQ3OQXD";
+const ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+function reqs(payTo: string): PaymentRequirements {
+  return {
+    scheme: "exact", network: "stellar:testnet", asset: ASSET,
+    amount: "1000000", payTo, maxTimeoutSeconds: 60, extra: {},
+  } as PaymentRequirements;
+}
+
+function stubScheme(): SchemeNetworkFacilitator {
+  return {
+    scheme: "exact", caipFamily: "stellar:*",
+    getExtra: () => undefined, getSigners: () => [],
+    verify: async () => ({ isValid: true, payer: "CPAYER" }),
+    settle: async () => ({ success: true, transaction: "tx", network: "stellar:testnet", payer: "CPAYER" }),
+  } as unknown as SchemeNetworkFacilitator;
+}
+
+function payload(url: string, payTo: string, routeTemplate?: string): PaymentPayload {
+  const extensions = declareDiscoveryExtension({
+    input: { city: "lagos" },
+    inputSchema: { properties: { city: { type: "string" } }, required: ["city"] },
+  }) as Record<string, { info: { input: Record<string, unknown> }; routeTemplate?: string }>;
+  extensions.bazaar!.info.input.method = "GET";
+  // routeTemplate lives on the extension object itself (the extractor reads
+  // `rawExt.routeTemplate`), not inside `info`.
+  if (routeTemplate) extensions.bazaar!.routeTemplate = routeTemplate;
+  return {
+    x402Version: 2,
+    resource: { url, description: "Quotes", serviceName: "MerchantSvc" },
+    accepted: reqs(payTo),
+    payload: { transaction: "AAAA" },
+    extensions,
+  } as PaymentPayload;
+}
+
+/** A verifier that COUNTS calls — the amplification is what is being tested. */
+function counter(verdict: OwnershipVerdict | ((url: string, payTos: string[]) => OwnershipVerdict)) {
+  const calls: Array<{ url: string; payTos: string[] }> = [];
+  const fn = async (url: string, payTos: string[]): Promise<OwnershipVerdict> => {
+    calls.push({ url, payTos: [...payTos] });
+    return typeof verdict === "function" ? verdict(url, payTos) : verdict;
+  };
+  return { calls, fn };
+}
+
+function seeded(): BazaarCatalog {
+  const c = new BazaarCatalog();
+  c.upsertFromPayment(
+    { resourceUrl: URL_X, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+    reqs(OWNER),
+  );
+  return c;
+}
+
+describe("G-1 — the behaviour bindLoadedEntry's comment promised", () => {
+  it("a restored entry re-verifies on the bound owner's next settlement", async () => {
+    const file = join(tmpDir(), "catalog.json");
+
+    // Run 1: cataloged and verified.
+    const before = new BazaarCatalog(file);
+    const v1 = counter("match");
+    const f1 = new x402Facilitator().register("stellar:testnet", stubScheme());
+    registerBazaar(f1, before, { verifyOwnership: v1.fn as never });
+    await f1.settle(payload(URL_X, OWNER), reqs(OWNER));
+    await new Promise((r) => setImmediate(r));
+    expect(before.isVerifiedOwner(URL_X), "precondition: verified in run 1").toBe(true);
+    before.flush();
+
+    // Run 2: restart. The entry is restored UNVERIFIED (RA-9 — never trusted
+    // from disk), and before this fix nothing could ever restore it.
+    const after = new BazaarCatalog(file);
+    expect(after.isVerifiedOwner(URL_X), "restored entries start unverified").toBe(false);
+
+    const v2 = counter("match");
+    const f2 = new x402Facilitator().register("stellar:testnet", stubScheme());
+    registerBazaar(f2, after, { verifyOwnership: v2.fn as never });
+    await f2.settle(payload(URL_X, OWNER), reqs(OWNER));
+    await new Promise((r) => setImmediate(r));
+
+    expect(v2.calls, "the next settlement must re-verify").toHaveLength(1);
+    expect(after.isVerifiedOwner(URL_X), "the comment's promise, now true").toBe(true);
+  });
+
+  it("re-verification asks about the BOUND owner, not the settling payTo", async () => {
+    const c = seeded();
+    const v = counter("match");
+    await c.reverify(URL_X, OWNER, v.fn, 0);
+    expect(v.calls[0]!.payTos, "must ask about the durable binding").toEqual([OWNER]);
+  });
+
+  it("matches ANY bound address, so a runbook rotation can restore the badge", async () => {
+    // The operator rotation procedure produces boundPayTo: [OLD, NEW].
+    const file = join(tmpDir(), "catalog.json");
+    const c = seeded();
+    // Simulate the operator's edit by loading an ownership file with both.
+    const path = join(tmpDir(), "c2.json");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(ownershipPathFor(path), JSON.stringify([{ resource: URL_X, boundPayTo: [OWNER, OTHER] }]));
+    writeFileSync(path, JSON.stringify([{
+      resource: { resource: URL_X, type: "http", x402Version: 2, lastUpdated: "2026-08-01T00:00:00.000Z",
+        accepts: [{ scheme: "exact", network: "stellar:testnet", asset: ASSET, amount: "1", payTo: OWNER }] },
+      stats: { settlements: 0, payers: [], observed: 0 },
+    }]));
+    const rotated = new BazaarCatalog(path);
+    const v = counter((_u, payTos) => (payTos.includes(OTHER) ? "match" : "mismatch"));
+    await rotated.reverify(URL_X, OWNER, v.fn, 0);
+    expect(v.calls[0]!.payTos, "one fetch, both addresses").toEqual([OWNER, OTHER]);
+    expect(rotated.isVerifiedOwner(URL_X)).toBe(true);
+    expect(c.size).toBe(1); // keep `file`/`c` referenced
+    expect(file).toBeTruthy();
+  });
+});
+
+describe("G-1 — the 24h mismatch cooldown is the brake (measured in fetches)", () => {
+  it("a mismatching resource is fetched ONCE, not once per settlement", async () => {
+    const c = seeded();
+    const v = counter("mismatch");
+    // 50 settlements from the bound owner across 23 hours.
+    for (let i = 0; i < 50; i++) {
+      await c.reverify(URL_X, OWNER, v.fn, i * (27 * MIN)); // ~22.5h total
+    }
+    expect(v.calls.length, "24h cooldown must collapse 50 settles to 1 fetch").toBe(1);
+  });
+
+  it("retries only after the full 24h", async () => {
+    const c = seeded();
+    const v = counter("mismatch");
+    await c.reverify(URL_X, OWNER, v.fn, 0);
+    await c.reverify(URL_X, OWNER, v.fn, 24 * HOUR - 1);
+    expect(v.calls.length, "still inside the window").toBe(1);
+    await c.reverify(URL_X, OWNER, v.fn, 24 * HOUR);
+    expect(v.calls.length, "window elapsed").toBe(2);
+  });
+
+  it("an UNVERIFIABLE endpoint uses the shorter 15min floor, not 24h", async () => {
+    // Uncertainty is not a definite answer, so it must not be parked for a day.
+    const c = seeded();
+    const v = counter("unverifiable");
+    await c.reverify(URL_X, OWNER, v.fn, 0);
+    await c.reverify(URL_X, OWNER, v.fn, 15 * MIN - 1);
+    expect(v.calls.length).toBe(1);
+    await c.reverify(URL_X, OWNER, v.fn, 15 * MIN);
+    expect(v.calls.length, "15min floor for uncertainty").toBe(2);
+  });
+
+  it("stops fetching entirely once verified", async () => {
+    const c = seeded();
+    const v = counter("match");
+    for (let i = 0; i < 20; i++) await c.reverify(URL_X, OWNER, v.fn, i * 48 * HOUR);
+    expect(v.calls.length, "a verified entry is never re-probed").toBe(1);
+  });
+});
+
+describe("G-1 — amplification gates: no fetch at all", () => {
+  it("an UNBOUND settling payTo triggers no fetch", async () => {
+    const c = seeded();
+    const v = counter("match");
+    for (let i = 0; i < 10; i++) await c.reverify(URL_X, OTHER, v.fn, i * 48 * HOUR);
+    expect(v.calls.length, "only the bound owner's settle may trigger a probe").toBe(0);
+  });
+
+  it("an entry with an EMPTY binding triggers no fetch", async () => {
+    // bindLoadedEntry produces boundPayTo:[] for a stored entry with no accepts
+    // (G-5). Probing it would pass no address and read back a false MISMATCH.
+    const path = join(tmpDir(), "empty.json");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(ownershipPathFor(path), JSON.stringify([]));
+    writeFileSync(path, JSON.stringify([{
+      resource: { resource: URL_X, type: "http", x402Version: 2, lastUpdated: "2026-08-01T00:00:00.000Z", accepts: [] },
+      stats: { settlements: 0, payers: [], observed: 0 },
+    }]));
+    const c = new BazaarCatalog(path);
+    const v = counter("match");
+    await c.reverify(URL_X, OWNER, v.fn, 0);
+    expect(v.calls.length, "a missing claim is not a refuted claim — do not probe").toBe(0);
+  });
+
+  it("a routeTemplate key triggers no fetch", async () => {
+    // The canonical key becomes `origin + /quote/:symbol`; fetching it would GET
+    // a literal `:symbol`. Structurally unverifiable — skip rather than probe.
+    const c = new BazaarCatalog();
+    const f = new x402Facilitator().register("stellar:testnet", stubScheme());
+    const v = counter("match");
+    registerBazaar(f, c, { verifyOwnership: v.fn as never });
+    await f.settle(payload("https://api.merchant.example/quote/AAPL", OWNER, "/quote/:symbol"), reqs(OWNER));
+    await new Promise((r) => setImmediate(r));
+    expect(v.calls.length, "templated keys must not be fetched").toBe(0);
+  });
+
+  it("an uncataloged resource triggers no fetch", async () => {
+    const c = new BazaarCatalog();
+    const v = counter("match");
+    await c.reverify("https://nowhere.example/x", OWNER, v.fn, 0);
+    expect(v.calls.length).toBe(0);
+  });
+});
+
+describe("G-1 — a failed re-verify is never a route to rebinding", () => {
+  it("no verdict, under any retry path, changes a binding", async () => {
+    const path = join(tmpDir(), "bind.json");
+    const c = new BazaarCatalog(path);
+    c.upsertFromPayment(
+      { resourceUrl: URL_X, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      reqs(OWNER),
+    );
+    c.flush();
+    const { readFileSync } = await import("node:fs");
+    const ownershipBefore = readFileSync(ownershipPathFor(path), "utf8");
+
+    // Every verdict, repeatedly, across many cooldown windows.
+    let t = 0;
+    for (const verdict of ["mismatch", "unverifiable", "mismatch", "unverifiable"] as OwnershipVerdict[]) {
+      const v = counter(verdict);
+      await c.reverify(URL_X, OWNER, v.fn, t);
+      t += 48 * HOUR;
+    }
+
+    expect(c.isBound(URL_X, OWNER), "the original owner stays bound").toBe(true);
+    expect(c.isBound(URL_X, OTHER), "no verdict may bind anyone new").toBe(false);
+    c.flush();
+    expect(readFileSync(ownershipPathFor(path), "utf8"), "ownership store byte-identical").toBe(ownershipBefore);
+  });
+
+  it("a MATCH for a different address does not bind that address", async () => {
+    // The verifier is told the bound set; a hostile one claiming "match" must
+    // not be able to smuggle in a new owner.
+    const c = seeded();
+    const v = counter("match");
+    await c.reverify(URL_X, OWNER, v.fn, 0);
+    expect(c.isBound(URL_X, OTHER)).toBe(false);
+    expect(c.isVerifiedOwner(URL_X)).toBe(true);
+  });
+
+  it("does not hand out the ownership array (it aliases the tombstone)", async () => {
+    // entry.boundPayTo IS the tombstone array object; a caller that mutated it
+    // would durably rebind at the next saveOwnership.
+    const c = seeded();
+    const v = counter((_u, payTos) => {
+      payTos.push(OTHER); // a caller mutating what it was given
+      return "match";
+    });
+    await c.reverify(URL_X, OWNER, v.fn, 0);
+    expect(c.isBound(URL_X, OTHER), "mutation must not reach the binding").toBe(false);
+  });
+});
+
+describe("G-1 — uncertainty never downgrades, and the hot path is preserved", () => {
+  it("a verified entry is never re-probed, so nothing can strip its badge", async () => {
+    const c = seeded();
+    await c.reverify(URL_X, OWNER, counter("match").fn, 0);
+    expect(c.isVerifiedOwner(URL_X)).toBe(true);
+
+    // Assert the MECHANISM, not just the outcome: the verifier must not be
+    // consulted at all. That is what makes an existing verification
+    // undowngradable — and it means the write below can only ever act on an
+    // unverified entry, so a "mismatch" can never clear a live badge.
+    const later = counter("unverifiable");
+    await c.reverify(URL_X, OWNER, later.fn, 100 * HOUR);
+    expect(later.calls.length, "a verified entry must not be re-fetched").toBe(0);
+    expect(c.isVerifiedOwner(URL_X), "uncertainty never downgrades").toBe(true);
+  });
+
+  it("settlement never waits on the verification fetch", async () => {
+    // @x402/core AWAITS the afterSettle hook, so a verifier that never resolves
+    // would stall every settlement if the hook awaited it.
+    const c = new BazaarCatalog();
+    const f = new x402Facilitator().register("stellar:testnet", stubScheme());
+    registerBazaar(f, c, { verifyOwnership: (() => new Promise<never>(() => {})) as never });
+    const settled = await Promise.race([
+      f.settle(payload(URL_X, OWNER), reqs(OWNER)).then(() => "settled"),
+      new Promise((r) => setTimeout(() => r("STALLED"), 1_000)),
+    ]);
+    expect(settled, "a hanging verifier must not delay settlement").toBe("settled");
+  });
+
+  it("a THROWING verifier neither fails nor delays settlement", async () => {
+    const c = new BazaarCatalog();
+    const f = new x402Facilitator().register("stellar:testnet", stubScheme());
+    registerBazaar(f, c, { verifyOwnership: (async () => { throw new Error("hostile"); }) as never });
+    const res = await f.settle(payload(URL_X, OWNER), reqs(OWNER));
+    await new Promise((r) => setImmediate(r));
+    expect(res.success, "settlement is unaffected by verification failure").toBe(true);
+  });
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -11,6 +11,7 @@ import type {
   SearchDiscoveryResourcesParams,
   SearchDiscoveryResourcesResponse,
 } from "@x402/extensions/bazaar";
+import type { OwnershipVerdict } from "./ownership.js";
 import type { TrustedDiscoveryResource } from "./trust.js";
 
 const DEFAULT_LIMIT = 20;
@@ -31,6 +32,29 @@ const MAX_ACCEPTS = 20;
 /** Max ownership tombstones. At this cap the catalog FREEZES new bindings
  * rather than forgetting ownership — see `frozen`. */
 const MAX_TOMBSTONES = 100_000;
+/** G-1 retry floors. A `mismatch` is a DEFINITE answer, so retrying it buys
+ * nothing but outbound traffic — 24h makes it effectively terminal while still
+ * self-healing after a legitimate operator rotation. An `unverifiable` is
+ * UNCERTAIN (endpoint down, timeout, non-402), so it recovers far sooner. They
+ * deliberately do not share a floor. These are the brake on amplification. */
+const REVERIFY_COOLDOWN_MISMATCH_MS = 24 * 60 * 60 * 1000;
+const REVERIFY_COOLDOWN_UNVERIFIABLE_MS = 15 * 60 * 1000;
+
+function cooldownFor(verdict: OwnershipVerdict): number {
+  return verdict === "mismatch" ? REVERIFY_COOLDOWN_MISMATCH_MS : REVERIFY_COOLDOWN_UNVERIFIABLE_MS;
+}
+
+/** A catalog key derived from a client-declared routeTemplate, e.g.
+ * `https://h/quote/:symbol`. Such a key is not a fetchable URL. */
+function isTemplatedKey(key: string): boolean {
+  try {
+    const p = new URL(key).pathname;
+    return p.includes(":") || p.includes("{");
+  } catch {
+    return false;
+  }
+}
+
 /** Debounce window for the (reconstructible) entry file. Ownership is never
  * debounced. */
 const PERSIST_DEBOUNCE_MS = 250;
@@ -354,6 +378,10 @@ export class BazaarCatalog {
    * problem; forgetting ownership is a silent security one.
    */
   private frozen: false | "ownership-unreadable" | "tombstone-cap" = false;
+  /** G-1 verification scheduling state. In-memory ONLY: never persisted (RA-9)
+   * and never on the wire (no attacker-forceable signal for consumers). */
+  private readonly verifyState = new Map<string, { verdict: OwnershipVerdict; at: number }>();
+  private readonly verifyInFlight = new Set<string>();
 
   constructor(persistPath?: string, opts: { bootstrapOwnership?: boolean } = {}) {
     this.persistPath = persistPath;
@@ -418,6 +446,89 @@ export class BazaarCatalog {
    * boundaries; `isBound` assumes the caller already holds a canonical key. */
   isBoundResource(rawResourceUrl: string, payTo: string): boolean {
     return this.isBound(BazaarCatalog.canonicalResourceKey(rawResourceUrl), payTo);
+  }
+
+  /**
+   * G-1: re-run Layer 2 for an already-cataloged resource.
+   *
+   * `verifiedOwner` is never trusted from disk (RA-9), and Layer 2 used to fire
+   * only on first catalog, so a restored entry stayed unverified forever and
+   * `verified_only=true` served an empty catalog. This is the path
+   * `bindLoadedEntry` always claimed existed.
+   *
+   * The catalog owns this rather than exposing the binding, because
+   * `entry.boundPayTo` IS the ownership tombstone array — handing it out would
+   * put a durable rebinding primitive one `.push()` away. The verifier receives
+   * a COPY.
+   *
+   * Every gate below exists to bound outbound traffic. The settling payTo must
+   * already be bound, so a stranger cannot make the facilitator fetch a URL;
+   * note this is 1:1, not zero — under TOFU the bound owner is the first
+   * settler, not necessarily whoever controls the endpoint — which is exactly
+   * why the cooldowns, not the gate, are the real brake.
+   *
+   * Verdicts: `match` verifies; `mismatch` is a DEFINITE denial and parks the
+   * URL for 24h; `unverifiable` is UNCERTAIN and never downgrades an existing
+   * verification, retrying after 15min. No verdict ever touches a binding.
+   *
+   * State is in-memory only — never persisted (RA-9 stays closed) and never on
+   * the wire (nothing an attacker can force onto a victim's entry).
+   */
+  async reverify(
+    rawResourceUrl: string,
+    settlingPayTo: string,
+    verify: (url: string, payTos: string[]) => Promise<OwnershipVerdict>,
+    now: number = Date.now(),
+  ): Promise<"match" | "mismatch" | "unverifiable" | "skipped"> {
+    const key = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
+    const entry = this.entries.get(key);
+    if (!entry) return "skipped";
+    // Already verified: nothing to re-establish, and re-probing a good entry is
+    // pure outbound traffic. This is also what makes an existing verification
+    // undowngradable — the verifier is never consulted again — so the
+    // match-only write below can only ever act on an unverified entry.
+    if (entry.verifiedOwner) return "skipped";
+    // An entry that binds to nothing (bindLoadedEntry's empty-accepts branch)
+    // has no claim to test — asking would read back a false mismatch. Checked
+    // BEFORE the bound-owner gate: that gate would reject an empty binding too,
+    // which would make this line dead code that merely looks load-bearing.
+    if (entry.boundPayTo.length === 0) return "skipped";
+    // Only the bound owner's own settlement may trigger a probe. Note this is
+    // 1:1, not zero: under TOFU the bound owner is the FIRST SETTLER, not
+    // necessarily whoever controls the endpoint, so a stranger who bound a
+    // victim's URL can still cause one probe per settlement. The cooldowns
+    // below, not this gate, are the actual brake.
+    if (!settlingPayTo || !entry.boundPayTo.includes(settlingPayTo)) return "skipped";
+    // A routeTemplate key is `origin + /quote/:symbol`; fetching it would GET a
+    // literal `:symbol`. Structurally unverifiable, so never probe it.
+    if (isTemplatedKey(key)) return "skipped";
+    if (this.verifyInFlight.has(key)) return "skipped";
+
+    const last = this.verifyState.get(key);
+    if (last && now - last.at < cooldownFor(last.verdict)) return "skipped";
+
+    this.verifyInFlight.add(key);
+    try {
+      // Copy: the verifier must never receive the tombstone array itself.
+      const verdict = await verify(key, [...entry.boundPayTo]);
+      this.verifyState.set(key, { verdict, at: now });
+      if (verdict === "match") {
+        this.setVerifiedOwner(key, true);
+      } else if (verdict === "mismatch") {
+        console.warn(
+          `[catalog] ownership MISMATCH on re-verify for ${key}: the resource's 402 challenge no longer ` +
+            `names its bound owner. Left UNVERIFIED; binding unchanged. This reads the same as a merchant ` +
+            `who rotated and as a domain that changed hands — see docs/operator-runbook.md §1 (G-1/G-2).`,
+        );
+      }
+      return verdict;
+    } catch {
+      // A hostile or broken verifier is uncertainty, not a denial.
+      this.verifyState.set(key, { verdict: "unverifiable", at: now });
+      return "unverifiable";
+    } finally {
+      this.verifyInFlight.delete(key);
+    }
   }
 
   /** Whether the resource's own 402 challenge has confirmed its bound owner
@@ -745,11 +856,15 @@ export class BazaarCatalog {
       stats: stored.stats ?? { settlements: 0, payers: [], observed: 0 },
       boundPayTo: authoritative ?? [ownerPayTo],
       // Never trust a stored verified flag — a crafted file could forge it (RA-9).
+      // Layer 2 re-verifies from the resource on the bound owner's next
+      // settlement, via `reverify` (G-1).
       //
-      // NOTE: this does NOT re-verify. Layer 2 fires only when upsertFromPayment
-      // reports isFirstCatalog, which is false for any entry loaded from disk, so
-      // a restored entry serves ownerVerified:false permanently. See G-1 in
-      // docs/security-audit.md — that is a known gap, not the intended design.
+      // That sentence was in this file for a long time before it was true: Layer 2
+      // fired only on first catalog, which is never the case for a loaded entry, so
+      // a restored entry stayed unverified forever and `verified_only=true` served
+      // an empty catalog. It is now asserted end-to-end in
+      // src/catalog.reverify.test.ts — if the path is removed, that test fails and
+      // this comment stops being a claim nobody checks.
       verifiedOwner: false,
     };
   }

--- a/src/ownership.ts
+++ b/src/ownership.ts
@@ -152,9 +152,22 @@ export async function assertPublicHttpsUrl(
  */
 export async function verifyResourceOwnership(
   resourceUrl: string,
-  settledPayTo: string,
+  settledPayTo: string | readonly string[],
   opts: VerifyOptions = {},
 ): Promise<OwnershipVerdict> {
+  // G-1: a resource may have more than one bound address — the operator rotation
+  // procedure (runbook §1) appends rather than replaces. Match if the challenge
+  // names ANY of them, in ONE fetch.
+  //
+  // An empty or all-blank claim set is UNVERIFIABLE, never "mismatch": asking
+  // "does this resource claim <nothing>?" has no answer, and the old single-arg
+  // form returned "mismatch" for undefined — reading a missing claim as a
+  // refuted one. bindLoadedEntry can produce exactly that (an entry with no
+  // accepts binds to nothing).
+  const claims = (Array.isArray(settledPayTo) ? settledPayTo : [settledPayTo as string]).filter(
+    (p): p is string => typeof p === "string" && p.length > 0,
+  );
+  if (claims.length === 0) return "unverifiable";
   // MUST be undici's own fetch, not the global one. The pinned dispatcher is an
   // undici@8 Agent; Node's global fetch is a DIFFERENT bundled undici (6.x on
   // Node 22, 7.x on Node 25) whose handler interface undici@8 rejects with
@@ -214,7 +227,7 @@ export async function verifyResourceOwnership(
         .filter((p): p is string => typeof p === "string" && p.length > 0),
     );
     if (payTos.size === 0) return "unverifiable";
-    return payTos.has(settledPayTo) ? "match" : "mismatch";
+    return claims.some((c) => payTos.has(c)) ? "match" : "mismatch";
   } catch {
     // Abort (timeout), network error, DNS failure — all degrade to unverifiable.
     return "unverifiable";


### PR DESCRIPTION
Makes true the path `bindLoadedEntry`'s comment always claimed existed.

`verifiedOwner` is never read back from disk (RA-9, deliberately) and Layer 2
fired only on first catalog — false for any loaded entry. So a restored entry
served `ownerVerified: false`, every verdict clamped to `"unknown"`, and
`verified_only=true` returned an **empty catalog**, including over MCP.

## Design, decided and red-teamed before building

**Settle-triggered only — no background prober.** A timer would grant `verified`
on *current domain control* with no contemporaneous payment: the same inference
we refused for automated rotation. Accepted price: zero-traffic resources stay
unverified until their merchant next settles.

**In-memory state only** — never persisted (RA-9 stays closed), never on the wire
(no signal an attacker can force onto a victim's entry).

**`mismatch` (definite, 24h) and `unverifiable` (uncertain, 15min) do not share a
retry floor.**

## A rationale I had to correct

I first claimed the bound-owner gate *removes* the amplification vector. It does
not: under TOFU the bound owner is whoever **settled first**, not whoever
controls the endpoint — which is why Layer 2 exists at all. An attacker who
settles once against a victim's URL becomes its bound owner. The gate is **1:1,
not zero**, so the cooldowns are the real brake — and they're asserted by
**counting outbound fetches**: 50 settlements against a mismatching resource
produce exactly **one**.

## The binding is never handed out

`entry.boundPayTo` **is** the ownership tombstone array — red-teaming proved one
`.push()` reaches the ownership file on disk and survives a restart, i.e. full
takeover-rebinding. So the catalog owns `reverify()` and passes a copy; a test
mutates what the verifier receives and asserts the binding is unmoved. A second
test snapshots the ownership store, runs every verdict across cooldown windows,
and asserts it byte-identical.

## Also fixed, found while building

- `verifyResourceOwnership` returned **`"mismatch"` for `undefined`** — a missing
  claim read as a refuted one. Now takes the bound *set* (the runbook rotation
  appends), matches any in one fetch, and returns `"unverifiable"` when empty.
- `routeTemplate` keys were fetched literally (`GET /quote/:symbol`). Now skipped.
- The empty-binding guard sat *after* the bound-owner gate — dead code that looked
  load-bearing. Reordered.

## Mutation testing

Detected: cooldown removed; `mismatch` given the 15-min floor; bound-owner gate
dropped; real binding array handed out; `await` inside the hook; already-verified
skip removed.

**Not detected, reported rather than papered over:** making the write
unconditional is an *equivalent mutant* — a verified entry is never re-probed, so
that write can only set `false` on an already-`false` entry, which
`setVerifiedOwner` early-returns on.

228 tests, typecheck clean.