### PR TITLE
fix: restore the /health observability dropped by #9's squash, and report the deployed commit

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -78,6 +78,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      # Needed only so `git rev-parse` below has a repo to read: the stale-deploy
+      # check compares the deployed commit against this branch's HEAD. Without
+      # it the comparison silently never runs.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
       - name: Ping /health
         env:
           # /health is exempt from the per-IP rate limit, so this cannot throttle
@@ -104,6 +111,16 @@ jobs:
           # replaced since the last ping — i.e. it slept (or redeployed) and the
           # catalog was wiped. This is how we find out from DATA rather than
           # from a developer reporting an empty listing.
+          # Is the running build actually what is on this branch? /health reports
+          # the deployed commit, so a stale deploy is a string comparison rather
+          # than something discovered by probing for security headers.
+          deployed=$(sed -n 's/.*"commit":"\([0-9a-f]*\)".*/\1/p' /tmp/body)
+          expected=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
+          if [ -n "$deployed" ] && [ -n "$expected" ] && [ "$deployed" != "$expected" ]; then
+            echo "::warning::deployed commit is $deployed but this branch is at $expected — the running build is NOT current"
+          fi
+          echo "deployed=${deployed:-unknown} expected=${expected:-unknown}"
+
           up=$(sed -n 's/.*"uptimeSeconds":\([0-9]*\).*/\1/p' /tmp/body)
           size=$(sed -n 's/.*"catalogSize":\([0-9]*\).*/\1/p' /tmp/body)
           echo "uptimeSeconds=${up:-?} catalogSize=${size:-?}"

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -32,10 +32,29 @@
 ## TO RUN 24/7 instead: change the cron to "*/10 * * * *" and first confirm this
 ## is the only Free service in the workspace.
 ##
-## RELIABILITY CAVEAT: GitHub's scheduled workflows are best-effort and can be
-## delayed well past their cron time under load. A delay beyond 15 minutes lets
-## the service sleep anyway. If the catalog needs to be reliably warm, use an
-## external uptime pinger (5-minute interval) instead of, or alongside, this.
+## RELIABILITY CAVEAT — READ BEFORE RELYING ON THIS.
+##
+## GitHub's scheduled workflows are best-effort and can be delayed well past
+## their cron time under load. A delay beyond 15 minutes lets the service sleep
+## anyway, so this is a keep-alive that *mostly* works — the failure mode is
+## silent and intermittent. An external uptime monitor (UptimeRobot free tier:
+## 50 monitors, 5-minute checks, ~5 minutes to set up, no code) is dependable in
+## a way this is not. Recommended arrangement: external monitor as primary, this
+## workflow as backup.
+##
+## BUDGET INTERACTION — the pinger schedule is not free to choose.
+## An external monitor checking every 5 minutes runs 24/7 by default, which keeps
+## the instance awake 24/7 = 744 h/month against a 750 h WORKSPACE allowance.
+## That silently overrides the 20 h/day decision below and leaves <1% margin. If
+## you add an external monitor, either configure its maintenance window to match
+## the gap here, or accept 24/7 and first confirm this is the only Free service
+## in the workspace.
+##
+## HOW TO TELL IF IT IS WORKING: /health reports `uptimeSeconds`. A value shorter
+## than the ping interval means the container was replaced since the last ping —
+## the step below warns on it. That is the data signal; do not wait for a
+## developer to report an empty catalog.
+##
 ## GitHub also disables scheduled workflows on repositories with no activity for
 ## 60 days.
 
@@ -78,4 +97,16 @@ jobs:
           # Surface a frozen catalog, which is invisible from the outside otherwise.
           if grep -q 'catalogFrozen' /tmp/body; then
             echo "::warning::/health reports catalogFrozen — see docs/operator-runbook.md §2 and §3"
+          fi
+
+          # Did it actually stay awake? /health reports process uptime, so a
+          # value shorter than the ping interval means the container was
+          # replaced since the last ping — i.e. it slept (or redeployed) and the
+          # catalog was wiped. This is how we find out from DATA rather than
+          # from a developer reporting an empty listing.
+          up=$(sed -n 's/.*"uptimeSeconds":\([0-9]*\).*/\1/p' /tmp/body)
+          size=$(sed -n 's/.*"catalogSize":\([0-9]*\).*/\1/p' /tmp/body)
+          echo "uptimeSeconds=${up:-?} catalogSize=${size:-?}"
+          if [ -n "$up" ] && [ "$up" -lt 900 ]; then
+            echo "::warning::instance uptime is ${up}s — it was replaced since the last ping, so the catalog was wiped. If this recurs outside deploy windows the keep-alive is not holding (GitHub cron delay); switch to an external 5-minute pinger."
           fi

