### PR TITLE
fix: disable the keep-alive, and surface sellers whose URL can never be verified

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -60,10 +60,27 @@
 
 name: keepalive
 
+# DISABLED ON PURPOSE — no `schedule:` trigger. Manual only.
+#
+# The workspace has EIGHT services sharing one 750-hour monthly pool, and
+# exhausting it suspends EVERY free service in the workspace — including
+# vellar-backend and the frontend, which do real work and have nothing to do
+# with this facilitator.
+#
+# What a keep-alive buys is a demo catalog that stays warm between deploys.
+# What it risks is taking down unrelated production services. Even a 4 h/day
+# window is 124 h/month of that exposure for a convenience. Off is the correct
+# default until the instance types are confirmed and the real divisor is known;
+# it can be re-enabled then with an informed number.
+#
+# TO RE-ENABLE, once you know how many free WEB services share the pool (static
+# sites and databases do NOT draw instance hours, so the divisor is likely
+# smaller than the service count): add back a `schedule:` block, e.g.
+#     schedule:
+#       - cron: "*/10 5-23 * * *"   # 20 h/day = 620 h  -> 83% of the pool
+#       - cron: "*/10 9-12 * * *"   #  4 h/day = 124 h  -> 17% of the pool
+# and re-do the arithmetic against the CURRENT number of free web services.
 on:
-  schedule:
-    # Every 10 minutes, 05:00–23:59 UTC (20 h/day). See the budget note above.
-    - cron: "*/10 5-23 * * *"
   workflow_dispatch: {}
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ without hardcoded integrations.
 | `GET /supported` | Advertise scheme/network/extensions/signers to sellers |
 | `GET /discovery/resources` | List cataloged x402 resources (filters: `type`, `payTo`, `scheme`, `network`, `extensions`, `verified_only`; `limit`/`offset`) |
 | `GET /discovery/search` | Keyword search over the catalog — tokenized and relevance-scored, not semantic (`query`, same filters, cursor-paginated) |
-| `GET /health` | Liveness, plus `catalogFrozen` when the catalog has stopped accepting new bindings |
+| `GET /health` | Liveness, plus the deployed `commit`, `uptimeSeconds`, `catalogSize`, `catalogFrozen` when bindings are frozen, and `unverifiableEntries` when any seller advertises an address the facilitator cannot fetch |
 
 **Smart accounts welcome.** Policy-governed smart-account payments cost ~130k
 stroops of simulation fee (the policy contract runs inside `__check_auth`);
@@ -53,6 +53,12 @@ before you build on it:
   may include a base loaded from `CATALOG_FILE`, which has no independent source
   of truth; `observedSettlements` counts only what this process witnessed. If you
   need a number you can rely on, use that one.
+- **If you are a seller, advertise your PUBLIC address.** The `resource.url` in
+  your 402 is what gets cataloged and what ownership verification re-fetches. A
+  `http://localhost:…` value (the default in `examples/seller.mjs`) can never be
+  verified — it is not https and not reachable — so your entry is served
+  permanently unverified. `PUBLIC_BASE_URL` is how the example declares its real
+  address; `/health` reports `unverifiableEntries` when any entry is in this state.
 - **Verification verdicts read `"unknown"` unless `VERIFICATION_API_URL` is set**,
   and `?verified_only=true` then returns an empty list. That is the honest
   default, not a fault — see F4-ts in the audit for why it is deliberately
@@ -72,13 +78,19 @@ Refusals are deliberately loud and carry a reason. Spend controls are **log-only
 on testnet and enforced on pubnet**, so a testnet client will see them in logs
 before it ever sees a 503.
 
