### PR TITLE
feat: keep-alive ping, G-7 fix, and the durable-catalog milestone (disk rejected)

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,81 @@
+## Keep-alive ping for the hosted testnet facilitator.
+##
+## WHY THIS EXISTS — it is not a latency tweak.
+##
+## Render spins a Free web service down after 15 minutes without inbound
+## traffic. Spinning down DESTROYS the container, and with it the ephemeral
+## filesystem holding CATALOG_FILE and its companion ownership store. So every
+## idle period wipes the Bazaar catalog: a seller's listing disappears and the
+## trust-on-first-use URL bindings reset, reopening the claim race.
+##
+## Keeping the instance awake is therefore the *emptiness* fix for what a
+## developer actually experiences, not merely a cold-start fix. Between deploys,
+## the catalog survives.
+##
+## THE BUDGET, and why this is not 24/7 by default.
+##
+## Render grants 750 Free instance hours per WORKSPACE per calendar month —
+## workspace, not service. Exhausting it SUSPENDS EVERY Free web service in the
+## workspace until the 1st of the next month.
+##
+##   24/7 in a 31-day month = 744 h  ->  6 h of margin (<1%)
+##   20 h/day               = 620 h  ->  130 h of margin
+##
+## 24/7 fits arithmetically and only if this is the ONLY Free service in the
+## workspace. A second Free service, or one added later by anyone, blows the
+## budget and takes this one down with it. So the default below is 20 h/day.
+##
+## Outside the window the service sleeps as before: the first request takes
+## ~1 minute and the catalog comes back EMPTY, repopulating from the next
+## settled payment per resource.
+##
+## TO RUN 24/7 instead: change the cron to "*/10 * * * *" and first confirm this
+## is the only Free service in the workspace.
+##
+## RELIABILITY CAVEAT: GitHub's scheduled workflows are best-effort and can be
+## delayed well past their cron time under load. A delay beyond 15 minutes lets
+## the service sleep anyway. If the catalog needs to be reliably warm, use an
+## external uptime pinger (5-minute interval) instead of, or alongside, this.
+## GitHub also disables scheduled workflows on repositories with no activity for
+## 60 days.
+
+name: keepalive
+
+on:
+  schedule:
+    # Every 10 minutes, 05:00–23:59 UTC (20 h/day). See the budget note above.
+    - cron: "*/10 5-23 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: keepalive
+  cancel-in-progress: true
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ping /health
+        env:
+          # /health is exempt from the per-IP rate limit, so this cannot throttle
+          # real traffic no matter how often it runs.
+          URL: https://vellar-facilitator.onrender.com/health
+        run: |
+          set -uo pipefail
+          # A cold start takes ~1 minute, so allow for it rather than failing the
+          # very request that is doing the waking up.
+          code=$(curl -sS -o /tmp/body -w '%{http_code}' --max-time 120 --retry 2 --retry-delay 15 "$URL" || echo 000)
+          echo "HTTP $code"
+          cat /tmp/body || true
+          if [ "$code" != "200" ]; then
+            echo "::warning::keepalive ping did not return 200 (got $code) — the service may be suspended or down"
+            exit 0   # never fail the workflow: a red X here is noise, not signal
+          fi
+          # Surface a frozen catalog, which is invisible from the outside otherwise.
+          if grep -q 'catalogFrozen' /tmp/body; then
+            echo "::warning::/health reports catalogFrozen — see docs/operator-runbook.md §2 and §3"
+          fi

--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ Refusals are deliberately loud and carry a reason. Spend controls are **log-only
 on testnet and enforced on pubnet**, so a testnet client will see them in logs
 before it ever sees a 503.
 
