### PR TITLE
fix(thresholds): consolidate the shadowed per-payTo budget, fail closed on an unholdable floor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,9 @@ STELLAR_NETWORK=testnet
 # attacker controlling several addresses can rotate them for a fresh bucket each,
 # so this is a convenience throttle, not a hard bound — size the GLOBAL ceiling
 # below as if this control did not exist (see policy.ts, audit D6):
-# SETTLE_RATE_MAX=30
+# SETTLE_RATE_MAX is RETIRED — it was a second per-payTo budget that shadowed
+# SETTLE_PER_PAYTO_MAX, so F12's per-payTo dimension never ran. Setting it now
+# warns and has no effect. Use SETTLE_PER_PAYTO_MAX.
 # SETTLE_RATE_WINDOW_MS=60000
 # Global rolling sponsor-spend ceiling (default 1 XLM = 10,000,000 stroops per
 # 60s) — sized so the ceiling binds BEFORE the per-payTo rate limit (30 settles
@@ -52,7 +54,7 @@ STELLAR_NETWORK=testnet
 #                            bound URL's budget, so spraying N unverified URLs
 #                            yields 10/N each. That ratio is the economic signal.
 # SETTLE_PER_URL_MAX=10
-# SETTLE_PER_PAYTO_MAX=100
+# SETTLE_PER_PAYTO_MAX=50   # half the global capacity; the only per-payTo budget
 # SETTLE_UNBOUND_POOL_MAX=10
 # SPEND_WINDOW_MS=60000
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -395,16 +395,63 @@ the current deployment.
 
 Every value below is a **placeholder**, chosen from reasoning rather than
 production data. They are **log-only on testnet and enforced on pubnet**, so they
-first bite whenever someone sets `STELLAR_NETWORK=pubnet`. Revisit before that.
+first bite whenever someone sets `STELLAR_NETWORK=pubnet`.
+
+**Reviewed 2026-08-10.** Decision for cutover: **ship tight and widen on
+evidence.** Refusals are loud and carry a reason; silent over-permission is not
+observable. Widening is a one-line env change, and the balance guard is the real
+backstop either way. The relationships between these numbers are now asserted in
+`src/config.thresholds.test.ts` rather than only described here.
 
 | Value | Default | Reasoning |
 | --- | --- | --- |
 | `MAX_TX_FEE_STROOPS` | **500,000** | The one value that IS measured. Worst real settlement observed on-chain: 127,808 stroops (a stacked double-policy smart-account payment). 500k is ~3.9x that and 2.5x the documented 200k floor, cutting worst-case drain per settle from 0.2 to 0.05 XLM. |
-| `SPEND_CEILING_STROOPS` | **1 XLM / 60s** | Sized so the GLOBAL ceiling binds before the per-payTo rate limit: 30 settles x 500,000 = 1.5 XLM, so 1 XLM trips first. **This is ~20 settlements/minute across ALL merchants — deliberately tight.** Raise it if legitimate pubnet traffic exceeds that; it will throttle honest load before it throttles an attacker with many addresses. |
-| `SETTLE_RATE_MAX` | **30 / 60s per payTo** | A convenience throttle only. An attacker with several addresses rotates them for a fresh bucket each, so size the global ceiling as if this did not exist (RA-6/D6). |
-| `SPONSOR_SOFT/HARD_FLOOR` | **25 / 10 XLM** | The hard floor MUST exceed one spend window's ceiling, or a stale balance read (up to one interval old) can be drained straight through it. `loadConfig` warns at startup if that invariant is broken. |
+| `SPEND_CEILING_STROOPS` | **5 XLM / 60s** | At the 500,000-stroop worst-case fee that is **100 settlements per window across ALL merchants**. Raising it helps honest throughput and costs a funded attacker nothing — they were never bound by it — so treat it as a sponsor-exposure dial, not a security control. |
+| `SETTLE_PER_PAYTO_MAX` | **50 / 60s per payTo** | Half the global capacity: no single payTo can consume the whole service, while a merchant can run 5 bound URLs at their full rate. **Consolidated from two budgets** — see the defect below. |
+| `SETTLE_PER_URL_MAX` | **10 / 60s per bound URL** | The F12 fairness control: one merchant can no longer starve another. |
+| `SETTLE_UNBOUND_POOL_MAX` | **10 / 60s shared** | Deliberate 1:1 with one bound URL — a spray across many unverified URLs gets what one honest merchant gets. |
+| `SPONSOR_SOFT/HARD_FLOOR` | **25 / 10 XLM** | The hard floor MUST exceed one spend window's ceiling, or a stale balance read (up to one interval old) can be drained straight through it. **Fatal at boot on pubnet**, warning on testnet. |
 | Per-IP rate limit | **60 / min** | `/health` exempt so the Render health check cannot trip. Keyed via `trustProxy: 1` — exactly one hop, because `true` is client-spoofable (RA-4). |
 | Body limit | **32 KiB** | Derived, not picked: largest real settlement envelope measured on-chain is 3,400 base64 chars (~2.5 KB), giving ~9.6x margin. |