-**On the hosted instance, the catalog is only as durable as the container.**
-Render spins a free service down after 15 minutes without traffic, and spin-down
-destroys the filesystem holding the catalog — so an idle period empties it and
-resets URL ownership bindings. A keep-alive keeps it warm between deploys
-(`.github/workflows/keepalive.yml`); durable storage is scoped in
-[`docs/milestone-durable-catalog.md`](./docs/milestone-durable-catalog.md). Your
-listing returns automatically on your next settled payment either way.
+**On the hosted instance, an empty catalog after an idle period is expected —
+not a fault.** Render spins a free service down after 15 minutes without
+traffic, and spin-down destroys the container's filesystem, so the catalog and
+its URL ownership bindings go with it. Your listing returns automatically on your
+next settled payment; nothing is lost that a payment does not restore.
+
+There is a keep-alive workflow that would prevent this, and it is **deliberately
+disabled**. Free instance hours are pooled per Render *workspace*, and running
+this one warm would consume most of that pool — exhausting it suspends **every**
+free service in the workspace, including unrelated production ones. A warm demo
+catalog is not worth that blast radius. Durable storage, which fixes this
+properly, is scoped in
+[`docs/milestone-durable-catalog.md`](./docs/milestone-durable-catalog.md).
 
 **Resource-URL ownership is trust-on-first-use.** The first settlement for a
 canonical URL (`origin + pathname`) binds it to that payment's `payTo`; later

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -369,6 +369,77 @@ The output names the stage. Read it literally:
 
 ---
 
+## 5. "The catalog is empty after the service was idle"
+
+**This is designed behaviour on the free tier.** Render spins a free web service
+down after 15 minutes without traffic, and spin-down destroys the container's
+filesystem — which is where `CATALOG_FILE` and its ownership store live. Entries
+and bindings go with it.
+
+**Do not treat it as a fault, and do not fix it with a keep-alive.**
+
+`.github/workflows/keepalive.yml` exists and is deliberately left with no
+`schedule:` trigger. Free instance hours are pooled per **workspace** (750/month,
+shared by every free service), and exhausting the pool **suspends every free
+service in the workspace** — including services unrelated to this one. Keeping
+this facilitator warm 20 h/day would consume 83% of that pool; even 4 h/day is
+124 h/month of exposure. The thing being bought is a warm demo catalog; the thing
+being risked is unrelated production.
+
+Re-enable it only with a known divisor. Count the **free web services** in the
+workspace — static sites and databases do not draw instance hours, so the divisor
+is usually smaller than the service count — then pick a window and record the
+arithmetic beside the cron.
+
+### Verify rather than assume
+
+```sh
+curl -sS <base>/health
+```
+
+`catalogSize: 0` with a low `uptimeSeconds` means the container was recently
+replaced: expected. Each resource returns on its next settled payment.
+
+The permanent fix is durable storage, scoped in
+[`docs/milestone-durable-catalog.md`](./milestone-durable-catalog.md).
+
+---
+
+## 6. "`/health` reports `unverifiableEntries`"
+
+A non-zero `unverifiableEntries` means one or more sellers advertise a
+`resource.url` the facilitator **can never fetch** — so those entries are
+permanently unverified, no matter how long you wait.
+
+This is distinct from "not verified yet". While `VERIFICATION_API_URL` is unset
+every entry reads unverified, so that flag carries no information; this count
+does.
+
+### Cause, in order of likelihood
+
+1. **The seller advertises `http://localhost:…`.** This was the default in
+   `examples/seller.mjs` and it made ownership verification vacuous in production
+   for the whole of its life. Fix: set `PUBLIC_BASE_URL` on the seller to the
+   address it is actually reachable at.
+2. **The seller advertises a private or loopback literal** over https.
+3. **The resource declared a `routeTemplate`**, so the catalog key is
+   `origin + /quote/:symbol` — not a fetchable URL. Structural; nothing to fix.
+
+### Confirm which
+
+```sh
+curl -sS '<base>/discovery/resources' | python3 -m json.tool | grep '"resource"'
+```
+
+Any entry whose URL is not public https is one of the above. The log also names
+each one once, when it is first cataloged:
+
+```
+[catalog] <url> can never be ownership-verified: ...
+```
+
+---
+
 ## Related
 
 - `docs/security-audit.md` — findings F1–F12 and G-1…G-9, with what each control

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -994,6 +994,51 @@ assumed newest, an ordering the API never promised.
 is the right posture, not a gap to close. Every verdict degrading to `"unknown"`
 is the honest answer while no verdict can be produced.
 