+**On the hosted instance, the catalog is only as durable as the container.**
+Render spins a free service down after 15 minutes without traffic, and spin-down
+destroys the filesystem holding the catalog — so an idle period empties it and
+resets URL ownership bindings. A keep-alive keeps it warm between deploys
+(`.github/workflows/keepalive.yml`); durable storage is scoped in
+[`docs/milestone-durable-catalog.md`](./docs/milestone-durable-catalog.md). Your
+listing returns automatically on your next settled payment either way.
+
 **Resource-URL ownership is trust-on-first-use.** The first settlement for a
 canonical URL (`origin + pathname`) binds it to that payment's `payTo`; later
 settlements with a different `payTo` are refused from the catalog, though the

--- a/docs/milestone-durable-catalog.md
+++ b/docs/milestone-durable-catalog.md
@@ -1,0 +1,192 @@
+# Milestone — durable catalog (Turso)
+
+**Status: design only. No code.** This scopes the work; it does not authorise it.
+
+Supersedes the "attach a persistent disk" plan, which was rejected: a disk costs
+money *and* activates three dormant findings (G-5, G-6, G-7) that a real store
+closes instead. Paying to acquire bugs is the wrong trade.
+
+---
+
+## Why a store at all
+
+Two separate causes make the hosted catalog look empty, and they need different
+fixes:
+
+| Cause | Effect | Fixed by |
+| --- | --- | --- |
+| Ephemeral filesystem | Nothing survives a container replacement | **This milestone** |
+| Idle spin-down every 15 min | Container replacement happens constantly | Keep-alive (shipped) |
+
+The keep-alive is not merely a latency fix: spin-down *destroys the container*,
+so keeping the instance awake is what preserves the catalog between deploys. But
+it cannot survive a deploy, a crash, or an exhausted instance-hour budget. Only a
+store outside the container does that.
+
+## Why Turso specifically
+
+- **Non-expiring free tier.** Render's free Postgres is deleted at 30 days, which
+  would silently destroy every ownership binding on a timer. Disqualifying for
+  anything a developer is told to build on.
+- **Real transactions.** SQLite/libSQL semantics are closest to what the code
+  already assumes, so the least new reasoning.
+- **Cloudflare KV is rejected outright:** it is eventually consistent, and a
+  stale read lets a second claimant bind an already-bound URL. That breaks F11.
+- Upstash Redis is workable but lacks cross-key transactions, so the ownership
+  store's atomicity would have to be hand-rolled.
+
+## How much of the code this touches
+
+The class comment at `src/catalog.ts` claims the store sits behind `BazaarCatalog`
+"so a database can replace the file without touching routes/ingestion." **Tested
+against the tree: half true.**
+
+**True.** Filesystem access is confined to five call sites — `writeFileAtomic`
+from `saveOwnership` and `flush`, and three `readFileSync` in `load` /
+`loadOwnership`. Reads (`list`, `search`, `isBound`, `isVerifiedOwner`) never
+touch storage; they read the in-memory maps. Routes and ingestion are genuinely
+unaffected.
+
+**False.** The public API is **synchronous** — `upsertFromPayment`,
+`recordSettlement`, `setVerifiedOwner`, `flush`. Two consequences the comment does
+not admit, and the first is a security problem.
+
+### The sync-to-async problem — do not re-create G-7
+
+`saveOwnership()` is synchronous **deliberately**. `bindOwnership` writes the
+binding to disk *before* returning `true`, so a binding is durable before anything
+relies on it. G-7 was precisely the bug where a binding lived in memory and never
+reached disk, and the migration silently persisted nothing.
+
+An async write reintroduces exactly that window: bound in memory, not yet durable,
+crash, binding gone — and the URL is claimable again by whoever settles next.
+
+**The design must preserve durable-before-relied-upon.** Concretely:
+
+1. **`bindOwnership` becomes `async` and the caller awaits it.** The only caller is
+   `upsertFromPayment`, which runs inside `onAfterSettle` — already async, already
+   after on-chain settlement. Awaiting there delays the settle *response* by one
+   round-trip; it cannot delay or fail the payment.
+2. **A binding that has not been persisted must not be treated as established.**
+   On write failure, `bindOwnership` returns `false` and the upsert is refused —
+   the same fail-closed path already used at the tombstone cap. It must not
+   optimistically populate the in-memory map and hope the write lands.
+3. **Entry writes stay debounced and fire-and-forget.** Catalog entries are
+   reconstructible from settlement traffic; ownership is not. That asymmetry is
+   the existing design and it survives the move — only the ownership path needs
+   the strict guarantee.
+4. **A test must pin it:** simulate a write failure, assert the binding is *not*
+   established and the upsert is refused. Mutation-verify by making the write
+   fire-and-forget and confirming the test fails. Without that, this is G-7 with
+   a network in the middle.
+
+### Async construction
+
+`load()` runs in the constructor. It becomes `await BazaarCatalog.create(...)`.
+Contained: `buildServer` is already async and there is one production call site.
+
+## The availability coupling — and whether fail-closed is still right
+
+Today an unreadable ownership store means the catalog **fails closed**: empty,
+frozen, `catalogFrozen: "ownership-unreadable"` on `/health`. That default was
+chosen when the store was a local file, where unreadable means *tampered or
+deleted* — a security event.
+
+With a network store, unreadable also means *the vendor is having a bad ten
+minutes*, which is not a security event. Same signal, two very different causes —
+the same ambiguity that runbook §1 exists to handle for rotations.
+
+**Recommendation: keep fail-closed, and it is not a close call.** Serving a
+catalog whose ownership bindings could not be loaded means serving entries with
+no enforceable ownership — every URL open to first-writer claim, which is F11
+with extra steps. A transient outage would silently reopen every binding in the
+catalog at once. Discovery going quiet is recoverable; discovery serving
+attacker-claimable entries is not.
+
+What should change is the **blast radius and the diagnosis**, not the default:
+
+- **Distinguish the causes in the signal.** `catalogFrozen` should say whether the
+  store was unreachable (retryable) or returned something invalid (investigate).
+  Today both read `"ownership-unreadable"`.
+- **Retry with backoff before freezing.** A file read fails once and stays failed;
+  a network read deserves a few attempts. Freeze only after they are exhausted.
+- **Settlement must remain unaffected.** It already is — the catalog is downstream
+  of settlement, and a frozen catalog refuses cataloging, not payments. That
+  property must survive the change and is worth an explicit test.
+
+## Findings: what closes, what changes shape, what does not move
+
+**Closed outright:**
+
+| Finding | Why |
+| --- | --- |
+| **G-5** — empty-`accepts` entry loads with no tombstone and becomes permanently unclaimable | Bindings load from their own table instead of being derived from `accepts[0]`. The derivation that creates G-5 stops existing. |
+| **G-6** — `MAX_ENTRIES` not enforced on the load path | `ORDER BY last_updated DESC LIMIT n` in the load query. |
+| **G-7** — bootstrap-derived bindings not persisted | The bootstrap hatch exists only because an ownership *file* can be absent while a catalog *file* is present. One store, one schema — the ambiguity, the hatch, and `CATALOG_OWNERSHIP_BOOTSTRAP` all disappear. |
+
+**Also deleted:** `writeFileAtomic` (temp + fsync + rename) and the debounce
+bookkeeping around it, replaced by transactions.
+
+**Gained, which the file store cannot do:** catalog and ownership update in **one
+transaction**, making the split-brain state that F3, G-7 and the whole fail-closed
+dance exist to manage **unrepresentable** rather than merely handled.
+
+**Changes shape:**
+
+| Finding | Before | After |
+| --- | --- | --- |
+| Crafted-`CATALOG_FILE` tombstone clearing (accepted risk under F6/RA-13) | Anyone with filesystem access deletes a file | Anyone with **database credentials** runs a `DELETE`. Higher bar and auditable, but credentials now live in the environment and are a new secret to manage. Not eliminated — relocated. |
+| RA-13 — persisted settlement stats are unverifiable | Unverifiable rows in a file | Unverifiable rows in a table. `observedSettlements` / `statsSource` remain the honest signal. **No improvement.** |
+
+**Untouched — these are policy, not storage:**
+
+- **G-2** — no in-band `payTo` rotation. Still operator-mediated (runbook §1), and
+  the procedure changes from editing a file to updating a row.
+- **G-8** — the tombstone cap is a one-way freeze with no reset path. A store makes
+  the cap *reachable* (tombstones now accumulate instead of resetting on restart),
+  so this becomes **more** relevant, not less. Worth fixing in the same batch.
+
+**New trust boundary:** a network dependency on the write path, credentials in the
+environment, and vendor availability coupled to catalog availability. That is a
+real cost, stated plainly — it is the price of durability without a disk.
+
+## Migration from the current file store
+
+**Almost certainly nothing to migrate, and that is the cheapest path.**
+
+The hosted instance has no persistent disk, so there is no durable catalog to
+carry over — it is empty after every spin-down. A local development instance may
+have a `CATALOG_FILE`, but its contents are test data.
+
+**Recommended: start empty.** The catalog is self-repopulating — every resource
+returns on its next settled payment, and ownership re-binds at that point. A
+one-time importer would exist solely to preserve data that regenerates itself,
+while carrying the exact risk the bootstrap hatch warns about: trusting a file to
+name each resource's owner.
+
+If a genuine catalog ever does need importing, it is the bootstrap problem again
+and needs the same explicit opt-in, the same "verify the owners before they become
+durable" step, and the same removal step. Do not build it speculatively.
+
+## Prerequisite: the displacement variant
+
+The displacement variant — letting a *verified* claim displace an *unverified*
+binding — was scoped as a prerequisite of attaching a disk. **Its urgency drops
+under this plan and then returns.**
+
+- **Now, with no durable store:** a squat clears on the next spin-down, so the
+  exposure is small and self-healing.
+- **After this milestone:** bindings become durable, so a squat becomes permanent
+  until an operator intervenes — exactly the condition that made it a prerequisite
+  of the disk.
+
+**It is therefore a prerequisite of this milestone for the same reason, and should
+land before the cutover, not after.**
+
+## Effort
+
+Several days, not one. The persistence rewrite itself is contained (five call
+sites), but the sync-to-async conversion, the durable-before-relied-upon
+guarantee and its failure-injection test, the retry-then-freeze logic, and the
+schema all carry real design. Treat it as the "DB-backed catalog" milestone
+already named in `technical-doc.md`, not as a stopgap.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -201,24 +201,57 @@ Determine which one you are in:
 - **Did the ownership file exist and then stop existing, with no deploy?** Treat
   it as tampering and investigate before continuing.
 
