### PR TITLE
fix(seller): bounded retry with 429 awareness; record D-1 and D-2

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -531,6 +531,8 @@ Closed since this table was first written (kept here so the history is not lost)
 | **F3** | Non-atomic `save()`, unbounded entries/`accepts` | **closed-by-test** — atomic writes, bounds, and ownership tombstones so eviction cannot drop a binding. |
 | **F10-op** | `examples/.env.recording` held a live testnet `AGENT_SECRET` | **closed** — signer removed on-chain and confirmed `null`, local copies deleted. See the `argv` lesson above. |
 | **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement. |
+| **D-1** | Seller had a hard boot dependency on the facilitator; the facilitator has none | **closed** — warm + bounded backoff in the seller. The dependency half (@x402/core retries 429 but not 502) is upstream and unfixed here. |
+| **D-2** | F7's rate limit sustained a crash loop it could not distinguish from an attack | **closed-by-doc** — the defence belongs in the dependent, not in a weaker limiter. |
 | **G-3** | Spend policy keyed on the raw URL while the catalog keys on the canonical one | **closed-by-test** — found by red-teaming the F12 change before it merged. |
 | **G-4** | Settlement stats writable by anyone, against any entry | **closed-by-test** — gated on the bound owner; cross-entity forgery now impossible. |
 | **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement; settle-triggered only, cooldowns asserted in outbound fetches. |

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -75,7 +75,55 @@ const routes = {
 };
 
 const httpServer = new x402HTTPResourceServer(coreServer, routes);