+## Live evidence vs unit tests — what has actually been exercised in production
+
+Added 2026-08-10 after the first live Layer 2 run. Every control below is
+closed-by-test in CI; this table is about something narrower and more important:
+**which ones have ever executed against the deployed service with real traffic.**
+
+### Has live evidence
+
+| Control | Evidence |
+| --- | --- |
+| **F11 Layer 2** — 402-challenge ownership verification | `match` against `https://vellar-seller-demo.onrender.com/quote` with the SSRF guard fully armed: real DNS (`216.24.57.7`), the pin taken from the guard's own resolution, TLS validated against the hostname (Google Trust Services), and a **control** proving an unrelated `payTo` returns `mismatch`. Repeatable via `src/ownership.live.test.ts` (manual gate, runbook §4). |
+| **F7 baseline hardening** | Probed against the deployed service: helmet headers present, `x-ratelimit-limit: 60`, and junk XDR returning a clean `400 invalid_payload` rather than the pre-audit `500` that leaked an internal `TypeError`. |
+
+### Unit tests ONLY — never executed live
+
+**Everything on the settle path.** These are the controls built during this
+engagement, and not one of them has run against the deployed service, because
+every one of them only executes when a real payment settles:
+
+| Control | What has never been observed live |
+| --- | --- |
+| **F11 Layer 1** — TOFU ownership binding | A real settlement establishing a binding; a second `payTo` being refused. |
+| **F12** — per-entity spend budgets | Any of the three budgets recording or refusing under real traffic. |
+| **G-3** — canonical resource key | `/settle` keying the policy on `origin + pathname` for a real payload. |
+| **G-4** — settlement-stat integrity | A rejected upsert failing to move a victim entry's stats. |
+| **G-1** — re-verify on settle | A restored entry recovering `verifiedOwner` on the bound owner's next settlement. |
+| **F3** — balance guard | `/settle` refused below the hard floor. |
+
+**Why it has never run:** `examples/buyer.mjs` requires a deployed Vellar smart
+account (`WALLET_CONTRACT_ID` plus an attached ed25519 agent signer). Its
+signature format is smart-account-specific, so a fresh keypair is not sufficient
+— a keypair is not a wallet — and the contract and its deploy flow live in the
+wallet repository, not here.
+
+**Why this matters more than it looks.** The pattern this engagement kept hitting
+is controls that are green in CI and inert in production: Layer 2 was decorative
+for its entire life because the example seller advertised `localhost`; the
+threshold sweep found a per-payTo budget that never ran because another budget
+shadowed it; RA-12 found eight tests that passed against deliberately broken
+code. Unit-test coverage has repeatedly failed to predict live behaviour in this
+codebase, and the settle path is where every remaining unverified control sits.
+
+**This is an OPEN item, not a footnote.** It closes when a real payment settles
+through the deployed facilitator and the six rows above are observed.
+
 ## What `main` is running today
 
 **Merged, as of 2026-08-10:** every finding above marked closed-by-test or

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -11,6 +11,8 @@ import type {
   SearchDiscoveryResourcesParams,
   SearchDiscoveryResourcesResponse,
 } from "@x402/extensions/bazaar";
+import { isIP } from "node:net";
+import { isBlockedAddress } from "./ownership.js";
 import type { OwnershipVerdict } from "./ownership.js";
 import type { TrustedDiscoveryResource } from "./trust.js";
 