-### Steps — migration case only
+### Steps — first boot on a NEW disk (nothing to migrate)
 
-1. Set `CATALOG_OWNERSHIP_BOOTSTRAP=1` in the environment (dashboard, not
-   `render.yaml` — it is deliberately not declared there).
-2. Start the service **once**. It will derive each URL's owner from the first
-   `accepts` entry in the catalog file and warn loudly on every boot while set.
-3. **Remove the variable** and restart.
+If the disk is brand new and there was never a catalog file, there is nothing to
+do: with **neither** file present the loader treats it as a genuinely fresh start
+and the catalog comes up empty and unfrozen. You will not see the symptom above.
 
-Understand what you just granted: bootstrap trusts the catalog file to name each
-resource's owner. It grants **no more trust than that file already had** — but if
-that file was tampered with, you have now made the tampering durable. Only do
-this when you know where the file came from.
+### Steps — migration case (a catalog file exists, no ownership file)
 
-> Known gap (**G-7**): the bindings derived during a bootstrap run are seeded in
-> memory but are not immediately written to the ownership file. After the
-> bootstrap boot, confirm `<CATALOG_FILE>.ownership` actually exists and contains
-> a row per entry before removing the variable. If it does not, keep the variable
-> set for one more boot rather than restarting without it.
+This is the state the **first boot after attaching a disk** produces if a catalog
+file was restored alongside it.
+
+1. **Confirm where the catalog file came from.** Bootstrap trusts it to name each
+   resource's owner. It grants **no more trust than that file already had** — but
+   if it was tampered with, this makes the tampering durable. If you cannot
+   account for the file, delete it and start empty instead; the catalog rebuilds
+   from settlements.
+
+2. Set `CATALOG_OWNERSHIP_BOOTSTRAP=1` **in the Render dashboard**, not in
+   `render.yaml` — it is deliberately not declared there so it cannot be left on
+   by a merge.
+
+3. **Start the service once.** It warns on every boot while the flag is set, and
+   now also logs how many bindings it wrote:
+
+   ```
+   [catalog] wrote N ownership binding(s) derived during load to <path>.ownership
+   ```
+
+4. **Verify the file exists and is complete before going further:**
+
+   ```sh
+   cat /var/data/bazaar-catalog.json.ownership | python3 -m json.tool | head
+   ```
+
+   It must contain one `{resource, boundPayTo}` row per catalog entry. Spot-check
+   that a `boundPayTo` matches the address that resource actually bills to — this
+   is your only chance to catch a wrong owner before it becomes durable.
+
+5. **Remove `CATALOG_OWNERSHIP_BOOTSTRAP` and restart.** Do not skip this. While
+   it is set, the fail-closed protection against a missing or deleted ownership
+   store is DISABLED, so a later deletion would silently re-derive bindings from
+   whatever the catalog file says at that moment.
+
+6. **Confirm the removal took**: `/health` must report no `catalogFrozen`, and
+   the boot logs must no longer contain `CATALOG_OWNERSHIP_BOOTSTRAP`.
+
+> **G-7 (fixed).** Bindings derived during load used to be seeded in memory and
+> never written, so the migration silently persisted nothing and the *next* boot
+> failed closed again. They are now flushed once after load, and step 3's log
+> line is the confirmation. If you are running a build from before that fix, keep
+> the flag set for one more boot rather than restarting without it.
 
 ### Verify
 

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,11 @@
 # testnet account, never a mainnet key. Set it in the Render dashboard
 # (sync:false keeps it out of git).
 #