+
+### Defect found by the review: F12's per-payTo budget never ran
+
+`SETTLE_RATE_MAX` (30) and `SETTLE_PER_PAYTO_MAX` (100) were **two budgets over
+the same key and the same window**. `policy.ts` checked both in sequence, so the
+tighter one always returned first and the looser one was unreachable: the entire
+per-payTo dimension of F12 — designed, debated, and approved — had no effect on
+the running system.
+
+Consolidated to **one** budget at 50, and `SETTLE_RATE_MAX` is **removed rather
+than aliased**: two names for one dimension is how the shadowing arose. Setting
+it now logs that it is retired, names its replacement, and warns that the
+effective limit is no longer the value you set — a retired knob that still
+parses is the next dead control.
+
+The test that would have caught it did not exist, so it does now
+(`policy.f12.test.ts` — "no tighter budget may shadow it"). Mutation-verified:
+reintroducing a hardcoded 30 fails it. Note the first version of that test did
+**not** catch the shadow, because no existing case drove one payTo past 30
+settles while its budget was higher.
+
+### Pattern: rationale in comments rots because nothing tests it
+
+Three comments in this repo have now asserted something untrue:
+
+1. `bindLoadedEntry` claimed *"Layer 2 re-verifies from the resource on the next
+   settlement"* — that path did not exist until G-1.
+2. This document claimed *"Layer 2 is the control that survives a restart"* — it
+   was exactly backwards; Layer 1 survives, and Layer 2 was what did not.
+3. `config.ts` reasoned about *"1 XLM… ~20 settlements/minute globally"* long
+   after the value had moved to 5 XLM (~100/min), so anyone reading it was
+   reasoning about a system that did not exist.
+
+Each was load-bearing prose that nothing executed. **Standing rule: numeric
+rationale lives with the value AND a test.** `src/config.thresholds.test.ts` is
+the pattern — its `documented rationale` block turns each sentence into an
+assertion ("the ceiling admits 100 per window", "per-payTo is half of global",
+"the hard floor exceeds one window"), so changing a value without revisiting its
+reasoning fails the build instead of quietly making a comment false.
 
 ### Operational lesson: secrets in `argv`
 
@@ -489,7 +536,8 @@ it is per-entity budgeting keyed off the F11 bindings.
 The two spend controls are keyed on different, wrong things:
 
 - `SPEND_CEILING_STROOPS` is **global** — one bucket for the whole facilitator.
-- The per-IP rate limit is **per-IP**, and `SETTLE_RATE_MAX` is **per-payTo**.
+- The per-IP rate limit is **per-IP**, and the settle budget is **per-payTo**
+  (then `SETTLE_RATE_MAX`, since retired — see the shadowing defect above).
 
 A self-dealing attacker spreads across many addresses and many source IPs. Each
 individual bucket stays under its limit, but the **global** ceiling is consumed

--- a/src/catalog.restart-verification.test.ts
+++ b/src/catalog.restart-verification.test.ts
@@ -77,7 +77,7 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogFile: undefined,
   verificationApiUrl: undefined,