@@ -52,6 +54,36 @@ function isTemplatedKey(key: string): boolean {
     return p.includes(":") || p.includes("{");
   } catch {
     return false;
+  }
+}
+
+/**
+ * A catalog key Layer 2 can NEVER verify, decidable without DNS: the guard is
+ * https-only, refuses loopback/private literals, and a routeTemplate key is not
+ * a fetchable URL at all.
+ *
+ * This is deliberately distinct from "not verified yet". With
+ * VERIFICATION_API_URL unset every entry already reads unverified, so that flag
+ * carries no information — whereas this says the entry can never become
+ * verified however long you wait. examples/seller.mjs advertising
+ * `http://localhost:<port>` made ownership verification vacuous in production
+ * for its entire life, and nothing surfaced it.
+ */
+function isStructurallyUnverifiable(key: string): boolean {
+  try {
+    const u = new URL(key);
+    if (u.protocol !== "https:") return true;
+    if (isTemplatedKey(key)) return true;
+    if (u.hostname === "localhost") return true;
+    // Bare IP literals only. isBlockedAddress fails CLOSED on anything that is
+    // not a parseable IP, which is right where it guards a resolved address but
+    // would flag every healthy hostname here — so gate it on isIP first.
+    // Hostnames need DNS and are left to the live check, making this count a
+    // LOWER BOUND: it never over-reports.
+    if (isIP(u.hostname) !== 0 && isBlockedAddress(u.hostname)) return true;
+    return false;
+  } catch {
+    return true;
   }
 }
 
