### PR TITLE
feat(seller): /whoami and one source of truth for the advertised address (D-3)

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -358,8 +358,17 @@ So this is a **manual gate before any release that touches `src/ownership.ts`**.
      https://vellar-seller-demo.onrender.com/quote     # expect 402
    ```
 
-2. Confirm it advertises its PUBLIC address, not localhost. This is the failure
-   that made Layer 2 unreachable in production for the whole of its life:
+2. Confirm it advertises its PUBLIC address, not localhost — **one request**:
+
+   ```sh
+   curl -sS https://vellar-seller-demo.onrender.com/whoami | python3 -m json.tool
+   ```
+
+   `verifiable: true` is the precondition. `resourceUrl` must be public https;
+   `commit` tells you which build is serving. Do NOT read the boot log for this —
+   it was hardcoded and lied (D-3).
+
+   The longer form, if you want to see the challenge itself:
 
    ```sh
    curl -sS -D- -o /dev/null https://vellar-seller-demo.onrender.com/quote \

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -533,6 +533,7 @@ Closed since this table was first written (kept here so the history is not lost)
 | **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement. |
 | **D-1** | Seller had a hard boot dependency on the facilitator; the facilitator has none | **closed** — warm + bounded backoff in the seller. The dependency half (@x402/core retries 429 but not 502) is upstream and unfixed here. |
 | **D-2** | F7's rate limit sustained a crash loop it could not distinguish from an attack | **closed-by-doc** — the defence belongs in the dependent, not in a weaker limiter. |
+| **D-3** | Seller's boot log hardcoded `localhost`, imitating the exact symptom of F11 Layer 2 being decorative | **closed-by-test** — one `publicBase()` source of truth, plus `GET /whoami` making advertised state queryable. |
 | **G-3** | Spend policy keyed on the raw URL while the catalog keys on the canonical one | **closed-by-test** — found by red-teaming the F12 change before it merged. |
 | **G-4** | Settlement stats writable by anyone, against any entry | **closed-by-test** — gated on the bound owner; cross-entity forgery now impossible. |
 | **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement; settle-triggered only, cooldowns asserted in outbound fetches. |

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -40,6 +40,21 @@ const FACILITATOR_URL = process.env.FACILITATOR_URL || "https://vellar-facilitat
 const PAYTO = "GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH";
 const ASSET = "CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR"; // X402TST bound token
 const PRICE_ATOMIC = process.env.PRICE_ATOMIC || "1000000";
+
+/**
+ * The address this merchant advertises as its own — the single source of truth
+ * for the 402 challenge, /whoami, and the boot log.
+ *
+ * D-3: the boot log used to print `http://localhost:${PORT}` as a HARDCODED
+ * string while the challenge correctly used PUBLIC_BASE_URL. It did not merely
+ * fail to reflect reality; it printed the precise symptom of the most serious
+ * defect in this repo (a seller advertising localhost, which makes F11 Layer 2
+ * decorative) on a service that was working correctly. Three consumers now read
+ * the same function, so they cannot disagree again.
+ */
+function publicBase() {
+  return process.env.PUBLIC_BASE_URL ?? `http://localhost:${PORT}`;
+}
 // PORT first: Render (and most PaaS) inject it and health-check that port, so
 // binding SELLER_PORT there would fail the deploy. SELLER_PORT still wins
 // locally when PORT is unset, so `docs/guide.md`'s walkthrough is unchanged.
