### PR TITLE
docs: record the fabricated-pass evidence lesson, and fix a burn template that contradicted §7

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -456,6 +456,47 @@ assertion ("the ceiling admits 100 per window", "per-payTo is half of global",
 "the hard floor exceeds one window"), so changing a value without revisiting its
 reasoning fails the build instead of quietly making a comment false.
 
+### Evidence lesson: a non-200 is ambiguous, and the failure mode is a FABRICATED PASS
+
+From the live walkthrough, and it generalises well beyond it.
+
+`/settle` returning a non-200 is **ambiguous between infrastructure and a control
+decision**. A stale-view error from the RPC load balancer and F11 refusing a
+resource-URL squat look identical from the client: both are simply "not 200".
+During wallet provisioning the testnet RPC produced four distinct stale-view
+errors and three outright failures, so this is the normal condition, not an edge
+case.
+
+**The danger is not a failed test. It is manufactured evidence for the claim you
+most want to be true.** Recording an RPC failure as "F11 blocked the squat"
+produces a *pass* — for the single most important control in the audit — that
+nothing downstream would ever contradict. The inverse error, dismissing a real
+refusal as "flake, retry", quietly erases a genuine result. Both are worse than
+an inconclusive run, because both look like knowledge.
+
+**Horizon is the arbiter, not the `/settle` response.** For any settle that does
+not cleanly succeed:
+
+- tx exists and `successful: true` → the payment went through, so whatever the
+  catalog did next is a **real control decision** and may be recorded
+- tx absent or `successful: false` → **infrastructure or signing**; retry, and
+  record nothing
+
+`fee_account` on the same Horizon read doubles as independent proof the
+facilitator sponsored the fee — which the F11 evidence depends on anyway, since
+the whole claim is "the payment succeeded *and* the catalog refused it".
+
+**Retrying is always cheaper than recording an ambiguity.** The test wallet was
+funded at twenty times the plan specifically so that no result ever has to be
+guessed at. Fund for retries, not for the happy path.
+
+This sits alongside the other evidence lessons here — [decorative tests
+(RA-12)](#ra-12--decorative-tests--high--closed-by-test), where eight tests
+passed against deliberately broken code, and [live evidence vs unit
+tests](#live-evidence-vs-unit-tests--what-has-actually-been-exercised-in-production).
+The common thread is that **a green result is not self-validating**: something
+independent has to be able to contradict it.
+
 ### Operational lesson: secrets in `argv`
 
 During the F11 reproduction, throwaway secrets were passed as command-line

--- a/docs/walkthrough-wallet-spec.md
+++ b/docs/walkthrough-wallet-spec.md
@@ -189,8 +189,10 @@ WALLET_CONTRACT_ID : C…
 agent signer (pub) : G…        # ed25519, secret never persisted
 SIM_SOURCE_ACCOUNT : G…
 asset              : CBIN4HTP… (X402TST)
-BURN DATE          : <date + 14d> — remove the signer on-chain and confirm
-                     get_signer returns null, as done for the previous wallet.
+BURN DATE          : <date + 14d> — DESTROY THE SECRET. Do NOT attempt
+                     remove_signer if this key is the wallet's only signer:
+                     LastAdminSigner refuses it and get_signer stays non-null,
+                     which is expected, not an incomplete burn. See §7.
 ```
 
 ---


### PR DESCRIPTION
## The fabricated-pass lesson, filed to outlive the run

A non-200 from `/settle` is **ambiguous between infrastructure and a control
decision** — a stale-view RPC error and F11 refusing a squat look identical from
the client.

**The danger is not a failed test. It's manufactured evidence for the claim you
most want to be true.** Recording an RPC failure as "F11 blocked the squat"
produces a *pass* for the most important control in the audit, and nothing
downstream would contradict it. The inverse quietly erases a real result. Both
are worse than an inconclusive run, because both look like knowledge.

Horizon is the arbiter, with the classification rule written out. `fee_account`
on the same read doubles as independent proof of sponsorship — which the F11
claim depends on anyway, since it *is* "the payment succeeded and the catalog
refused it".

Filed beside RA-12 and the live-evidence table, with the common thread named:
**a green result is not self-validating** — something independent has to be able
to contradict it.

## Burn template fixed

§4's `decisions.md` template still said "remove the signer on-chain and confirm
`get_signer` returns null" — contradicting the §7 correction **in the same
document**. A reader following the template would hit `LastAdminSigner` and go
hunting a fault that doesn't exist.

278 passing, 3 skipped.