--- a/docs/milestone-durable-catalog.md
+++ b/docs/milestone-durable-catalog.md
@@ -142,9 +142,40 @@ dance exist to manage **unrepresentable** rather than merely handled.
 
 - **G-2** — no in-band `payTo` rotation. Still operator-mediated (runbook §1), and
   the procedure changes from editing a file to updating a row.
-- **G-8** — the tombstone cap is a one-way freeze with no reset path. A store makes
-  the cap *reachable* (tombstones now accumulate instead of resetting on restart),
-  so this becomes **more** relevant, not less. Worth fixing in the same batch.
+- **G-8** — the tombstone cap is a one-way freeze with no reset path. Durable
+  storage does make the cap *accumulate* rather than reset, so this was raised as
+  a possible prerequisite. **The arithmetic says no.** See below.
+
+### G-8 under durable storage — worked out, not assumed
+
+A tombstone is created per distinct canonical URL that binds. A brand-new URL is
+by definition unbound at settle time, so it is gated by the **unbound pool**
+(`SETTLE_UNBOUND_POOL_MAX`, 10 per 60 s shared across all unbound URLs):
+
+| Quantity | Value |
+| --- | --- |
+| New-URL settlements per day at the cap | **14,400** |
+| Days of *sustained maximum* to reach `MAX_TOMBSTONES` (100,000) | **6.9** |
+| Sponsor XLM burned to get there (at the 127,808-stroop measured fee) | **~1,278 XLM** |
+| …per day at that rate | **~184 XLM/day** |
+
+Seven days looks alarming until you price it. **The binding constraint is the
+sponsor balance, not the tombstone cap.** `/settle` refuses below the 10 XLM hard
+floor, so at maximum rate the attack self-terminates in **~78 minutes** from a
+10 XLM surplus. Reaching the cap needs someone to keep refunding ~184 XLM/day for
+a week — which only the operator can do, and would notice.
+
+Organically, 100,000 distinct URLs is roughly 10,000 merchants at 10 endpoints
+each: a very large service, not a near-term state.
+
+**Verdict: G-8 stays a policy item and is NOT a prerequisite of this milestone.**
+The finding is real — a one-way freeze with no reset path is disproportionate to
+its trigger — but it is not on a schedule, and the sponsor balance guard bounds it
+roughly two orders of magnitude tighter than the cap does.
+
+One caveat to revisit if the numbers move: raising `SETTLE_UNBOUND_POOL_MAX`, or
+running with a much larger sponsor balance and no hard floor, removes the very
+constraint doing the work here. If either changes, redo this arithmetic.
 
 **New trust boundary:** a network dependency on the write path, credentials in the
 environment, and vendor availability coupled to catalog availability. That is a

--- a/src/config.thresholds.test.ts
+++ b/src/config.thresholds.test.ts
@@ -244,3 +244,38 @@ describe("documented rationale — module constants", () => {
     expect(SERVER_LIMITS.defaultRateMaxPerMinute).toBeLessThanOrEqual(globalPerWindow);
   });
 });
+
+// G-8's verdict ("stays a policy item, not a Turso prerequisite") rests on a
+// numeric argument, so it lives here rather than only in prose. The argument:
+// filling MAX_TOMBSTONES requires ~100,000 settlements of NEW urls, each gated
+// by the unbound pool and each costing the sponsor a fee — and /settle refuses
+// below the hard floor long before the cap is reachable. The sponsor balance,
+// not the tombstone cap, is what bounds tombstone growth.
+//
+// Raise the unbound pool, or drop the hard floor, and that stops being true.
+// These assertions fail if either happens, which is the point.
+describe("documented rationale — G-8 stays bounded by the sponsor balance", () => {
+  const c = loadConfig(base);
+
+  it("filling the tombstone cap is not on a realistic schedule", () => {
+    // THE argument, in one line: new urls are gated by the unbound pool, so the
+    // cap is days of SUSTAINED maximum away — and those days cost the sponsor
+    // ~1,278 XLM, which the hard floor refuses long before. Widen the pool and
+    // the cap comes within reach; that is when G-8 becomes a prerequisite.
+    const newUrlsPerDay = c.spend.unboundPoolMax * 60 * 24;
+    const daysToFillCap = CATALOG_LIMITS.maxTombstones / newUrlsPerDay;
+    expect(daysToFillCap, "cap reachable in under 5 days of max rate — redo the G-8 arithmetic").toBeGreaterThan(5);
+  });
+
+  it("new URLs stay gated by the unbound pool, well below global capacity", () => {
+    // Every brand-new url is unbound at settle time, so this pool is the rate
+    // limiter on tombstone creation. Widening it toward the global ceiling
+    // removes the constraint the G-8 arithmetic depends on.
+    const globalPerWindow = Math.floor(c.spend.ceilingStroops / c.maxTransactionFeeStroops);
+    expect(c.spend.unboundPoolMax).toBeLessThan(globalPerWindow / 5);
+  });
+
+  it("a hard floor is actually set — a zero floor removes the bound entirely", () => {
+    expect(c.balance.hardFloorStroops).toBeGreaterThan(0);
+  });
+});