@@ -167,8 +182,9 @@ function adapter(req) {
     // one the SSRF guard rejects as non-https before opening a socket. That is
     // why Layer 2 had never succeeded in production: not the network, this line.
     // PUBLIC_BASE_URL is how a deployed merchant declares its own address.
-    getUrl: () =>
-      `${process.env.PUBLIC_BASE_URL ?? `http://localhost:${PORT}`}${req.originalUrl}`,
+    // Via publicBase() so this can never drift from what /whoami and the boot
+    // log report — drift between exactly these is what produced D-3.
+    getUrl: () => `${publicBase()}${req.originalUrl}`,
     getAcceptHeader: () => req.get("accept") || "",
     getUserAgent: () => req.get("user-agent") || "",
     getQueryParams: () => req.query,
@@ -177,6 +193,40 @@ function adapter(req) {
 }
 
 const app = express();
+/**
+ * What this seller is ACTUALLY advertising, queryable in one unauthenticated GET.
+ *
+ * Same shape as the facilitator's /health commit field, and for the same reason:
+ * twice in one day the repo held a fix that the running service did not, and both
+ * times the only way to tell was to decode a 402 or read boot logs. Running state
+ * should be queryable, not inferred.
+ *
+ * Reports the values in USE — every field is read from the same source the 402
+ * challenge is built from, so this cannot agree with the code while disagreeing
+ * with reality. `resourceUrl` is the one that matters: if it is not public https,
+ * ownership verification can never pass and every catalog entry this seller
+ * creates is permanently unverified.
+ */
+app.get("/whoami", (_req, res) => {
+  const resourceUrl = `${publicBase()}/quote`;
+  res.json({
+    service: "vellar-seller-demo",
+    resourceUrl,
+    payTo: PAYTO,
+    asset: ASSET,
+    priceAtomic: PRICE_ATOMIC,
+    facilitatorUrl: FACILITATOR_URL,
+    // Which build is serving. Render injects RENDER_GIT_COMMIT; omitted rather
+    // than faked when absent, so a local run never claims to be a deployment.
+    ...(process.env.RENDER_GIT_COMMIT
+      ? { commit: process.env.RENDER_GIT_COMMIT.slice(0, 7) }
+      : {}),
+    // Decided here rather than by the reader: an ownership-verifiable resource
+    // URL must be public https. This is the per-settle precondition.
+    verifiable: resourceUrl.startsWith("https://") && !resourceUrl.includes("localhost"),
+  });
+});
+
 app.get("/quote", async (req, res) => {
   let result;
   try {
@@ -224,7 +274,15 @@ app.get("/quote", async (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.error(`[seller] paid API on http://localhost:${PORT}/quote`);
+  console.error(`[seller] paid API on ${publicBase()}/quote  (bound to port ${PORT})`);
+  if (!process.env.PUBLIC_BASE_URL) {
+    console.error(
+      "[seller] WARNING: PUBLIC_BASE_URL is unset, so this seller advertises localhost. " +
+        "A localhost resource URL can NEVER pass the facilitator's ownership verification " +
+        "(https-only, no loopback), so every entry it creates is permanently unverified. " +
+        "Fine locally; wrong anywhere deployed.",
+    );
+  }
   console.error(`[seller] facilitator: ${FACILITATOR_URL}`);
   console.error(`[seller] price: ${PRICE_ATOMIC} atomic of ${ASSET} -> ${PAYTO}`);
 });


### PR DESCRIPTION
## The lie

`seller.mjs` printed its banner as a **hardcoded string** — `http://localhost:${PORT}/quote` — never consulting `PUBLIC_BASE_URL`, which was read only inside `getUrl`. A correctly-configured deployed seller announced `localhost` while its actual 402 carried the public URL.

## Why it's the worst of the three artifact lies here

| Artifact | What it did |
|---|---|
| `bindLoadedEntry` comment | claimed a path that didn't exist — **misleading** |
| §4 template | gave an instruction that would fail — **wasted effort** |
| **This log line** | printed **the precise symptom of the most serious defect in this repo**, on a service that was working correctly |

It didn't just misinform — it **imitated a specific failure**, producing a false positive for the defect we'd spent the day fixing, on the one service where that defect would have invalidated the whole walkthrough. The correct response (stop, settle nothing) was triggered by an artifact describing a problem that wasn't there.

**Rule:** anything that reports state must report the state it actually has. A hardcoded string that *resembles* a real value is worse than no output — no output prompts a check; a plausible wrong value ends one.

## Fixed structurally

One `publicBase()` function is now the only source of the advertised address — read by the 402 builder, the boot log, and `/whoami`. Three consumers that can't disagree, because drift between exactly two of them caused this.

`GET /whoami` returns `resourceUrl`, `payTo`, `asset`, `facilitatorUrl`, the deployed `commit`, and a computed `verifiable` flag — same shape and reason as the facilitator's `/health` commit field.

## Verified both configurations

**Unset:** `verifiable: false`, boot log warns with the consequence.
**Set:** `/whoami`, boot log and 402 all report the same public URL.

278 passing, 3 skipped.