-# Free-tier caveat: the service sleeps after ~15 min idle (~1 min cold start).
+# Free-tier caveat: Render spins the service down after 15 min without inbound
+# traffic. Spin-down DESTROYS the container, so this is not merely a ~1 min cold
+# start — it wipes CATALOG_FILE and its ownership store, emptying the Bazaar
+# catalog and resetting every URL ownership binding. The keep-alive workflow
+# (.github/workflows/keepalive.yml) is what prevents that between deploys.
 # Fine for a testnet demo; upgrade the plan before any uptime commitment.
 
 services:
@@ -15,6 +19,36 @@ services:
     buildCommand: "npm install --omit=dev && npm install -g tsx"
     startCommand: "tsx src/server.ts"
     healthCheckPath: /health
+    # ── ATTACHING A PERSISTENT DISK — NOT THE CHOSEN PLAN ────────────────────
+    # Kept for reference only. A disk was REJECTED in favour of an external store
+    # (docs/milestone-durable-catalog.md): a disk costs money AND activates three
+    # findings that are dormant on an ephemeral filesystem (G-5, G-6, G-7), which
+    # a real store closes instead. Read that document before enabling any of this.
+    #
+    # If you do enable it: uncomment BOTH the `plan: starter` above (replacing `plan: free`) and the
+    # `disk:` block below, together. They are one change: Render only offers
+    # disks on paid instance types, so a disk block under `plan: free` fails to
+    # deploy.
+    #
+    # THIS STARTS BILLING on the next deploy. It is left commented so that
+    # merging this file is never itself the thing that starts charging.
+    #
+    # It fixes TWO independent causes of the empty catalog:
+    #   1. no disk  — nothing survives any restart (the disk fixes this);
+    #   2. idle-sleep — the free tier stops after ~15 min idle, so restarts
+    #      happen constantly (moving off `free` fixes this).
+    # A disk alone would not stop the sleeping, and not sleeping alone would not
+    # survive a deploy. You need both, which is why they are one change here.
+    #
+    # BEFORE the first boot with a disk, read docs/operator-runbook.md §2. The
+    # first boot finds a catalog file with no companion ownership store and
+    # FAILS CLOSED by design; the one-boot CATALOG_OWNERSHIP_BOOTSTRAP procedure
+    # is how you migrate, and it has a removal step that must not be skipped.
+    #
+    # disk:
+    #   name: vellar-facilitator-data
+    #   mountPath: /var/data      # must match the dirname of CATALOG_FILE below
+    #   sizeGB: 1                 # the catalog is small; 1 GB is ample
     envVars:
       - key: NODE_VERSION
         value: "22"

