### PR TITLE
fix: restore the threshold sweep lost in #6's squash, and correct F4-ts + two stale status claims

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -20,9 +20,12 @@ Status vocabulary:
 | **deferred** | Understood, deliberately not fixed yet, with a stated trigger. |
 | **external** | Blocked on a system outside this repo. |
 
-> **All of this is fixed on `security/pubnet-blockers` only.** `main` — which the
-> hosted Render instance runs — carries the full unmitigated surface. See
-> [What `main` is running today](#what-main-is-running-today).
+> **As of 2026-08-10 every fix below is merged to `main`** (PRs #1–#6). This banner
+> previously said the opposite — that `main` carried the full unmitigated surface —
+> and stayed that way across six merges. It is called out rather than quietly
+> corrected, because it is a fourth instance of the rot pattern described below,
+> this time inside the document that describes it. Merge status is not deployment
+> status: see [What `main` is running today](#what-main-is-running-today).
 
 ---
 
@@ -515,7 +518,7 @@ change.
 | **G-7** | Bootstrap-derived bindings are seeded in memory but not written | **open** — undercuts the one-boot bootstrap procedure; runbook §2 tells the operator to verify the file before removing the flag. |
 | **G-8** | Tombstone cap is a one-way freeze with no reset path | **open** — deliberate fail-closed, but the absence of a reset needs an operator procedure (runbook §3 says escalate). |
 | **G-9** | `verified_only` silently ignored when no trust resolver is injected | **open** — not reachable in production; `server.ts` always constructs one. |
-| **F4-ts** | Verification API has no per-record timestamp | **external** — see the dependency note below. Consumer side already forward-compatible. |
+| **F4-ts** | Verification API is not deployed at all; the worker-service has never run hosted | **external, blocked on wallet-repo M5** — not a missing field. Chain: badge ← worker deployed ← `ATTESTOR_SECRET_KEY` ← M5 multisig attestor. |
 | **RA-14r** | RFC 6052 non-`/96` NAT64 offsets | deferred; not reachable in the current deployment. |
 | **F5** | Settle/confirm reconciliation | deferred; integration-level. |
 | **F8** | Unvalidated operator-supplied URLs | deferred; operator-supplied, not attacker-supplied. |
@@ -943,45 +946,71 @@ the floor cannot hold against the ceiling.
   security-*positive*: configuring it makes that API a trust root. It is a
   product gap, not a security one.
 
-### The `F4-ts` dependency, stated precisely
+### F4-ts — blocked on a service that has never run hosted, not on a field
 
-What this repo needs is small and entirely on the producer side: **each record in
-the verification history response must carry a timestamp.** The consumer is
+Corrected 2026-08-10 with information from the wallet repo. The earlier framing
+here — "waiting on one timestamp field" — understated it by a long way.
+
+The verification API is the wallet repo's **verification-service plus
+worker-service**. The worker polls the shared database, rebuilds contracts in a
+sandboxed container, compares wasm hashes, and mirrors verdicts on chain. **It is
+deployed nowhere:** no deploy manifest references it, and `ATTESTOR_SECRET_KEY` is
+absent from `.env.example` and every manifest. Verification jobs therefore sit at
+`status='submitted'` indefinitely and no attestation is ever written.
+
+So the missing timestamp is not the blocker. There is no record to timestamp.
+
+**The dependency chain, in order:**
+
+1. This facilitator can serve a real `"verified"` only if the verification API
+   returns a verdict.
+2. A verdict exists only if the **worker-service is deployed** and processing the
+   queue.
+3. The worker can attest only if **`ATTESTOR_SECRET_KEY` is provisioned**.
+4. That single-key attestor is itself a **deferred mainnet blocker (wallet repo
+   M5)**, awaiting a multisig design.
+
+**Therefore: the earliest this facilitator can serve a genuine `"verified"` badge
+is after M5 lands in the wallet repo.** Everything downstream of that — including
+the per-record timestamp — is a smaller problem that only becomes relevant once a
+verdict can exist at all.
+
+**Consumer requirements for whoever designs the M5 multisig attestor.** Two
+properties this repo needs are decided *during* that design, not bolted on after,
+so they are recorded here to be read as requirements rather than discovered later:
+
+| Requirement | Why this repo needs it |
+| --- | --- |
+| **The verdict endpoint must be authenticated** | It is currently unauthenticated. This facilitator reads it on the discovery path and clamps every served badge by it, so anyone who can answer as that endpoint can mint `"verified"` for any asset. |
+| **Configuring it makes that API a trust root** | The moment `VERIFICATION_API_URL` is set, this service's badge is only as trustworthy as that endpoint and its key custody. A single-key attestor makes the badge a single-key claim — which is exactly what M5 exists to fix, and why this repo will not enable it before then. |
+
+Third, smaller, and unchanged: **each record needs a timestamp.** The consumer is
 already forward-compatible — `src/trust.ts` accepts `timestamp`, `verifiedAt`, or
-`createdAt`, as an ISO string or an epoch number, and sorts by it **only when
-every record carries one**, falling back to array order otherwise.
+`createdAt`, ISO string or epoch number, and sorts by it **only when every record
+carries one**, falling back to array order otherwise. Until then `records[0]` is
+assumed newest, an ordering the API never promised.
 
-So the ask is one field, any of three names, on every record. Until then
-`records[0]` is assumed newest, which is an ordering the API never promised.
-
-Two further preconditions before enabling it at all, independent of the
-timestamp: the endpoint is **unauthenticated**, and pointing at it makes it a
-**trust root** for every badge served. Neither is fixed by the timestamp.
-
-**Owner: unknown from this repo.** Nothing here records where the verification
-API is hosted or which codebase implements it — `VERIFICATION_API_URL` is
-deliberately unset and appears in no deploy config. If it is a service that is
-not deployed anywhere, then `F4-ts` is not "waiting on a field", it is waiting on
-a service, and should be tracked as such rather than as an external ticket.
+**Status: external, and correctly blocked.** Leaving `VERIFICATION_API_URL` unset
+is the right posture, not a gap to close. Every verdict degrading to `"unknown"`
+is the honest answer while no verdict can be produced.
 
 ## What `main` is running today
 
-`main` is the deployed branch. **None of the above is fixed there.** Verified by
-reading `main`, not by inference:
+**Merged, as of 2026-08-10:** every finding above marked closed-by-test or
+closed-by-doc is on `main`. 257 tests, typecheck clean, CI gating each PR.
 
-| Control | `main` |
-| --- | --- |
-| Resource-URL ownership binding | **none** — `upsertFromPayment` keys on `discovered.resourceUrl` with no ownership check |
-| Rate limiting / helmet / CORS / body limit | **none** — Fastify default 1 MiB body, no plugins |
-| Catalog load validation | **blind-cast** `JSON.parse(...) as ...` |
-| Ingest/load sanitization | **none** — `description` and `extensions` stored verbatim |
-| Trust resolver timeout / size cap / validation | **none** |
-| `MAX_TX_FEE_STROOPS` | **2,000,000**, with **no spend accounting** |
-| CI gating deploy | **none** |
+**Deployed: unconfirmed from this repo.** `render.yaml` sets no `autoDeploy` key,
+so Render's default (deploy on push to the connected branch) applies — but which
+branch is connected, and whether a deploy has run since these merges, is dashboard
+state this repository cannot observe. Confirm there before treating the hosted
+instance as carrying any of the above.
 
-Test files: 5 on `main` vs 14 on the branch.
+Two things stay true of the hosted instance regardless of deploy status, both
+deliberate:
 
-`VERIFICATION_API_URL` is **not configured** on the deployed instance (absent from
-`render.yaml`), so the trust layer serves `"unknown"` for every result — the
-documented degrade mode, not a fault, but worth knowing when reading discovery
-output.
+- `plan: free` has **no persistent disk**, so the catalog and its ownership
+  bindings do not survive a restart or the ~15-minute idle sleep. That is pubnet
+  blocker **B1**; on testnet it is the documented behaviour.
+- `VERIFICATION_API_URL` is **not configured**, so every trust verdict is
+  `"unknown"` and `verified_only` returns empty. Per F4-ts this is not a
+  configuration oversight and cannot be fixed by setting the variable.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -509,12 +509,16 @@ change.
 
 | ID | Finding | Why |
 | --- | --- | --- |
-| **G-2** | A bound URL has no `payTo` rotation path | **open** — manual operator procedure exists and must be documented; the automated fix trades away F11's takeover resistance. |
-| **G-4** | `recordSettlement` lets anyone inflate a victim entry's trust stats | **open** — highest-value of the review findings; no `payTo` check, and it runs after a rejected upsert. |
-| **G-5**–**G-8** | Load-path squat, unbounded load, unpersisted bootstrap bindings, one-way tombstone cap | **open** — triaged below, none fixed. |
-| **F4-ts** | Verification API has no per-record timestamp | **external** — needs the API to emit one; consumer side is already forward-compatible. |
+| **G-2** | A bound URL has no `payTo` rotation path | **open** — manual operator procedure documented (runbook §1); the automated fix trades away F11's takeover resistance and is deliberately not built. |
+| **G-5** | Empty-`accepts` entry loads with no tombstone and is then unclaimable forever | **open** — reachable only by someone who can already write `CATALOG_FILE`. |
+| **G-6** | `MAX_ENTRIES` not enforced on the load path | **open** — a large `CATALOG_FILE` is an unbounded startup memory load. |
+| **G-7** | Bootstrap-derived bindings are seeded in memory but not written | **open** — undercuts the one-boot bootstrap procedure; runbook §2 tells the operator to verify the file before removing the flag. |
+| **G-8** | Tombstone cap is a one-way freeze with no reset path | **open** — deliberate fail-closed, but the absence of a reset needs an operator procedure (runbook §3 says escalate). |
+| **G-9** | `verified_only` silently ignored when no trust resolver is injected | **open** — not reachable in production; `server.ts` always constructs one. |
+| **F4-ts** | Verification API has no per-record timestamp | **external** — see the dependency note below. Consumer side already forward-compatible. |
 | **RA-14r** | RFC 6052 non-`/96` NAT64 offsets | deferred; not reachable in the current deployment. |
 | **F5** | Settle/confirm reconciliation | deferred; integration-level. |
+| **F8** | Unvalidated operator-supplied URLs | deferred; operator-supplied, not attacker-supplied. |
 
 Closed since this table was first written (kept here so the history is not lost):
 
@@ -523,6 +527,9 @@ Closed since this table was first written (kept here so the history is not lost)
 | **F12** | Spend accounting was global while rate limiting was per-IP | **closed-by-test** — per-entity budgets keyed off the F11 bindings. See the control-scope table for what this does and does not achieve. |
 | **F3** | Non-atomic `save()`, unbounded entries/`accepts` | **closed-by-test** — atomic writes, bounds, and ownership tombstones so eviction cannot drop a binding. |
 | **F10-op** | `examples/.env.recording` held a live testnet `AGENT_SECRET` | **closed** — signer removed on-chain and confirmed `null`, local copies deleted. See the `argv` lesson above. |
+| **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement. |
+| **G-3** | Spend policy keyed on the raw URL while the catalog keys on the canonical one | **closed-by-test** — found by red-teaming the F12 change before it merged. |
+| **G-4** | Settlement stats writable by anyone, against any entry | **closed-by-test** — gated on the bound owner; cross-entity forgery now impossible. |
 | **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement; settle-triggered only, cooldowns asserted in outbound fetches. |
 
 ---
@@ -897,6 +904,65 @@ Listed so they are not lost; none is fixed on this branch.
 | **G-9** | `if (!trust) return response` in both discovery routes returns unfiltered results *before* filtering, so `verified_only=true` is silently ignored when no resolver is injected. | **Not reachable in production** — `src/server.ts` always constructs a resolver, and an unset `VERIFICATION_API_URL` yields one that answers `"unknown"` rather than `undefined`. Test-only shape; worth a guard so it stays that way. |
 
 ---
+
+## Pubnet go / no-go
+
+**Status: NO-GO on two hard blockers.** Neither is a code defect; both are
+deployment facts. Everything the audit itself raised is closed or triaged.
+
+### Blockers — must be true before `STELLAR_NETWORK=pubnet`
+
+**B1 — No persistent disk.** `plan: free` has none, and the service sleeps after
+~15 minutes idle. Ownership bindings (F11 Layer 1) therefore reset on every cold
+start, so after each wake the first settler re-binds each URL. Layer 2 still
+fires and a hijacker's entry stays unverified and invisible to `verified_only`,
+but the catalog will advertise their `payTo` until corrected. **Attach a disk and
+follow runbook §2 before pubnet.** Note this is also what activates G-5 and G-7.
+
+**B2 — Sponsor key and funding.** The configured key is a dedicated *testnet*
+account. Pubnet needs its own funded key, set via the dashboard (`sync: false`),
+holding meaningfully more than `SPONSOR_HARD_FLOOR_STROOPS` (10 XLM) — the floor
+is a refusal point, not a budget. `loadConfig` now refuses to boot on pubnet if
+the floor cannot hold against the ceiling.
+
+### Conditions — true at cutover, watched afterwards
+
+- **Thresholds are unvalidated against real traffic.** Reviewed 2026-08-10 and
+  shipped tight by decision; every refusal carries a reason and should be read as
+  a signal, not a bug. Widening is a one-line env change.
+- **G-2 has no in-band rotation.** Runbook §1 must be in the operator's hands
+  *before* any merchant is onboarded on a disk-backed deployment — a merchant
+  who rotates cannot fix it themselves, and the symptom is invisible to them.
+- **`CATALOG_OWNERSHIP_BOOTSTRAP` must be removed after the migration boot**, and
+  its warning fires on every boot while set.
+
+### Explicitly NOT blockers
+
+- **`VERIFICATION_API_URL` unset.** Every asset verdict degrades to `"unknown"`,
+  so `verified_only` returns empty. That is the honest default and is
+  security-*positive*: configuring it makes that API a trust root. It is a
+  product gap, not a security one.
+
+### The `F4-ts` dependency, stated precisely
+
+What this repo needs is small and entirely on the producer side: **each record in
+the verification history response must carry a timestamp.** The consumer is
+already forward-compatible — `src/trust.ts` accepts `timestamp`, `verifiedAt`, or
+`createdAt`, as an ISO string or an epoch number, and sorts by it **only when
+every record carries one**, falling back to array order otherwise.
+
+So the ask is one field, any of three names, on every record. Until then
+`records[0]` is assumed newest, which is an ordering the API never promised.
+
+Two further preconditions before enabling it at all, independent of the
+timestamp: the endpoint is **unauthenticated**, and pointing at it makes it a
+**trust root** for every badge served. Neither is fixed by the timestamp.
+
+**Owner: unknown from this repo.** Nothing here records where the verification
+API is hosted or which codebase implements it — `VERIFICATION_API_URL` is
+deliberately unset and appears in no deploy config. If it is a service that is
+not deployed anywhere, then `F4-ts` is not "waiting on a field", it is waiting on
+a service, and should be tracked as such rather than as an external ticket.
 
 ## What `main` is running today
 

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -151,6 +151,26 @@ function sanitizeType(value: unknown): "http" | "mcp" | undefined {
  * outright rather than "cleaned", so the load path is not weaker than the wire. */
 const PRINTABLE_ASCII = /^[\x20-\x7e]+$/;
 
+/** Documented limits, exported so their RATIONALE is assertable — see the
+ * "module constants" block in src/config.thresholds.test.ts. Read-only. */
+export const CATALOG_LIMITS = Object.freeze({
+  maxEntries: MAX_ENTRIES,
+  maxAccepts: MAX_ACCEPTS,
+  maxTombstones: MAX_TOMBSTONES,
+  maxTrackedPayers: MAX_TRACKED_PAYERS,
+  persistDebounceMs: PERSIST_DEBOUNCE_MS,
+  reverifyCooldownMismatchMs: REVERIFY_COOLDOWN_MISMATCH_MS,
+  reverifyCooldownUnverifiableMs: REVERIFY_COOLDOWN_UNVERIFIABLE_MS,
+  maxDescriptionLen: MAX_DESCRIPTION_LEN,
+  maxServiceNameLen: MAX_SERVICE_NAME_LEN,
+  maxTagLen: MAX_TAG_LEN,
+  maxTags: MAX_TAGS,
+  maxMimeTypeLen: MAX_MIME_TYPE_LEN,
+  defaultLimit: DEFAULT_LIMIT,
+  maxLimit: MAX_LIMIT,
+});
+
+
 /**
  * Strip control/bidi chars, clamp, and require printable ASCII. Returns
  * undefined (field dropped) rather than a mangled string when the input isn't

--- a/src/config.thresholds.test.ts
+++ b/src/config.thresholds.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import { CATALOG_LIMITS } from "./catalog.js";
 import { loadConfig } from "./config.js";
+import { OWNERSHIP_LIMITS } from "./ownership.js";
+import { SERVER_LIMITS } from "./server.js";
+import { TRUST_LIMITS } from "./trust.js";
 
 const SECRET = "SBJP6HHFTABK2GXVVFAKY6C4B7DDNB5PIEQXKUNL2ZAOBPWFOUOSTLVNMA";
 const base = { SPONSOR_SECRET_KEY: SECRET };
@@ -128,5 +132,115 @@ describe("threshold review — documented rationale, made executable", () => {
   it("the fee ceiling stays above the worst settlement actually measured", () => {
     // Worst real settle observed from this sponsor's history: 127,808 stroops.
     expect(c.maxTransactionFeeStroops).toBeGreaterThan(127_808);
+  });
+});
+
+describe("threshold review — the retired knob announces itself like an escape hatch", () => {
+  it("fires on EVERY boot, not once per process", () => {
+    // Same standard as CATALOG_OWNERSHIP_BOOTSTRAP: a warning that fires once
+    // and then goes quiet is indistinguishable from a fixed problem. loadConfig
+    // must hold no "already warned" state.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    for (let i = 0; i < 3; i++) loadConfig({ ...base, SETTLE_RATE_MAX: "30" });
+    const hits = warn.mock.calls.filter((x) => /SETTLE_RATE_MAX/.test(String(x[0]))).length;
+    expect(hits, "every boot must re-announce it").toBe(3);
+    warn.mockRestore();
+  });
+
+  it("names the value you set AND the effective limit, not a generic deprecation", () => {
+    // An operator with this in a Render dashboard should read "you set 30, the
+    // effective limit is 50" and be able to act without reading the source.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loadConfig({ ...base, SETTLE_RATE_MAX: "30" });
+    const said = warn.mock.calls.map((x) => String(x[0])).join("\n");
+    expect(said, "must quote the value they set").toMatch(/\b30\b/);
+    expect(said, "must state the EFFECTIVE limit numerically").toMatch(/\b50\b/);
+    expect(said, "must name the surviving knob").toMatch(/SETTLE_PER_PAYTO_MAX/);
+    warn.mockRestore();
+  });
+});
+
+// Sweep of every numeric rationale stated in prose elsewhere in the repo. The
+// three false comments we found were the ones somebody happened to check; these
+// are the rest, pulled in so nothing is load-bearing prose alone.
+describe("documented rationale — module constants", () => {
+  it("the body limit is DERIVED from the largest real envelope, with ~9.6x margin", () => {
+    // docs/security-audit.md states "3,400 base64 chars (~2.5 KB), ~9.6x margin".
+    const ratio = SERVER_LIMITS.defaultBodyLimitBytes / SERVER_LIMITS.measuredMaxEnvelopeChars;
+    expect(ratio).toBeGreaterThan(9);
+    expect(ratio).toBeLessThan(11);
+  });
+
+  it("tombstones outlive entries: the tombstone cap MUST exceed the entry cap", () => {
+    // A tombstone deliberately survives its evicted entry (F3/F11). If the caps
+    // were equal, eviction-driven rebinding would freeze bindings before the
+    // entry cap was ever reached — the freeze is one-way (G-8), so this is a
+    // real invariant, not a preference.
+    expect(CATALOG_LIMITS.maxTombstones).toBeGreaterThan(CATALOG_LIMITS.maxEntries);
+  });
+
+  it("a DEFINITE re-verify answer is parked far longer than an UNCERTAIN one", () => {
+    // mismatch (24h) vs unverifiable (15min). They must not converge: retrying a
+    // definite denial buys nothing but outbound traffic, and it is the brake on
+    // the 1:1 amplification the bound-owner gate does not remove (G-1).
+    expect(CATALOG_LIMITS.reverifyCooldownMismatchMs).toBeGreaterThanOrEqual(
+      CATALOG_LIMITS.reverifyCooldownUnverifiableMs * 24,
+    );
+  });
+
+  it("the ownership fetch is bounded well inside its own retry floor", () => {
+    // A probe must finish long before the next one is due, or attempts overlap.
+    expect(OWNERSHIP_LIMITS.fetchTimeoutMs).toBeLessThan(
+      CATALOG_LIMITS.reverifyCooldownUnverifiableMs / 10,
+    );
+  });
+
+  it("the 402 response cap is generous for a header-borne challenge", () => {
+    // The verdict comes entirely from the PAYMENT-REQUIRED header; the body is
+    // cancelled unread. 64 KB must still clear a large multi-accepts challenge.
+    expect(OWNERSHIP_LIMITS.maxResponseBytes).toBeGreaterThanOrEqual(64 * 1024);
+  });
+
+  it("an asset verdict goes stale far sooner than an ownership verdict", () => {
+    // They answer different questions about different parties: the asset cache
+    // (5 min) tracks upstream re-verification, the ownership cooldowns bound
+    // outbound probes. If the asset TTL ever exceeded them, a revoked asset
+    // would outlive a refuted owner.
+    expect(TRUST_LIMITS.defaultCacheTtlMs).toBeLessThan(
+      CATALOG_LIMITS.reverifyCooldownMismatchMs,
+    );
+  });
+
+  it("the persistence debounce stays well under one spend window", () => {
+    // Debounced writes must not let a crash lose a whole window of settlements.
+    expect(CATALOG_LIMITS.persistDebounceMs).toBeLessThan(loadConfig(base).spend.windowMs / 100);
+  });
+
+  it("per-resource accepts stay far below the entry cap", () => {
+    // MAX_ACCEPTS bounds a single entry's fan-out; it must not approach the
+    // catalog-wide cap or one resource could dominate the served payload.
+    expect(CATALOG_LIMITS.maxAccepts).toBeLessThan(CATALOG_LIMITS.maxEntries / 100);
+  });
+
+  it("a discovery page cannot request the whole catalog", () => {
+    expect(CATALOG_LIMITS.defaultLimit).toBeLessThanOrEqual(CATALOG_LIMITS.maxLimit);
+    expect(CATALOG_LIMITS.maxLimit).toBeLessThan(CATALOG_LIMITS.maxEntries);
+  });
+
+  it("free-text caps stay ordered: description > serviceName > tag", () => {
+    // These bound what reaches an LLM agent's context (F1). The ordering is the
+    // claim: a description is prose, a serviceName is a label, a tag is a word.
+    expect(CATALOG_LIMITS.maxDescriptionLen).toBeGreaterThan(CATALOG_LIMITS.maxServiceNameLen);
+    expect(CATALOG_LIMITS.maxServiceNameLen).toBeGreaterThan(CATALOG_LIMITS.maxTagLen);
+    expect(CATALOG_LIMITS.maxTags * CATALOG_LIMITS.maxTagLen).toBeLessThan(
+      CATALOG_LIMITS.maxDescriptionLen * 2,
+    );
+  });
+
+  it("the per-IP HTTP limit is not looser than the global settle capacity", () => {
+    // Otherwise one IP could saturate the sponsor's whole window on its own.
+    const c = loadConfig(base);
+    const globalPerWindow = Math.floor(c.spend.ceilingStroops / c.maxTransactionFeeStroops);
+    expect(SERVER_LIMITS.defaultRateMaxPerMinute).toBeLessThanOrEqual(globalPerWindow);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,9 +110,11 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
   // would leave two names for one dimension — exactly how the shadowing arose.
   if (env.SETTLE_RATE_MAX !== undefined) {
     console.warn(
-      `[config] SETTLE_RATE_MAX is RETIRED and is being IGNORED (you set ${env.SETTLE_RATE_MAX}). ` +
-        `It was a second per-payTo budget that shadowed SETTLE_PER_PAYTO_MAX. Use SETTLE_PER_PAYTO_MAX ` +
-        `instead — note the effective per-payTo limit is now that value, not the one you set here.`,
+      `[config] SETTLE_RATE_MAX is RETIRED and is being IGNORED. You set ${env.SETTLE_RATE_MAX}; ` +
+        `the EFFECTIVE per-payTo limit is ${spend.perPayToMax} settles per ${spend.rateWindowMs}ms. ` +
+        `It was a second per-payTo budget over the same key and window, and being tighter it shadowed ` +
+        `SETTLE_PER_PAYTO_MAX so that budget never ran. Set SETTLE_PER_PAYTO_MAX=${env.SETTLE_RATE_MAX} ` +
+        `if you intended the old value, then remove SETTLE_RATE_MAX.`,
     );
   }
 

--- a/src/ownership.ts
+++ b/src/ownership.ts
@@ -24,6 +24,14 @@ const FETCH_TIMEOUT_MS = 3_000;
 /** A 402 challenge is tiny (the payload rides in headers); 64 KB is generous. */
 const MAX_RESPONSE_BYTES = 64 * 1024;
 
+/** Documented limits, exported so their RATIONALE is assertable — see the
+ * "module constants" block in src/config.thresholds.test.ts. Read-only: this is
+ * not a runtime knob. */
+export const OWNERSHIP_LIMITS = Object.freeze({
+  fetchTimeoutMs: FETCH_TIMEOUT_MS,
+  maxResponseBytes: MAX_RESPONSE_BYTES,
+});
+
 export type OwnershipVerdict = "match" | "mismatch" | "unverifiable";
 
 interface LookupResult {

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,6 +50,16 @@ export interface HardeningOptions {
 const DEFAULT_RATE_MAX = 60;
 const DEFAULT_BODY_LIMIT = 32 * 1024;
 
+/** Documented limits, exported so their RATIONALE is assertable — see
+ * src/config.thresholds.test.ts. Read-only. */
+export const SERVER_LIMITS = Object.freeze({
+  defaultRateMaxPerMinute: DEFAULT_RATE_MAX,
+  defaultBodyLimitBytes: DEFAULT_BODY_LIMIT,
+  /** Largest real settlement envelope measured on-chain, in base64 chars. The
+   * body limit is derived from this, not picked. */
+  measuredMaxEnvelopeChars: 3_400,
+});
+
 export async function buildServer(
   facilitator: ReturnType<typeof buildFacilitator>,
   catalog: BazaarCatalog,

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -72,6 +72,16 @@ function strictMin(verdicts: TrustVerification[]): TrustVerification {
   return verdicts.reduce((worst, v) => (RANK[v] > RANK[worst] ? v : worst), "verified" as TrustVerification);
 }
 
+/** Documented limits, exported so their RATIONALE is assertable — see
+ * src/config.thresholds.test.ts. Read-only. */
+export const TRUST_LIMITS = Object.freeze({
+  /** How long an asset verdict is reused. A verdict can change when a contract
+   * is re-verified upstream, so this bounds how stale a served badge can be;
+   * it is deliberately far shorter than the ownership re-verify cooldowns,
+   * which answer a different question about a different party. */
+  defaultCacheTtlMs: 5 * 60_000,
+});
+
 export interface TrustResolver {
   /** Verification verdict for one contract id (cached). */
   assetStatus(contractId: string): Promise<TrustVerification>;
@@ -190,7 +200,7 @@ function recordTimestamp(r: HistoryRecord): number | undefined {
 }
 
 export function createTrustResolver(options: TrustResolverOptions): TrustResolver {
-  const cacheTtlMs = options.cacheTtlMs ?? 5 * 60_000;
+  const cacheTtlMs = options.cacheTtlMs ?? TRUST_LIMITS.defaultCacheTtlMs;
   const timeoutMs = options.timeoutMs ?? 3_000;
   const maxResponseBytes = options.maxResponseBytes ?? 64 * 1024;
   const fetchFn = options.fetchFn ?? fetch;


### PR DESCRIPTION
## Why this exists

`#6` squash-merged against a stale head: `origin/chore/threshold-review` pointed
at all three commits, but only the first landed on `main`. Verified by test count
(244 on `main` vs 257 on the branch — exactly the 13 tests the sweep added).

Both commits are restored here by cherry-pick, unchanged.

## What was lost and is now back

- The retired-var warning naming the **effective limit** ("you set 30, the
  effective limit is 50"), plus the every-boot assertion.
- The full sweep of numeric rationale — `CATALOG_LIMITS` / `OWNERSHIP_LIMITS` /
  `SERVER_LIMITS` / `TRUST_LIMITS` as frozen read-only objects, with assertions
  for the body-limit derivation, the tombstones-outlive-entries invariant, the
  definite-vs-uncertain cooldown ratio, and six more.
- The pubnet go/no-go section and the current finding inventory.

## New in this PR

**F4-ts corrected.** It is not waiting on a timestamp field — the verification
API's worker-service **has never run hosted**. No manifest references it,
`ATTESTOR_SECRET_KEY` is absent everywhere, so jobs sit at `status='submitted'`
and no attestation is written. There is no record to timestamp.

Chain: badge ← verdict ← worker deployed ← `ATTESTOR_SECRET_KEY` ← **wallet-repo
M5 multisig attestor** (itself a deferred mainnet blocker). Earliest a genuine
`"verified"` can be served here is after M5.

So the two preconditions get decided *during* M5's design. Recorded as consumer
requirements: the endpoint must be **authenticated**, and configuring it makes
that API a **trust root** — a single-key attestor makes the badge a single-key
claim.

**Two stale status claims fixed.** The header banner still said `main` "carries
the full unmitigated surface" — untrue since PR #1, and it survived six merges.
Called out rather than quietly corrected: fourth instance of the rot pattern,
inside the document describing it. The replacement separates merge status from
deployment status, which the old text conflated.

257 tests, typecheck clean.