@@ -405,6 +437,9 @@ export class BazaarCatalog {
   /** G-7: set when load() derives a binding that was not already in the
    * ownership store, so the constructor can flush it exactly once. */
   private ownershipSeededDuringLoad = false;
+  /** URLs already warned about, so the log fires once per resource rather than
+   * once per settlement. */
+  private readonly warnedUnverifiable = new Set<string>();
 
   constructor(persistPath?: string, opts: { bootstrapOwnership?: boolean } = {}) {
     this.persistPath = persistPath;
@@ -442,6 +477,15 @@ export class BazaarCatalog {
   }
 
   /** Number of cataloged resources. */
+  /** Entries whose URL can NEVER pass Layer 2 (see isStructurallyUnverifiable).
+   * Surfaced on /health: a non-zero value means those sellers are advertising an
+   * address the facilitator cannot reach, not that verification is pending. */
+  get unverifiableCount(): number {
+    let n = 0;
+    for (const key of this.entries.keys()) if (isStructurallyUnverifiable(key)) n++;
+    return n;
+  }
+
   get size(): number {
     return this.entries.size;
   }
@@ -691,6 +735,17 @@ export class BazaarCatalog {
       boundPayTo,
       verifiedOwner: existing?.verifiedOwner ?? false,
     });
+    // Active half of the signal: /health carries a standing count, but nothing
+    // polls it now that the keep-alive is off, so say it once per URL in the log.
+    if (isStructurallyUnverifiable(key) && !this.warnedUnverifiable.has(key)) {
+      this.warnedUnverifiable.add(key);
+      console.warn(
+        `[catalog] ${key} can never be ownership-verified: the resource advertises an address the ` +
+          `facilitator cannot fetch (https-only, no loopback/private literals, no route templates). ` +
+          `The entry is served but permanently unverified. If this is your seller, set PUBLIC_BASE_URL ` +
+          `to the address it is actually reachable at — see docs/operator-runbook.md §4.`,
+      );
+    }
     this.evictToCap();
     this.save();
     return isFirstCatalog;

--- a/src/catalog.unverifiable.test.ts
+++ b/src/catalog.unverifiable.test.ts
@@ -1,0 +1,74 @@
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { describe, expect, it, vi } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+
+// A seller that advertises a URL Layer 2 can NEVER verify — http://localhost,
+// a private literal, a routeTemplate key — produces an entry that looks normal
+// and is permanently unverified. That is how examples/seller.mjs made ownership
+// verification vacuous in production for its entire life without anything
+// noticing.
+//
+// The signal has to distinguish "not verified YET" from "can never BE verified".
+// With VERIFICATION_API_URL unset every entry already reads unverified, so the
+// existing flag carries no information — the distinction is the whole point.
+
+const ASSET = "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND";
+const PAY = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+
+function reqs(): PaymentRequirements {
+  return { scheme: "exact", network: "stellar:testnet", asset: ASSET, amount: "1", payTo: PAY, maxTimeoutSeconds: 60, extra: {} } as PaymentRequirements;
+}
+function disc(url: string): DiscoveredResource {
+  return { resourceUrl: url, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as DiscoveredResource;
+}
+
+describe("structurally unverifiable entries are counted, not hidden", () => {
+  it("counts an http:// resource — the seller.mjs failure", () => {
+    const c = new BazaarCatalog();
+    c.upsertFromPayment(disc("http://localhost:10000/quote"), reqs());
+    expect(c.unverifiableCount, "an http url can never pass the https-only guard").toBe(1);
+  });
+
+  it("does NOT count a healthy public https resource", () => {
+    const c = new BazaarCatalog();
+    c.upsertFromPayment(disc("https://vellar-seller-demo.onrender.com/quote"), reqs());
+    expect(c.unverifiableCount).toBe(0);
+  });
+
+  it("counts loopback and private literals even over https", () => {
+    const c = new BazaarCatalog();
+    c.upsertFromPayment(disc("https://localhost/x"), reqs());
+    c.upsertFromPayment(disc("https://127.0.0.1/y"), reqs());
+    c.upsertFromPayment(disc("https://10.0.0.5/z"), reqs());
+    expect(c.unverifiableCount).toBe(3);
+  });
+
+  it("counts a routeTemplate key, which is not a fetchable URL", () => {
+    const c = new BazaarCatalog();
+    c.upsertFromPayment(disc("https://api.example/quote/:symbol"), reqs());
+    expect(c.unverifiableCount).toBe(1);
+  });
+
+  it("warns ONCE when such an entry is cataloged, so it is not purely passive", () => {
+    // /health is a standing signal, but nothing polls it now that the keep-alive
+    // is off. The log line is the active half.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const c = new BazaarCatalog();
+    c.upsertFromPayment(disc("http://localhost:10000/quote"), reqs());
+    c.upsertFromPayment(disc("http://localhost:10000/quote"), reqs());
+    const hits = warn.mock.calls.filter((x) => /never be ownership-verified/i.test(String(x[0])));
+    expect(hits.length, "once per URL, not once per settlement").toBe(1);
+    expect(String(hits[0]?.[0])).toMatch(/PUBLIC_BASE_URL|advertis/i);
+    warn.mockRestore();
+  });
+
+  it("mixes correctly: only the unverifiable ones are counted", () => {
+    const c = new BazaarCatalog();
+    c.upsertFromPayment(disc("https://good.example/a"), reqs());
+    c.upsertFromPayment(disc("http://bad.example/b"), reqs());
+    c.upsertFromPayment(disc("https://also-good.example/c"), reqs());
+    expect(c.size).toBe(3);
+    expect(c.unverifiableCount).toBe(1);
+  });
+});

--- a/src/server.health.test.ts
+++ b/src/server.health.test.ts
@@ -78,3 +78,29 @@ describe("/health carries enough to detect a spin-down", () => {
     await app.close();
   });
 });