--- a/src/server.health.test.ts
+++ b/src/server.health.test.ts
@@ -1,0 +1,59 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+
+// /health must make "did the instance stay awake, and does it still have a
+// catalog" answerable from DATA rather than from a developer reporting an empty
+// listing. Render destroys the container on spin-down, so a process-uptime reset
+// is the ground truth for "it slept"; catalogSize is the consequence.
+
+const testConfig = {
+  port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(), maxTransactionFeeStroops: 500_000,
+  catalogFile: undefined, verificationApiUrl: undefined,
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 50, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 250_000_000, hardFloorStroops: 100_000_000, intervalMs: 60_000 },
+  catalogOwnershipBootstrap: false,
+};
+
+describe("/health carries enough to detect a spin-down", () => {
+  it("reports process uptime and catalog size", async () => {
+    const catalog = new BazaarCatalog();
+    const app = await buildServer(buildFacilitator(testConfig), catalog);
+    const body = (await app.inject({ method: "GET", url: "/health" })).json();
+
+    expect(body.status).toBe("ok");
+    // A reset uptime is the only reliable signal that the container was
+    // replaced — Render gives no other outside indication.
+    expect(typeof body.uptimeSeconds, "uptimeSeconds must be present").toBe("number");
+    expect(body.uptimeSeconds).toBeGreaterThanOrEqual(0);
+    // The consequence a developer actually feels.
+    expect(body.catalogSize, "catalogSize must be present").toBe(0);
+    await app.close();
+  });
+
+  it("catalogSize tracks the catalog", async () => {
+    const catalog = new BazaarCatalog();
+    catalog.upsertFromPayment(
+      { resourceUrl: "https://a.example/x", x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      { scheme: "exact", network: "stellar:testnet", asset: "CA", amount: "1", payTo: "GA", maxTimeoutSeconds: 60, extra: {} } as never,
+    );
+    const app = await buildServer(buildFacilitator(testConfig), catalog);
+    const body = (await app.inject({ method: "GET", url: "/health" })).json();
+    expect(body.catalogSize).toBe(1);
+    await app.close();
+  });
+
+  it("stays exempt from the rate limit so the pinger cannot throttle real traffic", async () => {
+    const app = await buildServer(buildFacilitator(testConfig), new BazaarCatalog(), undefined, undefined, {
+      rateMaxPerMinute: 2,
+    });
+    for (let i = 0; i < 8; i++) {
+      const r = await app.inject({ method: "GET", url: "/health" });
+      expect(r.statusCode, `ping ${i} must not be throttled`).toBe(200);
+    }
+    await app.close();
+  });
+});

--- a/src/server.health.test.ts
+++ b/src/server.health.test.ts
@@ -46,6 +46,27 @@ describe("/health carries enough to detect a spin-down", () => {
     await app.close();
   });
 
+  it("reports the deployed commit when the platform provides one", async () => {
+    // Render injects RENDER_GIT_COMMIT. Without this, "what is actually
+    // deployed?" can only be answered by fingerprinting behaviour — which is
+    // how a stale build went unnoticed twice in one session, and only works
+    // when a release happens to change something externally visible.
+    process.env.RENDER_GIT_COMMIT = "abc1234def5678";
+    const app = await buildServer(buildFacilitator(testConfig), new BazaarCatalog());
+    const body = (await app.inject({ method: "GET", url: "/health" })).json();
+    expect(body.commit, "must be short enough to eyeball against git rev-parse").toBe("abc1234");
+    await app.close();
+    delete process.env.RENDER_GIT_COMMIT;
+  });
+
+  it("omits commit entirely when not deployed on a platform that sets it", async () => {
+    delete process.env.RENDER_GIT_COMMIT;
+    const app = await buildServer(buildFacilitator(testConfig), new BazaarCatalog());
+    const body = (await app.inject({ method: "GET", url: "/health" })).json();
+    expect("commit" in body, "absent rather than a misleading placeholder").toBe(false);
+    await app.close();
+  });
+
   it("stays exempt from the rate limit so the pinger cannot throttle real traffic", async () => {
     const app = await buildServer(buildFacilitator(testConfig), new BazaarCatalog(), undefined, undefined, {
       rateMaxPerMinute: 2,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -69,7 +69,9 @@ describe("facilitator server", () => {
   it("GET /health responds ok", async () => {
     const res = await app.inject({ method: "GET", url: "/health" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ status: "ok", service: "vellar-facilitator" });
+    // Shape-checked rather than deep-equal: uptimeSeconds/catalogSize were added
+    // for spin-down observability and are asserted in server.health.test.ts.
+    expect(res.json()).toMatchObject({ status: "ok", service: "vellar-facilitator" });
   });
 
   it("GET /supported lists the stellar exact scheme, sponsored fees, and the bazaar extension", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -113,6 +113,16 @@ export async function buildServer(
     // catalogSize is already derivable from /discovery/resources.
     uptimeSeconds: Math.round(process.uptime()),
     catalogSize: catalog.size,
+    // Which build is actually serving. Render injects RENDER_GIT_COMMIT.
+    // Without this the only way to answer "is the deploy current?" is to
+    // fingerprint behaviour — probing for security headers or an error-message
+    // shape — which is archaeology, only works when a release happens to change
+    // something externally visible, and let a stale build go unnoticed twice.
+    // Now it is a string comparison against `git rev-parse --short HEAD`.
+    // Omitted rather than faked when unset, so local runs do not claim a build.
+    ...(process.env.RENDER_GIT_COMMIT
+      ? { commit: process.env.RENDER_GIT_COMMIT.slice(0, 7) }
+      : {}),
     // F3: surfaced so an operator sees a frozen catalog rather than wondering
     // why discovery stopped growing. Settlement is unaffected while frozen.
     ...(catalog.catalogFrozen ? { catalogFrozen: catalog.catalogFrozen } : {}),

--- a/src/server.ts
+++ b/src/server.ts
@@ -104,6 +104,15 @@ export async function buildServer(
   app.get("/health", async () => ({
     status: "ok",
     service: "vellar-facilitator",
+    // Spin-down observability. Render destroys the container after 15 min idle,
+    // which wipes the catalog — and gives no outside signal that it happened.
+    // A RESET uptimeSeconds between two observations is the ground truth for
+    // "it slept or redeployed"; catalogSize is the consequence a developer
+    // feels. Together they make the keep-alive verifiable from data instead of
+    // from someone reporting an empty listing. Neither leaks anything:
+    // catalogSize is already derivable from /discovery/resources.
+    uptimeSeconds: Math.round(process.uptime()),
+    catalogSize: catalog.size,
     // F3: surfaced so an operator sees a frozen catalog rather than wondering
     // why discovery stopped growing. Settlement is unaffected while frozen.
     ...(catalog.catalogFrozen ? { catalogFrozen: catalog.catalogFrozen } : {}),


### PR DESCRIPTION
## What was lost

**PR #9 squash-merged against a stale head and dropped its second commit** — the
same failure as #6, in the same session. Verified **by content**, not by SHA or
test count, which is exactly what let it through the first time:

| | On `main`? |
|---|---|
| `keepalive.yml`, milestone doc, G-7 fix | ✅ |
| `uptimeSeconds` / `catalogSize` on `/health` | ❌ |
| `server.health.test.ts` | ❌ |
| keepalive uptime parsing, G-8 arithmetic in the milestone doc | ❌ |

Also restored: the **G-8 threshold assertions**, which I committed *after*
pushing #9's branch, so they were never in the PR at all.

**A consequence worth naming:** I read the missing `/health` fields as evidence
of a stale *deploy* and started theorising about Render's auto-deploy setting.
The deploy was faithful — `main` simply didn't have the fields. Check the source
before blaming the platform.

## What's new: `/health` reports the deployed commit

Twice this session the only way to answer "what is actually running?" was to
fingerprint behaviour — probing for helmet headers, then for an error-message
shape. That's archaeology, it only works when a release changes something
externally visible, and it's why a pre-audit build served traffic unnoticed.

```json
{"status":"ok","commit":"2c87805","uptimeSeconds":142,"catalogSize":0}
```

Now it's a string comparison against `git rev-parse --short HEAD`. **Omitted
rather than faked** when the platform doesn't set it, so a local run never claims
to be a build.

The keep-alive workflow compares them and warns on divergence, so a stale deploy
announces itself. That needed an `actions/checkout` step — without a repo,
`git rev-parse` silently returns nothing and the comparison never runs. Caught by
checking the job, not by assuming.

## Verifying this one landed

Please merge, then I'll verify **by content**:

```sh
git show origin/main:src/server.ts | grep -c uptimeSeconds   # must be > 0
```

270 tests, typecheck clean.