### PR TITLE
fix: seller advertised localhost as its own address; add the live Layer 2 gate

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -290,6 +290,85 @@ on catalog availability and preserve the ownership file for analysis.
 
 ---
 
+## 4. Verifying F11 Layer 2 against a live seller (manual gate)
+
+**CI does not cover this, and cannot.** The check needs a live public endpoint,
+real DNS and a valid certificate. In CI that means a network dependency on every
+push, a free-tier seller that sleeps (so the first run pays a ~60s cold start),
+an external hostname that can change, and a red build whenever someone else's
+service is down. A recorded fixture would defeat the point entirely: the thing
+under test is that the bytes traverse real DNS and real TLS, which no fixture
+reproduces.
+
+So this is a **manual gate before any release that touches `src/ownership.ts`**.
+
+### Steps
+
+1. Wake the seller (free instances sleep after 15 min; the first request takes
+   ~1 min):
+
+   ```sh
+   curl -sS -o /dev/null -w '%{http_code}\n' --max-time 150 \
+     https://vellar-seller-demo.onrender.com/quote     # expect 402
+   ```
+
+2. Confirm it advertises its PUBLIC address, not localhost. This is the failure
+   that made Layer 2 unreachable in production for the whole of its life:
+
+   ```sh
+   curl -sS -D- -o /dev/null https://vellar-seller-demo.onrender.com/quote \
+     | grep -i '^payment-required:' | sed 's/^payment-required: //' | tr -d '\r' \
+     | base64 -d | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["resource"]["url"], d["accepts"][0]["payTo"])'
+   ```
+
+   The URL must be `https://…onrender.com/quote`. If it reads
+   `http://localhost:…`, `PUBLIC_BASE_URL` is unset on the seller service —
+   fix that before going further, or the test verifies nothing real.
+
+3. Run the gate with the payTo from step 2:
+
+   ```sh
+   LIVE_SELLER_URL=https://vellar-seller-demo.onrender.com/quote \
+   LIVE_SELLER_PAYTO=<payTo from step 2> \
+   npx vitest run src/ownership.live.test.ts
+   ```
+
+### What a pass looks like
+
+Every stage is printed, and all of them must be real:
+
+```
+DNS      vellar-seller-demo.onrender.com -> 216.24.57.7 (family 4)
+PIN      lookup() -> 216.24.57.7
+TLS      authorized=true CN=onrender.com issuer=Google Trust Services
+VERDICT  match (fetch impl: undici, not global)
+CONTROL  wrong payTo -> mismatch
+```
+
+**The CONTROL line is the one that matters.** Without it, `match` could mean
+"returns match unconditionally". A pass requires both a match for the real payTo
+and a mismatch for an unrelated one.
+
+**With the env vars unset the tests SKIP, they do not pass.** That is deliberate:
+a skip reads as "not run", a vacuous pass reads as "covered", and confusing those
+two is exactly the RA-12 failure this repo has already made once.
+
+### If it fails
+
+The output names the stage. Read it literally:
+
+| Stage | Meaning |
+| --- | --- |
+| scheme | The URL is not https. Check `PUBLIC_BASE_URL` on the seller. |
+| DNS | The hostname does not resolve. The service may be deleted or renamed. |
+| private-range | The host resolved into a blocked range — investigate, this is the SSRF guard doing its job. |
+| PIN | The pin is not the vetted address; the RA-2 rebinding defence is broken. Treat as critical. |
+| TLS | Certificate does not validate against the hostname. |
+| VERDICT `unverifiable` | Reached the endpoint but got no usable 402 — check the seller is awake and returning `PAYMENT-REQUIRED`. |
+| VERDICT `mismatch` | The challenge does not name that payTo. Usually a stale `LIVE_SELLER_PAYTO`. |
+
+---
+
 ## Related
 
 - `docs/security-audit.md` — findings F1–F12 and G-1…G-9, with what each control

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -74,7 +74,15 @@ function adapter(req) {
     getHeader: (name) => req.get(name),
     getMethod: () => req.method,
     getPath: () => req.path,
-    getUrl: () => `http://localhost:${PORT}${req.originalUrl}`,
+    // The resource URL a paying client echoes back, and therefore the key the
+    // facilitator catalogs and later re-fetches for F11 Layer 2 ownership
+    // verification. Hardcoding localhost here meant every settled payment
+    // cataloged `http://localhost:<port>/quote` — a URL no agent can pay, and
+    // one the SSRF guard rejects as non-https before opening a socket. That is
+    // why Layer 2 had never succeeded in production: not the network, this line.
+    // PUBLIC_BASE_URL is how a deployed merchant declares its own address.
+    getUrl: () =>
+      `${process.env.PUBLIC_BASE_URL ?? `http://localhost:${PORT}`}${req.originalUrl}`,
     getAcceptHeader: () => req.get("accept") || "",
     getUserAgent: () => req.get("user-agent") || "",
     getQueryParams: () => req.query,

--- a/render.yaml
+++ b/render.yaml
@@ -136,3 +136,11 @@ services:
       # walkthrough exercises the deployed build rather than a local one.
       - key: FACILITATOR_URL
         value: "https://vellar-facilitator.onrender.com"
+      # The address this merchant advertises in its own 402 challenge, and
+      # therefore the key the facilitator catalogs and re-fetches for F11
+      # Layer 2. Without it seller.mjs falls back to http://localhost:<port>,
+      # which is what made Layer 2 unreachable in production: the guard rejects
+      # a non-https URL before opening a socket, so every cataloged entry was
+      # permanently unverified.
+      - key: PUBLIC_BASE_URL
+        value: "https://vellar-seller-demo.onrender.com"

--- a/src/ownership.live.test.ts
+++ b/src/ownership.live.test.ts
@@ -1,0 +1,131 @@
+import tls from "node:tls";
+import { describe, expect, it } from "vitest";
+import {
+  assertPublicHttpsUrl,
+  defaultFetch,
+  isBlockedAddress,
+  pinnedLookup,
+  verifyResourceOwnership,
+} from "./ownership.js";
+
+// ============================================================================
+// LIVE — F11 Layer 2 against a real public HTTPS endpoint, SSRF guard armed.
+//
+// WHAT THIS EXISTS FOR. Until 2026-08-10, `verifyResourceOwnership` had NEVER
+// returned "match" over a real network path — not in tests, not in production:
+//
+//   - every match-asserting unit test either relaxes the guard
+//     (__insecureTestTransport, permitting http + 127.0.0.1) or stubs BOTH
+//     fetchFn and lookupFn, so no real DNS or TLS is involved;
+//   - the fully-armed real-socket tests only ever assert REJECTION (hits === 0);
+//   - and production could not have covered it, because examples/seller.mjs
+//     hardcoded `http://localhost:<port>` as its own resource URL, which the
+//     guard rejects as non-https before opening a socket.
+//
+// So the control was unproven on the one path it exists for. This test is the
+// proof, and it is deliberately honest about its cost.
+//
+// WHY IT IS OPT-IN, AND WHY CI DOES NOT COVER THIS.
+// It needs a live public endpoint, real DNS, and a valid certificate. In CI that
+// would be: a network dependency on every push, a free-tier instance that sleeps
+// (so the first run pays a ~60s cold start), an external hostname that can
+// change, and a red build whenever someone else's service is down. A recorded
+// fixture would defeat the purpose entirely — the whole point is that the bytes
+// traverse real DNS and real TLS, which a fixture cannot reproduce.
+//
+// So: CI does NOT cover this, and pretending otherwise would be worse than the
+// gap. It is a MANUAL gate, run against a live seller before a release that
+// touches ownership.ts. The procedure lives in docs/operator-runbook.md §4.
+//
+//   LIVE_SELLER_URL=https://vellar-seller-demo.onrender.com/quote \
+//   LIVE_SELLER_PAYTO=G... \
+//   npx vitest run src/ownership.live.test.ts
+//
+// Unset, it SKIPS rather than passes — a skipped test reads as "not run", while
+// a vacuous pass reads as "covered", and that difference is the whole lesson of
+// RA-12.
+// ============================================================================
+
+const LIVE_URL = process.env.LIVE_SELLER_URL;
+const LIVE_PAYTO = process.env.LIVE_SELLER_PAYTO;
+const enabled = Boolean(LIVE_URL && LIVE_PAYTO);
+
+describe.skipIf(!enabled)("LIVE — Layer 2 over a real network path (manual gate)", () => {
+  it("resolves, pins, validates TLS, fetches, and matches — every stage armed", async () => {
+    const url = new URL(LIVE_URL!);
+    const evidence: string[] = [];
+
+    // Stages 1–3: https-only, REAL DNS resolution, post-resolution range check.
+    // No lookupFn is passed, so this uses the platform resolver.
+    const vetted = await assertPublicHttpsUrl(LIVE_URL!, undefined as never, false);
+    expect(vetted.address, "must resolve to a real address").toBeTruthy();
+    expect(isBlockedAddress(vetted.address), "a public host must not be blocked").toBe(false);
+    evidence.push(`DNS      ${url.hostname} -> ${vetted.address} (family ${vetted.family})`);
+
+    // Stage 4: the pin the guard applies to the socket must be the address the
+    // guard itself vetted — this is what closes the DNS-rebinding TOCTOU (RA-2).
+    const lookup = pinnedLookup(vetted) as unknown as (
+      h: string,
+      o: unknown,
+      cb: (e: unknown, a: string) => void,
+    ) => void;
+    const pinned = await new Promise<string>((res) => lookup(url.hostname, {}, (_e, a) => res(a)));
+    expect(pinned, "the pin must be the vetted address, not a re-resolution").toBe(vetted.address);
+    evidence.push(`PIN      lookup() -> ${pinned}`);
+
+    // Stage 5: real TLS to the PINNED address, certificate validated against the
+    // hostname via SNI. rejectUnauthorized proves a real chain, not a bypass.
+    const cert = await new Promise<{ authorized: boolean; cn: string; issuer: string }>(
+      (res, rej) => {
+        const s = tls.connect(
+          { host: vetted.address, port: 443, servername: url.hostname, rejectUnauthorized: true },
+          () => {
+            const c = s.getPeerCertificate();
+            const one = (v: string | string[] | undefined): string =>
+              (Array.isArray(v) ? v[0] : v) ?? "(none)";
+            res({ authorized: s.authorized, cn: one(c.subject?.CN), issuer: one(c.issuer?.O) });
+            s.end();
+          },
+        );
+        s.on("error", rej);
+      },
+    );
+    expect(cert.authorized, "certificate must validate against the hostname").toBe(true);
+    evidence.push(`TLS      authorized=${cert.authorized} CN=${cert.cn} issuer=${cert.issuer}`);
+
+    // Stages 6–7: the real call. No __insecureTestTransport, no fetchFn, no
+    // lookupFn — the guard is fully armed and the 402 is the seller's own.
+    const verdict = await verifyResourceOwnership(LIVE_URL!, LIVE_PAYTO!);
+    evidence.push(`VERDICT  ${verdict} (fetch impl: undici, not global)`);
+
+    // The control that makes the match meaningful: a payTo the challenge does
+    // NOT name must come back "mismatch". Without this, "match" could just mean
+    // "returns match unconditionally".
+    const negative = await verifyResourceOwnership(
+      LIVE_URL!,
+      "GNOTTHEOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+    evidence.push(`CONTROL  wrong payTo -> ${negative}`);
+
+    console.log("\n" + evidence.join("\n") + "\n");
+    expect(verdict, "the live seller must verify its own bound payTo").toBe("match");
+    expect(negative, "an unrelated payTo must be refused").toBe("mismatch");
+  }, 180_000);
+
+  it("refuses the same live host over http, without contacting it", async () => {
+    // The guard must reject on scheme before any socket opens, even for a host
+    // it would otherwise accept. This is the check that made every recorded
+    // production run unverifiable, so it is worth pinning against a real host.
+    const httpUrl = LIVE_URL!.replace(/^https:/, "http:");
+    const verdict = await verifyResourceOwnership(httpUrl, LIVE_PAYTO!);
+    expect(verdict, "http must be unverifiable regardless of the host").toBe("unverifiable");
+  }, 60_000);
+
+  it("uses undici's fetch, not the global one", () => {
+    // A version mismatch here silently disabled the whole control once before:
+    // undici@8's Agent rejects Node's bundled fetch with UND_ERR_INVALID_ARG
+    // before a socket opens, and the catch degraded every verdict to
+    // "unverifiable" while 22 mocked tests stayed green.
+    expect(defaultFetch).not.toBe(globalThis.fetch);
+  });
+});


### PR DESCRIPTION
## The test that had never run — result: **match**

`verifyResourceOwnership` against a real public HTTPS endpoint, guard fully armed:

```
DNS      vellar-seller-demo.onrender.com -> 216.24.57.7 (family 4)
PIN      lookup() -> 216.24.57.7                (identical to vetted address)
TLS      authorized=true CN=onrender.com issuer=Google Trust Services
VERDICT  match                                  (undici fetch, not global)
CONTROL  wrong payTo -> mismatch
```

No `__insecureTestTransport`, no stubbed `fetchFn`, no stubbed `lookupFn`. **The
CONTROL line is what makes it meaningful** — an unrelated payTo comes back
`mismatch`, so this isn't "returns match unconditionally".

**F11 Layer 2 is proven live for the first time since it shipped.**

## The bug that run exposed

The live 402 advertised `"resource":{"url":"http://localhost:10000/quote"}`.

Not a proxy artifact — `examples/seller.mjs` hardcoded:

```js
getUrl: () => `http://localhost:${PORT}${req.originalUrl}`
```

That value is what a paying client echoes back, what the facilitator catalogs as
the entry key, and what Layer 2 later re-fetches. `assertPublicHttpsUrl` rejects
it as non-https **before opening a socket**.

**So the control was unreachable in production for its entire life** — not
because of the network, because of that line. The 2026-07-31 recording published
a localhost URL to the public catalog that no agent could pay, and every entry
the hosted instance has cataloged is permanently `verifiedOwner: false`.

Fixed with `PUBLIC_BASE_URL`, defaulting to the old behaviour so the local
walkthrough in `docs/guide.md` is unchanged.

## The permanent test, and what CI actually covers

`src/ownership.live.test.ts` pins all seven stages — but **CI does not run it,
deliberately.** In CI it would be a network dependency on every push, a sleeping
instance paying a ~60s cold start, a hostname that can change, and a red build
whenever someone else's service is down. A recorded fixture defeats the purpose:
the thing under test *is* real DNS and real TLS.

**Unset, the tests SKIP rather than pass.** A skip reads as "not run"; a vacuous
pass reads as "covered" — confusing those is the RA-12 failure already made once
in this repo.

Manual gate procedure in `docs/operator-runbook.md` §4, including how to confirm
the seller advertises its public address first — a seller advertising localhost
makes the gate verify nothing.

270 passing, 3 skipped, typecheck clean.