+
+describe("/health surfaces structurally unverifiable entries", () => {
+  it("reports the count when a seller advertises an unfetchable address", async () => {
+    const catalog = new BazaarCatalog();
+    catalog.upsertFromPayment(
+      { resourceUrl: "http://localhost:10000/quote", x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      { scheme: "exact", network: "stellar:testnet", asset: "CA", amount: "1", payTo: "GA", maxTimeoutSeconds: 60, extra: {} } as never,
+    );
+    const app = await buildServer(buildFacilitator(testConfig), catalog);
+    const body = (await app.inject({ method: "GET", url: "/health" })).json();
+    expect(body.unverifiableEntries, "the seller.mjs failure must be visible").toBe(1);
+    await app.close();
+  });
+
+  it("stays quiet when every entry is fetchable", async () => {
+    const catalog = new BazaarCatalog();
+    catalog.upsertFromPayment(
+      { resourceUrl: "https://seller.example/quote", x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      { scheme: "exact", network: "stellar:testnet", asset: "CA", amount: "1", payTo: "GA", maxTimeoutSeconds: 60, extra: {} } as never,
+    );
+    const app = await buildServer(buildFacilitator(testConfig), catalog);
+    const body = (await app.inject({ method: "GET", url: "/health" })).json();
+    expect("unverifiableEntries" in body, "a healthy catalog must not add noise").toBe(false);
+    await app.close();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -113,6 +113,11 @@ export async function buildServer(
     // catalogSize is already derivable from /discovery/resources.
     uptimeSeconds: Math.round(process.uptime()),
     catalogSize: catalog.size,
+    // Non-zero means those sellers advertise an address the facilitator cannot
+    // fetch, so their entries are permanently unverified — distinct from "not
+    // verified yet", which every entry reads as while VERIFICATION_API_URL is
+    // unset. Omitted at zero so a healthy catalog stays quiet.
+    ...(catalog.unverifiableCount > 0 ? { unverifiableEntries: catalog.unverifiableCount } : {}),
     // Which build is actually serving. Render injects RENDER_GIT_COMMIT.
     // Without this the only way to answer "is the deploy current?" is to
     // fingerprint behaviour — probing for security headers or an error-message


### PR DESCRIPTION
## Keep-alive off, not reduced

Eight services share one 750-hour pool, and exhausting it suspends **every** free
service in the workspace — `vellar-backend` and the frontend included. Even
4 h/day is 124 h/month of exposure for a warm demo catalog.

The file stays with **no `schedule:` trigger**, manual dispatch only, so it can be
re-enabled once the divisor is known. Both candidate crons and their arithmetic
are recorded beside it — and the divisor is likely smaller than eight, since
static sites and databases don't draw instance hours.

## The `PUBLIC_BASE_URL` signal — I went with your instinct, and here's why

**Refusing to catalog non-https URLs moves the silence rather than removing it.**
The rejection would land *after* settlement: the seller is paid, the goods are
delivered, and they're quietly not listed — invisible to them and to us. It would
also break the documented local walkthrough, which uses `http://localhost:4031`.

The count adds a signal without taking anything away.

What makes it useful is the distinction between **"can never be verified"** and
"not verified yet" — non-https, loopback/private literal, or a `routeTemplate`
key. With `VERIFICATION_API_URL` unset every entry already reads unverified, so
that flag carries no information; this does. All decidable without DNS, so it's a
lower bound that never over-reports.

**One extension to your proposal:** passive alone is weak now that nothing polls
`/health`. So there's an active half — one warning per URL when such an entry is
cataloged, naming `PUBLIC_BASE_URL` and the runbook.

Implementation note worth keeping: `isBlockedAddress` fails **closed** on
anything that isn't a parseable IP — right where it guards a resolved address,
but it flagged every healthy hostname here until gated behind `isIP()`.

## What is actually proven — new audit section

**Live evidence:** F11 Layer 2 (match against a real public HTTPS endpoint, guard
armed, with a control) · F7 baseline hardening (probed on the deployed service).

**Unit tests only, never executed live — everything on the settle path:**

| Control | Never observed live |
|---|---|
| F11 Layer 1 TOFU binding | a real settlement establishing a binding |
| F12 spend budgets | any budget recording or refusing under real traffic |
| G-3 canonical key | `/settle` keying the policy for a real payload |
| G-4 stats gate | a rejected upsert failing to move a victim's stats |
| G-1 re-verify | a restored entry recovering `verifiedOwner` |
| F3 balance guard | `/settle` refused below the hard floor |

That's everything built this engagement. Recorded as an **open item, not a
footnote**, because this codebase keeps producing green tests over inert
production: Layer 2 was decorative for its whole life, F12's per-payTo budget
never ran, and RA-12 found eight tests passing against deliberately broken code.

278 passing, 3 skipped, typecheck clean. Mutation-verified on both new guards.