### PR TITLE
chore: ignore scratch and provisioning scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,26 @@ node_modules/
 !.env.example
 !.env.recording.example
 *.log
+
+# Scratch and provisioning scripts — never commit.
+#
+# These are the files that HANDLE key material even when they do not contain it:
+# provisioning scripts hold secrets in process memory, take them on stdin, and
+# print public values. A stray `git add -A` commits the code path, and the next
+# person to edit it has no signal that it is throwaway.
+#
+# Deliberately broad so siblings are covered without anyone remembering to add a
+# rule: `.provision-tmp.mjs` was the file that prompted this, but the next one
+# will be called something else. Verified against `git ls-files` — these patterns
+# match nothing currently tracked.
+#
+# If you need a scratch file to persist, put it in the session scratchpad OUTSIDE
+# the repo (docs/walkthrough-wallet-spec.md §4), not here. This rule stops an
+# accident; it is not a place to keep secrets.
+*provision-tmp*
+*.provision.mjs
+*.scratch.*
+.scratch/
+scratch/
+*-tmp.mjs
+*.tmp.mjs


### PR DESCRIPTION
`examples/.provision-tmp.mjs` turned up untracked at mode `644`, and `.gitignore`
didn't cover it — a stray `git add -A` would have committed it.

It held **no secret** when I checked. But it's about to handle four in process
memory, and the committed artifact would be the code path that touches them, with
no signal to the next reader that it's throwaway.

## Broader than the one filename

The next such file will be called something else:

```
*provision-tmp*
*.provision.mjs
*.scratch.*
.scratch/
scratch/
*-tmp.mjs
*.tmp.mjs
```

## Verified both directions

**Catches** the file plus six plausible siblings (`provision-tmp.mjs`,
`wallet.provision.mjs`, `foo.scratch.ts`, `scratch/x.mjs`, `deploy-tmp.mjs`,
`a.tmp.mjs`).

**Doesn't catch** `seller.mjs`, `buyer.mjs`, `src/`, `render.yaml`,
`.env.example` — and `git ls-files -i -c --exclude-standard` is empty, so
**nothing currently tracked is silently un-tracked**. That check matters: a broad
ignore rule can mask an already-committed file rather than protect a new one.

The comment points at spec §4 — a scratch file that must persist belongs in the
session scratchpad **outside** the repo. This rule stops an accident; it isn't a
place to keep secrets.

278 passing, 3 skipped.