--- a/src/catalog.bootstrap-persist.test.ts
+++ b/src/catalog.bootstrap-persist.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { afterEach, describe, expect, it } from "vitest";
+import { BazaarCatalog, ownershipPathFor } from "./catalog.js";
+
+// G-7 — bootstrap-derived ownership bindings were never written to disk.
+//
+// bindLoadedEntry seeds `this.ownership` in memory but, unlike bindOwnership,
+// never calls saveOwnership(). So the one-boot CATALOG_OWNERSHIP_BOOTSTRAP
+// migration appeared to succeed and then persisted nothing: the next restart
+// found a catalog file with no ownership file again and FAILED CLOSED, serving
+// an empty catalog.
+//
+// This is a prerequisite of attaching a persistent disk, because the migration
+// is the first thing that runs on that deploy — and a silent failure here is
+// only discovered later, when a squat sticks.
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "vellar-boot-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+const OWNER_A = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+const OWNER_B = "GBQ3VANQZ6X3ZVGFTQJZ2MZ4KOCPZ5EGWSVYT7OPTQJ4M7VXMKQ3OQXD";
+const ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+const URL_A = "https://api.a.example/quote";
+const URL_B = "https://api.b.example/rates";
+
+function entry(resource: string, payTo: string) {
+  return {
+    resource: {
+      resource,
+      type: "http",
+      x402Version: 2,
+      lastUpdated: "2026-08-01T00:00:00.000Z",
+      accepts: [{ scheme: "exact", network: "stellar:testnet", asset: ASSET, amount: "1", payTo }],
+    },
+    stats: { settlements: 3, payers: ["CP1"], observed: 0 },
+  };
+}
+
+/** A catalog file with NO companion ownership file — exactly the state the
+ * first disk-backed boot produces. */
+function legacyCatalog(): string {
+  const path = join(tmpDir(), "bazaar-catalog.json");
+  writeFileSync(path, JSON.stringify([entry(URL_A, OWNER_A), entry(URL_B, OWNER_B)]));
+  return path;
+}
+
+function ownershipRows(path: string): Array<{ resource: string; boundPayTo: string[] }> {
+  return JSON.parse(readFileSync(ownershipPathFor(path), "utf8"));
+}
+
+describe("G-7 — the bootstrap migration must actually persist its bindings", () => {
+  it("writes an ownership file during the bootstrap boot", () => {
+    const path = legacyCatalog();
+    expect(existsSync(ownershipPathFor(path)), "precondition: no ownership file yet").toBe(false);
+
+    const cat = new BazaarCatalog(path, { bootstrapOwnership: true });
+    expect(cat.size).toBe(2);
+
+    // The whole point: the derived bindings must be on DISK, not just in memory.
+    expect(existsSync(ownershipPathFor(path)), "G-7: bootstrap must write the ownership store").toBe(true);
+    const rows = ownershipRows(path);
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.resource === URL_A)?.boundPayTo).toEqual([OWNER_A]);
+    expect(rows.find((r) => r.resource === URL_B)?.boundPayTo).toEqual([OWNER_B]);
+  });
+
+  it("the NEXT boot needs no bootstrap flag and does not fail closed", () => {
+    const path = legacyCatalog();
+    new BazaarCatalog(path, { bootstrapOwnership: true }); // migration boot
+
+    // Operator removes the flag, as the runbook instructs.
+    const after = new BazaarCatalog(path);
+    expect(after.catalogFrozen, "must not fail closed after a real migration").toBe(false);
+    expect(after.size, "the catalog must still load").toBe(2);
+    expect(after.isBound(URL_A, OWNER_A)).toBe(true);
+    expect(after.isBound(URL_A, OWNER_B), "bindings must not be interchangeable").toBe(false);
+  });
+
+  it("without the flag it still fails closed — the hatch is what changes, not the default", () => {
+    const path = legacyCatalog();
+    const cat = new BazaarCatalog(path); // no bootstrap
+    expect(cat.catalogFrozen).toBe("ownership-unreadable");
+    expect(cat.size).toBe(0);
+    expect(existsSync(ownershipPathFor(path)), "a frozen catalog must not write bindings").toBe(false);
+  });
+
+  it("does not rewrite an ownership file that already exists", () => {
+    // A normal boot must not churn the ownership store, and must never let the
+    // catalog file's accepts[0] override an authoritative tombstone.
+    const path = legacyCatalog();
+    writeFileSync(
+      ownershipPathFor(path),
+      JSON.stringify([{ resource: URL_A, boundPayTo: [OWNER_A] }]),
+    );
+    const before = readFileSync(ownershipPathFor(path), "utf8");
+
+    const cat = new BazaarCatalog(path);
+    expect(cat.catalogFrozen).toBe(false);
+    expect(cat.isBound(URL_A, OWNER_A)).toBe(true);
+    // URL_B had no row; it is seeded from the catalog file, so the store DOES
+    // change — but URL_A's authoritative row must be preserved verbatim.
+    const rows = ownershipRows(path);
+    expect(rows.find((r) => r.resource === URL_A)?.boundPayTo).toEqual([OWNER_A]);
+    expect(before).toContain(URL_A);
+  });
+
+  it("survives an unwritable ownership path without breaking the boot", () => {
+    // Persistence failure must never stop the service starting; it warns.
+    const path = join(tmpDir(), "nested", "does", "not", "exist", "catalog.json");
+    writeFileSync(join(tmpDir(), "unused"), "");
+    expect(() => new BazaarCatalog(path, { bootstrapOwnership: true })).not.toThrow();
+  });
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -402,6 +402,9 @@ export class BazaarCatalog {
    * and never on the wire (no attacker-forceable signal for consumers). */
   private readonly verifyState = new Map<string, { verdict: OwnershipVerdict; at: number }>();
   private readonly verifyInFlight = new Set<string>();
+  /** G-7: set when load() derives a binding that was not already in the
+   * ownership store, so the constructor can flush it exactly once. */
+  private ownershipSeededDuringLoad = false;
 
   constructor(persistPath?: string, opts: { bootstrapOwnership?: boolean } = {}) {
     this.persistPath = persistPath;
@@ -420,6 +423,16 @@ export class BazaarCatalog {
         return; // catalog stays empty; frozen blocks new bindings
       }
       this.load(persistPath);
+      // G-7: persist anything load() derived. Without this the bootstrap
+      // migration is a no-op on disk and the NEXT boot fails closed again.
+      if (this.ownershipSeededDuringLoad) {
+        this.saveOwnership();
+        console.warn(
+          `[catalog] wrote ${this.ownership.size} ownership binding(s) derived during load to ` +
+            `${ownershipPathFor(persistPath)}. If this was a CATALOG_OWNERSHIP_BOOTSTRAP migration, ` +
+            `verify that file now and REMOVE the flag before the next boot.`,
+        );
+      }
     }
   }
 