-await httpServer.initialize();
+
+// `initialize()` fetches /supported from the facilitator and THROWS if it can't,
+// which killed this process on every boot and produced a crash loop:
+//
+//   seller boots -> GET /supported -> facilitator is cold-starting -> 502
+//   -> seller exits -> Render restarts it -> immediately retries -> ...
+//   -> the retry storm hits the facilitator's own 60/min rate limit -> 429
+//
+// Two things we built collided. The facilitator sleeps (free tier, and the
+// keep-alive is deliberately disabled), so a boot fetch during its ~1 min cold
+// start reliably 502s. And F7's rate limit — which exempts /health but NOT
+// /supported — then turned a transient failure into a persistent one by
+// throttling the restarts.
+//
+// A merchant whose service dies permanently because its facilitator was briefly
+// asleep is fragile in a way any real deployment would hit, so this is a real
+// fix rather than a test accommodation.
+async function initializeWithRetry() {
+  // /health IS rate-limit exempt, so waking the facilitator this way cannot
+  // contribute to the 429 that made the loop persistent.
+  const base = FACILITATOR_URL.replace(/\/+$/, "");
+  try {
+    console.error("[seller] warming the facilitator (cold start can take ~1 min)…");
+    await fetch(`${base}/health`, { signal: AbortSignal.timeout(90_000) });
+  } catch {
+    // Warming is best-effort; the retries below are what actually guarantee it.
+  }
+
+  let delay = 2_000;
+  for (let attempt = 1; attempt <= 6; attempt++) {
+    try {
+      await httpServer.initialize();
+      console.error(`[seller] facilitator reachable (attempt ${attempt})`);
+      return;
+    } catch (err) {
+      if (attempt === 6) throw err;
+      // Backoff with jitter. A tight retry is what produced the 429; retrying
+      // without backing off would recreate the storm this exists to prevent.
+      const wait = delay + Math.floor(Math.random() * 1_000);
+      console.error(
+        `[seller] facilitator not ready (attempt ${attempt}/6): ${err?.cause?.message ?? err?.message ?? err}` +
+          ` — retrying in ${Math.round(wait / 1000)}s`,
+      );
+      await new Promise((r) => setTimeout(r, wait));
+      delay = Math.min(delay * 2, 30_000);
+    }
+  }
+}
+await initializeWithRetry();
 
 function adapter(req) {
   return {

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -76,52 +76,82 @@ const routes = {
 
 const httpServer = new x402HTTPResourceServer(coreServer, routes);
 
-// `initialize()` fetches /supported from the facilitator and THROWS if it can't,
-// which killed this process on every boot and produced a crash loop:
+// `initialize()` fetches /supported from the facilitator. Without this wrapper
+// the process died on every boot and produced a self-sustaining crash loop:
 //
-//   seller boots -> GET /supported -> facilitator is cold-starting -> 502
-//   -> seller exits -> Render restarts it -> immediately retries -> ...
-//   -> the retry storm hits the facilitator's own 60/min rate limit -> 429
+//   seller boots -> GET /supported -> facilitator cold-starting -> 502
+//   -> seller exits -> Render restarts -> retries at once -> ...
+//   -> the restart storm hits the facilitator's own 60/min limit -> 429
 //
-// Two things we built collided. The facilitator sleeps (free tier, and the
-// keep-alive is deliberately disabled), so a boot fetch during its ~1 min cold
-// start reliably 502s. And F7's rate limit — which exempts /health but NOT
-// /supported — then turned a transient failure into a persistent one by
-// throttling the restarts.
+// WHAT @x402/core ALREADY DOES, read from the source rather than assumed:
+// getSupported() loops GET_SUPPORTED_RETRIES (3) times, and on 429 it honours
+// Retry-After via computeRetryDelay() before continuing. But on ANY OTHER
+// non-ok status — 502 included — it throws IMMEDIATELY. That asymmetry is
+// backwards for this topology: a 502 from a cold-starting upstream is the
+// textbook retryable case, while a 429 is a deliberate refusal. So the library
+// covers the case that needs waiting and not the case that needs patience.
 //
-// A merchant whose service dies permanently because its facilitator was briefly
-// asleep is fragile in a way any real deployment would hit, so this is a real
-// fix rather than a test accommodation.
+// This wrapper therefore exists for 5xx/network, and defers to the library on
+// 429 — where it has already spent its Retry-After waits before throwing.
+const MAX_BOOT_ATTEMPTS = 5;
+const RATE_WINDOW_MS = 65_000; // facilitator limit is 60/min; +5s of margin
+
 async function initializeWithRetry() {
-  // /health IS rate-limit exempt, so waking the facilitator this way cannot
-  // contribute to the 429 that made the loop persistent.
   const base = FACILITATOR_URL.replace(/\/+$/, "");
+
+  // Warm via /health SPECIFICALLY because it is the ONE route exempt from the
+  // facilitator's rate limiter (src/server.ts: `allowList: req.url === "/health"`).
+  // Warming through any other route would consume the same 60/min bucket the
+  // seller needs, and could extend the very lockout this is recovering from.
+  // That exemption is now load-bearing — if the limiter config is ever tidied,
+  // this warm must move with it.
   try {
-    console.error("[seller] warming the facilitator (cold start can take ~1 min)…");
+    console.error("[seller] warming the facilitator via /health (rate-limit exempt)…");
     await fetch(`${base}/health`, { signal: AbortSignal.timeout(90_000) });
   } catch {
-    // Warming is best-effort; the retries below are what actually guarantee it.
+    // Best-effort. The retries below are what actually guarantee readiness.
   }
 
   let delay = 2_000;
-  for (let attempt = 1; attempt <= 6; attempt++) {
+  let lastError;
+  for (let attempt = 1; attempt <= MAX_BOOT_ATTEMPTS; attempt++) {
     try {
       await httpServer.initialize();
-      console.error(`[seller] facilitator reachable (attempt ${attempt})`);
+      console.error(`[seller] facilitator reachable (attempt ${attempt}/${MAX_BOOT_ATTEMPTS})`);
       return;
     } catch (err) {
-      if (attempt === 6) throw err;
-      // Backoff with jitter. A tight retry is what produced the 429; retrying
-      // without backing off would recreate the storm this exists to prevent.
-      const wait = delay + Math.floor(Math.random() * 1_000);
+      lastError = err;
+      const detail = err?.cause?.message ?? err?.message ?? String(err);
+      if (attempt === MAX_BOOT_ATTEMPTS) break;
+
+      // A 429 here means the library ALREADY exhausted its Retry-After waits and
+      // the bucket is still full. Backing off by seconds would just re-consume
+      // it — the loop that caused this. Wait out the whole window instead.
+      const rateLimited = /\(429\)/.test(detail);
+      const wait = rateLimited
+        ? RATE_WINDOW_MS
+        : delay + Math.floor(Math.random() * 1_000); // jitter
       console.error(
-        `[seller] facilitator not ready (attempt ${attempt}/6): ${err?.cause?.message ?? err?.message ?? err}` +
-          ` — retrying in ${Math.round(wait / 1000)}s`,
+        `[seller] facilitator not ready (attempt ${attempt}/${MAX_BOOT_ATTEMPTS}): ${detail}` +
+          ` — ${rateLimited ? "RATE LIMITED, waiting out the full window" : "retrying"} in ${Math.round(wait / 1000)}s`,
       );
       await new Promise((r) => setTimeout(r, wait));
-      delay = Math.min(delay * 2, 30_000);
+      if (!rateLimited) delay = Math.min(delay * 2, 30_000);
     }
   }
+
+  // Give up LOUDLY and specifically. A seller that retried forever against a
+  // permanently dead facilitator would be indistinguishable from a slow cold
+  // start, so a real misconfiguration must be legible in one line: which URL,
+  // and what it actually returned.
+  console.error(
+    `\n[seller] FATAL: gave up after ${MAX_BOOT_ATTEMPTS} attempts.\n` +
+      `  facilitator : ${base}\n` +
+      `  last error  : ${lastError?.cause?.message ?? lastError?.message ?? lastError}\n` +
+      `  If this is a cold start it should have recovered by now, so treat it as a\n` +
+      `  misconfiguration: check FACILITATOR_URL, and that ${base}/supported returns 200.\n`,
+  );
+  throw lastError;
 }
 await initializeWithRetry();
 


### PR DESCRIPTION
## The fix, against all three failure shapes

**Bounded at 5 attempts, then a loud exit** naming the facilitator URL and what
it returned — a seller retrying forever against a dead facilitator is
indistinguishable from a slow cold start.

**Warm via `/health` specifically** because it's the one route exempt from the
facilitator's own limiter. Warming through anything else consumes the same 60/min
bucket the seller needs and could extend the lockout. That exemption is now
load-bearing, and the comment says so for whoever next tidies the limiter config.

**429 gets the full window (65s), not the backoff.** Backing off by seconds is
exactly the loop that caused the lockout.

## A correction to my own earlier claim

I said `@x402/core` had "no retry, no backoff". **Wrong** — read from source,
`getSupported()` loops 3 times and honours `Retry-After` on 429.

What it does *not* retry is any other non-ok status — **502 included**, thrown
immediately. That's backwards for this topology: a 502 from a cold-starting
upstream is the textbook retryable case; a 429 is a deliberate refusal. So this
wrapper covers 5xx/network and defers to the library on 429.

## Verified all three, not just the one we hit

| Case | Result |
|---|---|
| Unreachable | backoff engages; gives up at 5 with the FATAL block naming URL + error |
| **429** | waits the window — **4 requests total** (1 warm + the library's 3), then quiet |
| Real sleeping facilitator | warm succeeded, `initialize()` passed on attempt 1, 402 served with the new asset |

## D-1 — boot-dependency asymmetry

The facilitator boots without any dependency — `balance.ts` says *"startup is not
blocked"* in the code. The seller had the mirror image and **nobody chose it**: a
module-scope `await` with no catch, no comment, no fallback.

One property deliberately engineered and documented, its opposite present by
omission, in the same repo. **That contrast is the finding.**

## D-2 — topology lesson

No component misbehaved. F7 refused a flood (its job); Render restarted a
crashing service (its job); together they closed a cycle.

> A rate limiter cannot distinguish an attack from a dependent service failing.
> Any load-shedding control will, under the right topology, shed the traffic that
> would have recovered the system.

**The defence lives in the dependent, not in a weaker limiter** — loosening F7
would trade a real control for a deployment convenience and wouldn't fix the
class anyway.

278 passing, 3 skipped.