### PR TITLE
docs: correct the README against the shipped code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,17 @@ settle HTTP-402 payments for any seller, and let agents find payable resources
 without hardcoded integrations.
 
 > **Status: working on testnet, pre-production.** The full loop is live-proven
-> (see `docs/decisions.md` for transaction hashes): a policy-governed Soroban
-> smart account paid a Bazaar-discoverable resource, this facilitator verified
-> and settled it on-chain, and the resource became searchable automatically.
-> Mainnet use is gated on the security review (BUILD-PLAN Phase 3).
+> (see [`docs/decisions.md`](./docs/decisions.md) for transaction hashes): a
+> policy-governed Soroban smart account paid a Bazaar-discoverable resource, this
+> facilitator verified and settled it on-chain, and the resource became
+> searchable automatically.
+>
+> **The pre-mainnet security review is complete** — see
+> [`docs/security-audit.md`](./docs/security-audit.md) for every finding, its
+> status, and the go/no-go. Mainnet is now gated on two *deployment* facts rather
+> than on code: a persistent disk (the free tier has none, so catalog ownership
+> bindings do not survive a restart) and a funded pubnet sponsor account. Running
+> it is documented in [`docs/operator-runbook.md`](./docs/operator-runbook.md).
 
 ## What it does
 
@@ -17,15 +24,18 @@ without hardcoded integrations.
 | `POST /verify` | Verify a payment by re-simulation on Soroban RPC (runs the payer's `__check_auth`, including any on-chain spending policy) |
 | `POST /settle` | Submit the payment on-chain, sponsoring the network fee — buyers hold only the payment asset, no XLM |
 | `GET /supported` | Advertise scheme/network/extensions/signers to sellers |
-| `GET /discovery/resources` | List cataloged x402 resources (filters: `type`, `payTo`, `scheme`, `network`, `extensions`; paginated) |
-| `GET /discovery/search` | Natural-language search over the catalog (`query`, cursor-paginated) |
-| `GET /health` | Liveness |
+| `GET /discovery/resources` | List cataloged x402 resources (filters: `type`, `payTo`, `scheme`, `network`, `extensions`, `verified_only`; `limit`/`offset`) |
+| `GET /discovery/search` | Keyword search over the catalog — tokenized and relevance-scored, not semantic (`query`, same filters, cursor-paginated) |
+| `GET /health` | Liveness, plus `catalogFrozen` when the catalog has stopped accepting new bindings |
 
-**Smart accounts welcome.** Policy-governed smart-account payments cost ~140k
+**Smart accounts welcome.** Policy-governed smart-account payments cost ~130k
 stroops of simulation fee (the policy contract runs inside `__check_auth`);
 hosted facilitators defaulting to a 50k ceiling reject them. This facilitator
-defaults to 2,000,000 (`MAX_TX_FEE_STROOPS`) — the exact bug that motivated
-this project, fixed from day one.
+defaults to **500,000** (`MAX_TX_FEE_STROOPS`) — the exact bug that motivated
+this project, fixed from day one. That default is sized from measured on-chain
+data, not guessed: the worst real settlement observed on this sponsor's history
+charged **127,808** stroops, so 500,000 clears it by ~3.9x while bounding
+worst-case sponsor drain per settle at 0.05 XLM.
 
 **Bazaar catalogs itself.** When a payment settles and its payload carries the
 official [`bazaar` discovery extension](https://www.npmjs.com/package/@x402/extensions),
@@ -33,6 +43,41 @@ the resource is upserted into the catalog automatically — no registration
 step. Catalog-on-settle keeps unpaid spam out; route templates and service
 metadata are validated/sanitized by the official extractor (catalog-poisoning
 guard).
+
+**Discovery responses carry a `trust` block.** Alongside the standard resource
+fields, each entry reports `settlements`, `uniquePayers` and `lastSettled`, plus
+`verification` / `acceptsVerification` / `ownerVerified`. Two things to know
+before you build on it:
+
+- **`observedSettlements` and `statsSource` disclose provenance.** `settlements`
+  may include a base loaded from `CATALOG_FILE`, which has no independent source
+  of truth; `observedSettlements` counts only what this process witnessed. If you
+  need a number you can rely on, use that one.
+- **Verification verdicts read `"unknown"` unless `VERIFICATION_API_URL` is set**,
+  and `?verified_only=true` then returns an empty list. That is the honest
+  default, not a fault — see F4-ts in the audit for why it is deliberately
+  unconfigured.
+
+## Integration limits
+
+Worth knowing before you point a client at it:
+
+| Limit | Value |
+| --- | --- |
+| Rate limit | 60 requests/min per IP (`/health` exempt) |
+| Request body | 32 KiB, applied to every route |
+| `/settle` refusals | `503 settlement_refused` with a `reason` — `sponsor_balance_low`, `spend_ceiling`, `rate_limited_payto`, `rate_limited_url`, `unbound_pool_exhausted` |
+
+Refusals are deliberately loud and carry a reason. Spend controls are **log-only
+on testnet and enforced on pubnet**, so a testnet client will see them in logs
+before it ever sees a 503.
+
+**Resource-URL ownership is trust-on-first-use.** The first settlement for a
+canonical URL (`origin + pathname`) binds it to that payment's `payTo`; later
+settlements with a different `payTo` are refused from the catalog, though the
+payment itself still settles. If you are a seller, be the first to settle for
+your own URL. Changing that address afterwards currently needs an operator —
+see runbook §1.
 
 ## Run
 


### PR DESCRIPTION
Prompted by one stale number, expanded to every factual claim in the file.

## Wrong

- **`MAX_TX_FEE_STROOPS` "defaults to 2,000,000"** — it is **500,000**, lowered
  during F2 and sized from measured data. This is the one a developer could
  actually have relied on. Now states the basis: worst real settlement observed
  was 127,808 stroops.
- **"~140k stroops"** for smart-account simulation — ~130k is what the code
  reasons from.
- **"Natural-language search"** — `/discovery/search` is tokenized keyword
  scoring with relevance ranking. Not semantic.
- **"Mainnet gated on the security review"** — the review is done. Mainnet is
  gated on two *deployment* facts: a persistent disk and a funded pubnet sponsor.

## Incomplete

- `/discovery/*` filters omitted `verified_only`; search omitted that it takes
  the same filters as list.
- `/health` also reports `catalogFrozen`.
- **The `trust` block was undocumented entirely** — including why
  `observedSettlements` / `statsSource` exist (`settlements` may include an
  unverifiable base from `CATALOG_FILE`).
- No mention that verdicts read `"unknown"` and `verified_only` returns empty
  while `VERIFICATION_API_URL` is unset.

## Added — things I hit blind

Integration limits (60/min per IP, 32 KiB body, the five `503` reasons),
testnet-log-only vs pubnet-enforced, and **trust-on-first-use URL ownership**:
the first settlement for a canonical URL binds it, and changing it later needs an
operator. Sellers should settle for their own URL first.

## On method

I verified the claims I *added*, not just the ones I removed — and caught myself
writing that the 32 KiB body limit was per-route when it is global. Also checked
the `/health` rate-limit exemption, all five reason strings, and that every
relative link resolves.

257 tests, typecheck clean (no source changes).