@@ -870,7 +883,16 @@ export class BazaarCatalog {
     // Ownership tombstone wins over whatever the entry file claims; only seed it
     // when there is none (first upgrade / bootstrap).
     const authoritative = this.ownership.get(stored.resource.resource);
-    if (!authoritative) this.ownership.set(stored.resource.resource, [ownerPayTo]);
+    if (!authoritative) {
+      this.ownership.set(stored.resource.resource, [ownerPayTo]);
+      // G-7: this seeding is the ENTIRE product of a CATALOG_OWNERSHIP_BOOTSTRAP
+      // migration, and unlike bindOwnership it used to write nothing. The
+      // migration therefore appeared to succeed and persisted nothing: the next
+      // boot found a catalog with no ownership file again and failed closed.
+      // Flushed once after the load loop rather than per entry — saving here
+      // would be O(n^2) over the catalog.
+      this.ownershipSeededDuringLoad = true;
+    }
     return {
       resource: { ...stored.resource, accepts: kept },
       stats: stored.stats ?? { settlements: 0, payers: [], observed: 0 },


### PR DESCRIPTION
## G-7 — bootstrap bindings now actually persist

`bindLoadedEntry` seeded ownership in memory but never wrote it, so a
`CATALOG_OWNERSHIP_BOOTSTRAP` migration **appeared to succeed and persisted
nothing** — the next boot failed closed again. Flushed once after the load loop,
with a log line giving the row count so an operator can verify before removing
the flag. Mutation-verified.

## Keep-alive — and a correction

I called this a latency fix. **Wrong**, and the docs now say so: spin-down
*destroys the container*, wiping `CATALOG_FILE` and its ownership store. Keeping
the instance awake is the **emptiness** fix for what a developer sees.

**The budget decides the schedule.** Render grants **750 instance hours per
workspace per month**, and exhausting it **suspends every free service in the
workspace** until the 1st.

| Schedule | Hours (31-day month) | Margin |
|---|---|---|
| 24/7 | 744 | **6 h (<1%)** |
| **20 h/day (default)** | 620 | 130 h |

24/7 fits arithmetically, and only if this is the **sole** free service in the
workspace — a second one added by anyone takes this down with it. Hence the
20 h/day default, with the 24/7 cron documented. Outside the window: sleeps as
before, catalog comes back empty.

Also noted: GitHub cron is best-effort and can be delayed past the 15-minute
window, so an external pinger is more dependable. The job never fails the build
and warns on `catalogFrozen`.

## Durable catalog — disk rejected, Turso scoped (design only)

A disk costs money **and activates** G-5/G-6/G-7. An external store closes them.
Free Postgres is out (30-day expiry destroys bindings on a timer); Cloudflare KV
is out (eventual consistency lets a stale read bind an already-bound URL —
breaks F11).

The doc tests `catalog.ts`'s "a database can replace the file without touching
routes/ingestion" claim: **true** for routes and reads, **false** for
construction and durability. `saveOwnership` is synchronous *by design* so a
binding is durable before anything relies on it — making it async **re-creates
G-7 with a network in the middle**, so the doc specifies how to preserve it and
requires a failure-injection test.

It argues to **keep fail-closed** on an unreachable store: serving entries whose
ownership could not load is F11 with extra steps. What changes is diagnosis and
blast radius, not the default.

Closes G-5/G-6/G-7 · tombstone clearing becomes credential-based · RA-13
unimproved · G-2 and G-8 untouched (G-8 gets *more* relevant). Migration: nothing
worth migrating.

262 tests, typecheck clean.