-  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
   catalogOwnershipBootstrap: false,
 };

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -49,20 +49,19 @@ describe("loadConfig", () => {
   it("defaults spend-policy limits and honors overrides", () => {
     const def = loadConfig({ SPONSOR_SECRET_KEY: SECRET });
     expect(def.spend).toEqual({
-      rateMax: 30,
       rateWindowMs: 60_000,
       ceilingStroops: 50_000_000,
       perUrlMax: 10,
-      perPayToMax: 100,
+      perPayToMax: 50,
       unboundPoolMax: 10,
       windowMs: 60_000,
     });
     const over = loadConfig({
       SPONSOR_SECRET_KEY: SECRET,
-      SETTLE_RATE_MAX: "10",
+      SETTLE_PER_PAYTO_MAX: "10",
       SPEND_CEILING_STROOPS: "1000000",
     });
-    expect(over.spend.rateMax).toBe(10);
+    expect(over.spend.perPayToMax).toBe(10);
     expect(over.spend.ceilingStroops).toBe(1_000_000);
   });
 
@@ -97,8 +96,10 @@ describe("loadConfig", () => {
   });
 
   it("rejects a non-positive spend limit", () => {
-    expect(() => loadConfig({ SPONSOR_SECRET_KEY: SECRET, SETTLE_RATE_MAX: "0" })).toThrow(
-      /SETTLE_RATE_MAX/,
+    // SETTLE_RATE_MAX is retired (it shadowed SETTLE_PER_PAYTO_MAX); validation
+    // coverage moves to the surviving name rather than disappearing with it.
+    expect(() => loadConfig({ SPONSOR_SECRET_KEY: SECRET, SETTLE_PER_PAYTO_MAX: "0" })).toThrow(
+      /SETTLE_PER_PAYTO_MAX/,
     );
     expect(() => loadConfig({ SPONSOR_SECRET_KEY: SECRET, SPEND_CEILING_STROOPS: "-1" })).toThrow(
       /SPEND_CEILING_STROOPS/,

--- a/src/config.thresholds.test.ts
+++ b/src/config.thresholds.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadConfig } from "./config.js";
+
+const SECRET = "SBJP6HHFTABK2GXVVFAKY6C4B7DDNB5PIEQXKUNL2ZAOBPWFOUOSTLVNMA";
+const base = { SPONSOR_SECRET_KEY: SECRET };
+
+// Threshold review. Two defects and one standing rule.
+//
+// DEFECT 1 — `SETTLE_RATE_MAX` (30) and `SETTLE_PER_PAYTO_MAX` (100) were two
+// budgets on the SAME key over the SAME window, so the tighter one shadowed the
+// looser one and F12's per-payTo dimension never ran. Consolidated to ONE
+// budget at 50 — half the global capacity, so it is a real ratchet rather than
+// an unreachable one, while a merchant can still run 5 URLs at their full rate.
+//
+// DEFECT 3 — a hard floor at or below the spend ceiling means the floor cannot
+// hold: one window can drain through it before the next balance poll. That used
+// to warn and boot anyway.
+//
+// STANDING RULE — numeric rationale must live with the value AND a test.
+// Three comments in this repo have now asserted something untrue (bindLoadedEntry's
+// re-verify claim, the "Layer 2 survives a restart" inversion, and this file's
+// "1 XLM / ~20 settles per minute"). Prose beside a number rots because nothing
+// checks it. The `documented rationale` block below is the antidote: it makes the
+// arithmetic executable, so changing a value without revisiting its reasoning
+// fails the build.
+
+describe("threshold review — one per-payTo budget, one name", () => {
+  it("defaults to a single per-payTo budget of 50", () => {
+    const c = loadConfig(base);
+    expect(c.spend.perPayToMax).toBe(50);
+  });
+
+  it("no second per-payTo budget survives on the config object", () => {
+    // A retired knob that still parses is the next dead control.
+    const c = loadConfig(base);
+    expect(Object.keys(c.spend)).not.toContain("rateMax");
+  });
+
+  it("announces SETTLE_RATE_MAX as retired instead of silently ignoring it", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const c = loadConfig({ ...base, SETTLE_RATE_MAX: "30" });
+    const said = warn.mock.calls.map((x) => String(x[0])).join("\n");
+    expect(said, "a retired var must announce itself").toMatch(/SETTLE_RATE_MAX/);
+    expect(said).toMatch(/retired|ignored|no longer/i);
+    expect(said, "must name the replacement").toMatch(/SETTLE_PER_PAYTO_MAX/);
+    // And it must NOT quietly take effect.
+    expect(c.spend.perPayToMax).toBe(50);
+    warn.mockRestore();
+  });
+
+  it("still honours SETTLE_PER_PAYTO_MAX", () => {
+    expect(loadConfig({ ...base, SETTLE_PER_PAYTO_MAX: "7" }).spend.perPayToMax).toBe(7);
+  });
+});
+
+describe("threshold review — the sponsor floor must be able to hold", () => {
+  const bad = { SPEND_CEILING_STROOPS: "50000000", SPONSOR_HARD_FLOOR_STROOPS: "50000000" };
+
+  it("REFUSES to boot on pubnet when the hard floor cannot hold", () => {
+    expect(() => loadConfig({ ...base, ...bad, STELLAR_NETWORK: "pubnet" })).toThrow(
+      /hard floor|CANNOT HOLD/i,
+    );
+  });
+
+  it("warns but boots on testnet", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const c = loadConfig({ ...base, ...bad, STELLAR_NETWORK: "testnet" });
+    expect(c.spend.ceilingStroops).toBe(50_000_000);
+    expect(warn.mock.calls.map((x) => String(x[0])).join("\n")).toMatch(/CANNOT HOLD/i);
+    warn.mockRestore();
+  });
+
+  it("accepts a floor that does exceed the ceiling, on pubnet", () => {
+    expect(() =>
+      loadConfig({
+        ...base,
+        STELLAR_NETWORK: "pubnet",
+        SPEND_CEILING_STROOPS: "50000000",
+        SPONSOR_HARD_FLOOR_STROOPS: "100000000",
+      }),
+    ).not.toThrow();
+  });
+
+  it("the shipped defaults satisfy the invariant on pubnet", () => {
+    // The defaults must not be a configuration the code refuses to run.
+    expect(() => loadConfig({ ...base, STELLAR_NETWORK: "pubnet" })).not.toThrow();
+  });
+});
+
+describe("threshold review — documented rationale, made executable", () => {
+  // Each assertion below is a sentence that used to live only in a comment.
+  const c = loadConfig(base);
+  const perWindow = Math.floor(c.spend.ceilingStroops / c.maxTransactionFeeStroops);
+
+  it("the global ceiling admits 100 settlements per window", () => {
+    // 5 XLM at a 500,000-stroop worst-case fee. If either value moves, this
+    // fails and the comment claiming "~N settles/min" gets revisited.
+    expect(perWindow).toBe(100);
+  });
+
+  it("per-payTo is exactly half the global capacity (the ratchet)", () => {
+    // The point of the ratchet: no single payTo may consume the whole service,
+    // and it must be REACHABLE — the shadowed 100 never was.
+    expect(c.spend.perPayToMax).toBe(perWindow / 2);
+    expect(c.spend.perPayToMax).toBeLessThan(perWindow);
+  });
+
+  it("a merchant's single URL cannot exhaust their own payTo budget", () => {
+    expect(c.spend.perUrlMax).toBeLessThan(c.spend.perPayToMax);
+  });
+
+  it("the unbound pool equals ONE bound URL's budget (the deliberate 1:1)", () => {
+    // A spray across many unverified URLs gets what one honest merchant gets.
+    expect(c.spend.unboundPoolMax).toBe(c.spend.perUrlMax);
+  });
+
+  it("the hard floor exceeds one full window of spend", () => {
+    expect(c.balance.hardFloorStroops).toBeGreaterThan(c.spend.ceilingStroops);
+  });
+
+  it("the soft floor sits above the hard floor by at least one window", () => {
+    // Otherwise the warning and the refusal arrive at effectively the same time.
+    expect(c.balance.softFloorStroops - c.balance.hardFloorStroops).toBeGreaterThanOrEqual(
+      c.spend.ceilingStroops,
+    );
+  });
+
+  it("the fee ceiling stays above the worst settlement actually measured", () => {
+    // Worst real settle observed from this sponsor's history: 127,808 stroops.
+    expect(c.maxTransactionFeeStroops).toBeGreaterThan(127_808);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,18 +12,25 @@ export interface FacilitatorConfig {
   verificationApiUrl: string | undefined;
   /** Fix 1 sponsorship spend control. Enforced on pubnet, log-only on testnet. */
   spend: {
-    /** Max settlements per payTo per window (default 30). */
-    rateMax: number;
-    /** Per-payTo rate window in ms (default 60_000). */
+    /** Shared window for ALL per-entity budgets below, in ms (default 60_000). */
     rateWindowMs: number;
-    /** Global rolling sponsor-spend ceiling in stroops (default 5 XLM). */
+    /** Global rolling sponsor-spend ceiling in stroops (default 50_000_000 = 5 XLM). */
     ceilingStroops: number;
     /** Global spend window in ms (default 60_000). */
     windowMs: number;
     /** F12: settles/window for one BOUND resource URL (default 10). */
     perUrlMax: number;
-    /** F12: settles/window per payTo (default 100 = global; a ratchet that only
-     * starts binding if the global ceiling is later raised). */
+    /**
+     * F12: settles/window per payTo (default 50). The ONLY per-payTo budget —
+     * `SETTLE_RATE_MAX` used to be a second one on the same key and window, and
+     * being tighter it shadowed this entirely, so this dimension never ran.
+     *
+     * 50 is half the global capacity (see `documented rationale` in
+     * src/config.thresholds.test.ts, which asserts that relationship). It is a
+     * real ratchet — no single payTo can consume the whole service — and it no
+     * longer taxes an honest merchant running several bound URLs, who gets
+     * `perUrlMax` on each up to this total.
+     */
     perPayToMax: number;
     /** F12: settles/window shared by ALL unbound URLs (default 10). */
     unboundPoolMax: number;
@@ -37,9 +44,10 @@ export interface FacilitatorConfig {
   catalogOwnershipBootstrap: boolean;
   /** Fix 3 sponsor balance guard floors, in stroops. */
   balance: {
-    /** Warn below this (default 10 XLM). */
+    /** Warn below this (default 250_000_000 = 25 XLM). */
     softFloorStroops: number;
-    /** Refuse /settle below this (default 2 XLM). */
+    /** Refuse /settle below this (default 100_000_000 = 10 XLM). Must exceed
+     * `ceilingStroops`; enforced at boot (fatal on pubnet). */
     hardFloorStroops: number;
     /** Poll interval in ms (default 60_000). */
     intervalMs: number;
@@ -76,21 +84,37 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
   }
 
   const spend = {
-    rateMax: positiveIntEnv(env.SETTLE_RATE_MAX, 30, "SETTLE_RATE_MAX"),
     rateWindowMs: positiveIntEnv(env.SETTLE_RATE_WINDOW_MS, 60_000, "SETTLE_RATE_WINDOW_MS"),
-    // 1 XLM = 10,000,000 stroops per window. Chosen so the GLOBAL ceiling binds
-    // before the per-payTo rate limit: 30 settles x 500,000 stroops = 1.5 XLM,
-    // so 1 XLM trips first. That is ~20 settles/minute globally across ALL
-    // merchants — deliberately tight, and unreviewed against real pubnet
-    // traffic. See docs/security-audit.md before raising STELLAR_NETWORK=pubnet.
+    // 50,000,000 stroops = 5 XLM per window. At the 500,000-stroop worst-case
+    // fee that is 100 settlements per window across ALL merchants, and
+    // perPayToMax (50) is deliberately half of it.
+    //
+    // These numbers are asserted in src/config.thresholds.test.ts rather than
+    // only described here: an earlier version of this comment still reasoned
+    // about "1 XLM / ~20 settles per minute" long after the value had moved to
+    // 5 XLM, so anyone reading it was reasoning about a system that did not
+    // exist. Unreviewed against real pubnet traffic — see docs/security-audit.md.
     ceilingStroops: positiveIntEnv(env.SPEND_CEILING_STROOPS, 50_000_000, "SPEND_CEILING_STROOPS"),
     windowMs: positiveIntEnv(env.SPEND_WINDOW_MS, 60_000, "SPEND_WINDOW_MS"),
     // F12 per-entity budgets. Keyed on the DURABLE F11 ownership binding, never
     // on verifiedOwner (not persisted; resets on restart).
     perUrlMax: positiveIntEnv(env.SETTLE_PER_URL_MAX, 10, "SETTLE_PER_URL_MAX"),
-    perPayToMax: positiveIntEnv(env.SETTLE_PER_PAYTO_MAX, 100, "SETTLE_PER_PAYTO_MAX"),
+    perPayToMax: positiveIntEnv(env.SETTLE_PER_PAYTO_MAX, 50, "SETTLE_PER_PAYTO_MAX"),
     unboundPoolMax: positiveIntEnv(env.SETTLE_UNBOUND_POOL_MAX, 10, "SETTLE_UNBOUND_POOL_MAX"),
   };
+
+  // A retired knob that still parses is the next dead control: SETTLE_RATE_MAX
+  // was a SECOND per-payTo budget over the same key and window, and being the
+  // tighter of the two it shadowed SETTLE_PER_PAYTO_MAX so that F12's per-payTo
+  // dimension never ran at all. It is gone rather than aliased, because an alias
+  // would leave two names for one dimension — exactly how the shadowing arose.
+  if (env.SETTLE_RATE_MAX !== undefined) {
+    console.warn(
+      `[config] SETTLE_RATE_MAX is RETIRED and is being IGNORED (you set ${env.SETTLE_RATE_MAX}). ` +
+        `It was a second per-payTo budget that shadowed SETTLE_PER_PAYTO_MAX. Use SETTLE_PER_PAYTO_MAX ` +
+        `instead — note the effective per-payTo limit is now that value, not the one you set here.`,
+    );
+  }
 
   // Balance floors. INVARIANT: the hard floor must exceed the maximum XLM a
   // single spend window can drain, because the balance verdict is up to one
@@ -103,12 +127,17 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
     intervalMs: positiveIntEnv(env.SPONSOR_BALANCE_INTERVAL_MS, 60_000, "SPONSOR_BALANCE_INTERVAL_MS"),
   };
   if (balance.hardFloorStroops <= spend.ceilingStroops) {
-    console.warn(
-      `[config] sponsor hard floor (${balance.hardFloorStroops} stroops) does not exceed the spend ceiling ` +
-        `(${spend.ceilingStroops} stroops per window): the floor CANNOT HOLD — a single window can drain the ` +
-        `sponsor through it before the next balance check. Raise SPONSOR_HARD_FLOOR_STROOPS above ` +
-        `SPEND_CEILING_STROOPS, or lower the ceiling.`,
-    );
+    const detail =
+      `sponsor hard floor (${balance.hardFloorStroops} stroops) does not exceed the spend ceiling ` +
+      `(${spend.ceilingStroops} stroops per window): the floor CANNOT HOLD — a single window can drain the ` +
+      `sponsor through it before the next balance check. Raise SPONSOR_HARD_FLOOR_STROOPS above ` +
+      `SPEND_CEILING_STROOPS, or lower the ceiling.`;
+    // Fail CLOSED on pubnet, matching the spend policy itself. This is the one
+    // misconfiguration that silently disables the sponsor's last protection, and
+    // boot is the cheapest place to catch it — a warning on a free-tier instance
+    // nobody is tailing is not a control.
+    if (network === "stellar:pubnet") throw new Error(`[config] ${detail}`);
+    console.warn(`[config] ${detail}`);
   }
 
   // Announce the escape hatch on EVERY boot while it is set, not only when it

--- a/src/hardening.test.ts
+++ b/src/hardening.test.ts
@@ -19,7 +19,7 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogFile: undefined,
   verificationApiUrl: undefined,
-  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
   catalogOwnershipBootstrap: false,
 };

--- a/src/policy.f12.test.ts
+++ b/src/policy.f12.test.ts
@@ -8,7 +8,6 @@ import { SpendPolicy, type SettleIdentity } from "./policy.js";
 
 const base = {
   network: "stellar:pubnet" as const,
-  rateMax: 1_000_000, // isolate the F12 dimensions
   rateWindowMs: 60_000,
   spendCeilingStroops: 1_000_000_000,
   spendWindowMs: 60_000,
@@ -52,6 +51,24 @@ describe("F12 — per-bound-URL budget", () => {
       }
     }
     // 30 settles for one payTo, all allowed — per-payTo (100) never bound.
+  });
+});
+
+describe("F12 — the per-payTo budget is the ONLY one on that key", () => {
+  it("admits exactly perPayToMax settles for one payTo — no tighter budget may shadow it", () => {
+    // This is the test that did not exist while the defect did. `SETTLE_RATE_MAX`
+    // (30) and `SETTLE_PER_PAYTO_MAX` (100) were two budgets over the same key
+    // and window; the tighter silently won, so the per-payTo dimension never ran
+    // and nothing failed. Any second per-payTo limit below perPayToMax breaks
+    // this test.
+    const c = clock();
+    const p = new SpendPolicy({ ...base, perPayToMax: 50, perUrlMax: 1_000 }, c.now);
+    let allowed = 0;
+    for (let i = 0; i < 60; i++) {
+      if (p.checkSettle(bound(`https://m/${i}`, "GMERCH")).allowed) allowed++;
+    }
+    expect(allowed, "a shadowing budget would cut this below perPayToMax").toBe(50);
+    expect(p.checkSettle(bound("https://m/x", "GMERCH")).reason).toBe("rate_limited_payto");
   });
 });
 

--- a/src/policy.test.ts
+++ b/src/policy.test.ts
@@ -11,13 +11,12 @@ import { SpendPolicy } from "./policy.js";
 // Enforcement is fail-OPEN on testnet (log-only) and fail-CLOSED on pubnet.
 
 const cfg = {
-  rateMax: 3,
   rateWindowMs: 1000,
   spendCeilingStroops: 600, // 3 settles * 200 estimate = 600 exactly at ceiling
   spendWindowMs: 1000,
   perSettleEstimateStroops: 200,
   perUrlMax: 1000,
-  perPayToMax: 1000,
+  perPayToMax: 3, // was `rateMax: 3` — the effective per-payTo budget
   unboundPoolMax: 1000,
 };
 
@@ -73,7 +72,7 @@ describe("SpendPolicy — pubnet (fail-closed)", () => {
     const clock = nowFn();
     // Give rate headroom so the SPEND ceiling is what trips.
     const p = new SpendPolicy(
-      { network: "stellar:pubnet", ...cfg, rateMax: 100 },
+      { network: "stellar:pubnet", ...cfg, perPayToMax: 100 },
       clock.now,
     );
     // 3 settles * 200 = 600 == ceiling; the 4th exceeds it.
@@ -88,7 +87,7 @@ describe("SpendPolicy — bounded state (audit D10)", () => {
   it("evicts elapsed per-payTo buckets instead of growing forever", () => {
     const clock = nowFn();
     const p = new SpendPolicy(
-      { network: "stellar:pubnet", ...cfg, rateMax: 1000, spendCeilingStroops: 1e12 },
+      { network: "stellar:pubnet", ...cfg, perPayToMax: 1000, spendCeilingStroops: 1e12 },
       clock.now,
     );
     // 500 distinct payTos (the rotation vector) all settle at t0.

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -53,7 +53,6 @@ export interface SettleIdentity {
 export interface SpendPolicyConfig {
   network: "stellar:testnet" | "stellar:pubnet";
   /** Max settlements per payTo per window (default 30). */
-  rateMax: number;
   /** Per-payTo rate window in ms (default 60_000). */
   rateWindowMs: number;
   /** Global rolling sponsor-spend ceiling in stroops (default 5 XLM = 50_000_000). */
@@ -150,7 +149,9 @@ export class SpendPolicy {
    */
   private evaluate(id: SettleIdentity, t: number): SettleRejectReason | undefined {
     const payToRecent = prune(this.perPayTo.get(id.payTo) ?? [], t - this.cfg.rateWindowMs);
-    if (payToRecent.length >= this.cfg.rateMax) return "rate_limited_payto";
+    // ONE per-payTo budget. There used to be two (rateMax and perPayToMax) over
+    // the same key and window, so the tighter silently shadowed the looser and
+    // F12's per-payTo dimension never ran.
     if (payToRecent.length >= this.cfg.perPayToMax) return "rate_limited_payto";
 
     if (id.bound && id.resourceUrl) {
@@ -247,7 +248,6 @@ function prune(times: number[], cutoff: number): number[] {
 /** Build a policy from config values, applying defaults. */
 export function createSpendPolicy(input: {
   network: "stellar:testnet" | "stellar:pubnet";
-  rateMax?: number;
   rateWindowMs?: number;
   spendCeilingStroops?: number;
   spendWindowMs?: number;
@@ -258,13 +258,12 @@ export function createSpendPolicy(input: {
 }): SpendPolicy {
   return new SpendPolicy({
     network: input.network,
-    rateMax: input.rateMax ?? 30,
     rateWindowMs: input.rateWindowMs ?? 60_000,
     spendCeilingStroops: input.spendCeilingStroops ?? 50_000_000, // 5 XLM
     spendWindowMs: input.spendWindowMs ?? 60_000,
     perSettleEstimateStroops: input.perSettleEstimateStroops,
     perUrlMax: input.perUrlMax ?? 10,
-    perPayToMax: input.perPayToMax ?? 100,
+    perPayToMax: input.perPayToMax ?? 50,
     unboundPoolMax: input.unboundPoolMax ?? 10,
   });
 }

--- a/src/server.policykey.test.ts
+++ b/src/server.policykey.test.ts
@@ -29,7 +29,7 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogFile: undefined,
   verificationApiUrl: undefined,
-  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
   catalogOwnershipBootstrap: false,
 };

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -18,7 +18,7 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogFile: undefined,
   verificationApiUrl: undefined,
-  spend: { rateMax: 30, rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
   balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
   catalogOwnershipBootstrap: false,
 };
@@ -151,7 +151,7 @@ describe("Fix 1 — spend policy on /settle", () => {
   it("does not let unsubmittable payloads exhaust the spend ceiling", async () => {
     const policy = createSpendPolicy({
       network: "stellar:pubnet",
-      rateMax: 1000,
+      perPayToMax: 1000,
       rateWindowMs: 60_000,
       spendCeilingStroops: 2_000_000, // room for ~4 settles at the estimate
       spendWindowMs: 60_000,
@@ -192,7 +192,7 @@ describe("Fix 1 — spend policy on /settle", () => {
   it("normalizes non-string and oversized payTo into the shared bucket", async () => {
     const policy = createSpendPolicy({
       network: "stellar:pubnet",
-      rateMax: 2,
+      perPayToMax: 2,
       rateWindowMs: 60_000,
       spendCeilingStroops: 1_000_000_000,
       spendWindowMs: 60_000,
@@ -229,7 +229,7 @@ describe("Fix 1 — spend policy on /settle", () => {
   it("refunds the reservation when facilitator.settle throws (zero-cost outage)", async () => {
     const policy = createSpendPolicy({
       network: "stellar:pubnet",
-      rateMax: 1000,
+      perPayToMax: 1000,
       rateWindowMs: 60_000,
       spendCeilingStroops: 1_500_000, // 3 slots at 500k
       spendWindowMs: 60_000,
@@ -281,7 +281,7 @@ describe("Fix 1 — spend policy on /settle", () => {
     // it is the durable evidence that the "<no-payto>" bucket is being enforced.
     const policy = createSpendPolicy({
       network: "stellar:pubnet",
-      rateMax: 2,
+      perPayToMax: 2,
       rateWindowMs: 60_000,
       spendCeilingStroops: 1_000_000_000, // ample: isolate the rate dimension
       spendWindowMs: 60_000,
@@ -311,7 +311,7 @@ describe("Fix 1 — spend policy on /settle", () => {
     // Pubnet policy, rateMax 2 so the 3rd settle from one payTo is refused.
     const policy = createSpendPolicy({
       network: "stellar:pubnet",
-      rateMax: 2,
+      perPayToMax: 2,
       rateWindowMs: 60_000,
       spendCeilingStroops: 50_000_000,
       spendWindowMs: 60_000,
@@ -338,7 +338,7 @@ describe("Fix 1 — spend policy on /settle", () => {
   it("never returns 503 on testnet (fail-open), even past the limit", async () => {
     const policy = createSpendPolicy({
       network: "stellar:testnet",
-      rateMax: 1,
+      perPayToMax: 1,
       rateWindowMs: 60_000,
       spendCeilingStroops: 1,
       spendWindowMs: 60_000,

--- a/src/server.ts
+++ b/src/server.ts
@@ -311,7 +311,6 @@ if (isDirectRun) {
   // simulated fee is not exposed on the verify response — over-counting fails safe.
   const policy = createSpendPolicy({
     network: config.network,
-    rateMax: config.spend.rateMax,
     rateWindowMs: config.spend.rateWindowMs,
     spendCeilingStroops: config.spend.ceilingStroops,
     spendWindowMs: config.spend.windowMs,


### PR DESCRIPTION
Threshold review before pubnet. The numbers mattered less than what the review found.

## Defect 1 — F12's per-payTo budget never ran

`SETTLE_RATE_MAX` (30) and `SETTLE_PER_PAYTO_MAX` (100) were **two budgets over
the same key and the same window**. `policy.ts` checked both in sequence, so the
tighter always returned first and the looser was unreachable — the per-payTo
dimension we designed, debated and approved had **no effect on the running
system**.

Consolidated to one budget at **50** (half the global capacity): a real ratchet,
no multi-URL merchant tax. `SETTLE_RATE_MAX` is **removed, not aliased** — two
names for one dimension is how the shadowing arose — and setting it now warns
that it is retired and that the effective limit is not the value you set.

**The test that would have caught this did not exist.** It does now — and its
first version *also* failed to catch the shadow, because no existing case drove
one payTo past 30 settles while its budget was higher. Tightened until
reintroducing a hardcoded 30 fails it.

## Defect 2 — an unholdable sponsor floor only warned

A hard floor at or below the ceiling means one window can drain through it before
the next poll. `loadConfig` detected it and booted anyway. Now **fatal on pubnet,
warning on testnet**, matching how the spend policy already fails open/closed.

## Defect 3 — comments contradicted the shipped values

Balance floors documented as 10/2 XLM; actually 25/10. The ceiling comment
reasoned about "1 XLM / ~20 settlements per minute" long after the value moved to
5 XLM (~100/min). `.env.example` was right — the inline reasoning had rotted,
which is worse, because that is what the next reader uses.

## Standing rule

Third comment in this repo to assert something untrue, after `bindLoadedEntry`
and the Layer 2 inversion. **Numeric rationale now lives with the value and a
test:** `config.thresholds.test.ts` turns each sentence into an assertion, so
changing a value without revisiting its reasoning fails the build.

Cutover: **ship tight, widen on evidence.** Refusals are loud; silent
over-permission is not observable.

244 tests, typecheck clean. Mutation-verified on all four guards.