### PR TITLE
feat: deploy the demo seller so Layer 2 can be exercised against a real public endpoint

### DIFF
--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -32,7 +32,12 @@ const FACILITATOR_URL = process.env.FACILITATOR_URL || "https://vellar-facilitat
 const PAYTO = "GBDZH5KZSVX67MEWPTEMSOP6FBHKYX4GYOW4RRM4JENRC4XZF5UHTKOP";
 const ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND"; // X402TST bound token
 const PRICE_ATOMIC = process.env.PRICE_ATOMIC || "1000000";
-const PORT = Number(process.env.SELLER_PORT || 4031);
+// PORT first: Render (and most PaaS) inject it and health-check that port, so
+// binding SELLER_PORT there would fail the deploy. SELLER_PORT still wins
+// locally when PORT is unset, so `docs/guide.md`'s walkthrough is unchanged.
+// This is the ONLY deployment concession in this file — the 402 challenge, the
+// discovery declaration and the payment path are untouched.
+const PORT = Number(process.env.PORT || process.env.SELLER_PORT || 4031);
 
 const coreServer = new x402ResourceServer(new HTTPFacilitatorClient({ url: FACILITATOR_URL }))
   .register("stellar:testnet", new ExactStellarScheme())

--- a/render.yaml
+++ b/render.yaml
@@ -100,3 +100,39 @@ services:
       # See docs/security-audit.md (F4) for the precondition before enabling.
       - key: SPONSOR_SECRET_KEY
         sync: false
+
+  # ── DEMO SELLER — for the end-to-end ownership-verification walkthrough ────
+  #
+  # WHY THIS EXISTS. Layer 2 ownership verification (F11) fetches the resource's
+  # OWN 402 challenge over the network. It has never once succeeded against a
+  # real public endpoint: every match-asserting test either relaxes the SSRF
+  # guard (__insecureTestTransport) or stubs fetch and DNS, and the recorded
+  # runs used RESOURCE_URL=http://localhost:4031/quote, which the guard rejects
+  # for being non-https before a socket is opened. So the control is unproven on
+  # the path it was built for. This service gives the seller a real public
+  # hostname with a valid certificate so that path can finally be exercised.
+  #
+  # NOT an always-on service. It sleeps like any free instance; wake it, run the
+  # walkthrough, let it sleep. Free instance hours are pooled per WORKSPACE
+  # (750/month), so a few hours here is negligible — but note it does mean the
+  # facilitator's keep-alive should stay at 20 h/day rather than 24/7:
+  #   20 h/day (620 h) + a few hours of seller  -> ~127 h of margin
+  #   24/7     (744 h) + a few hours of seller  -> over budget
+  #
+  # No healthCheckPath: the only route is /quote, which correctly returns 402
+  # when unpaid. Render falls back to port-binding detection, which is what we
+  # want — a 402 is the seller working, not failing.
+  - type: web
+    name: vellar-seller-demo
+    runtime: node
+    plan: free
+    rootDir: examples
+    buildCommand: "npm install"
+    startCommand: "node seller.mjs"
+    envVars:
+      - key: NODE_VERSION
+        value: "22"
+      # Point the seller's resource server at the hosted facilitator, so the
+      # walkthrough exercises the deployed build rather than a local one.
+      - key: FACILITATOR_URL
+        value: "https://vellar-facilitator.onrender.com"


### PR DESCRIPTION
## The gap this closes

**Layer 2 ownership verification has never returned `match` over a real network path — in tests or in production.**

| Test | Real socket | Guard armed |
|---|---|---|
| "real fetch, real pin, real 402 challenge" | ✅ | ❌ `__insecureTestTransport` |
| "returns match when the settled payTo is in the challenge" | ❌ stubbed `fetchFn` + `lookupFn` | ✅ |
| Fully-armed real-socket tests | ✅ | ✅ — but they only assert **rejection** |

Production can't have covered it either: the recorded runs used
`RESOURCE_URL=http://localhost:4031/quote`, which `assertPublicHttpsUrl` rejects
for being non-https *before opening a socket*. So every entry the hosted instance
has cataloged is permanently `verifiedOwner: false`, and the 2026-07-31 recording
published a `localhost` URL to the public catalog that no agent could pay.

The control is unproven on the exact path it exists for.

## What this adds

A second blueprint service giving the seller a real `*.onrender.com` hostname
with a valid cert — real DNS, real TLS, public address, guard fully armed.

**Why Render:** no new vendor or payment method, and it runs the real
`seller.mjs`. **Workers and Vercel were rejected on a technical fact** —
`seller.mjs` is `express` + `app.listen()`, so both would need the file under
test rewritten, which would prove something about the rewrite. Fly.io is the
fallback if you'd rather not touch the Render pool.

## The one code change

```js
const PORT = Number(process.env.PORT || process.env.SELLER_PORT || 4031);
```

Render injects `PORT` and health-checks it; binding `SELLER_PORT` would fail the
deploy. `SELLER_PORT` still wins locally when `PORT` is unset, so
`docs/guide.md` is unchanged. **Nothing else moves** — not the 402 challenge, not
the discovery declaration, not the payment path.

## Budget interaction

Free hours are pooled per **workspace** (750/month). This is wake-run-sleep, not
always-on, so a few hours is negligible — but it does constrain the open
keep-alive decision:

- facilitator 20 h/day (620 h) + seller → **~127 h margin**
- facilitator 24/7 (744 h) + seller → **over budget**

Recorded in `render.yaml` beside the service.

270 tests, typecheck clean.