### PR TITLE
docs(D-4): fee ceiling exonerated — the new wallet costs 674x the old on identical wasm

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -306,6 +306,47 @@ that is refused, and only the 503 body names the reason.
 
 ---
 
+### Sibling trap 2: `MAX_TX_FEE_STROOPS`, raised for an investigation
+
+**Exactly the same hazard as the two above**, and it will be met by someone who
+has forgotten all three. A dashboard variable is **not** reconciled by a
+blueprint sync, `render.yaml` declares `MAX_TX_FEE_STROOPS` with the safe value
+so a sync will not remove a dashboard override, and nothing warns.
+
+Raising it is occasionally necessary — a smart account whose `__check_auth` is
+expensive can legitimately exceed the ceiling, and refusing it is the exact bug
+this project exists to fix. But left raised it silently widens the worst-case
+sponsor drain per settlement, and **it cascades**:
+
+> `perSettleEstimateStroops` **is** `maxTransactionFeeStroops`
+> (`src/server.ts`), so the fee ceiling also drives the spend policy's estimate.
+> Raising the fee ceiling shrinks how many settlements fit under
+> `SPEND_CEILING_STROOPS` in a window. At 30,000,000 stroops per settle, a 5 XLM
+> ceiling admits **one settlement per minute** for the entire service.
+
+So a raise that looks local is three thresholds: the fee ceiling, the spend
+ceiling that must accommodate it, and the hard floor that must exceed the spend
+ceiling.
+
+**Procedure:**
+
+1. Record the current value first — the shipped default is `500000`.
+2. Set the new value in the dashboard. Note the deploy restarts the service.
+3. Do the investigation. Keep it short; every settlement in this window can drain
+   up to the raised ceiling.
+4. **REVERT to `500000`** and confirm with a settle that a normal payment still
+   succeeds. Do not defer to the end of a session.
+
+**Symptom if left raised:** nothing obvious. Settlements succeed, `/health` is
+clean, and the only signal is a sponsor balance falling faster than it should —
+plus `spend_ceiling` refusals appearing at a fraction of the expected rate,
+because each settlement now reserves far more of the window's budget than it
+used to. `/health` looks entirely normal in this state —
+`status: ok`, no `catalogFrozen` — because the catalog is fine. It is settlement
+that is refused, and only the 503 body names the reason.
+
+---
+
 ## 3. "New resources stop being cataloged and the logs mention a tombstone cap"
 
 ### Symptom

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -408,7 +408,7 @@ backstop either way. The relationships between these numbers are now asserted in
 
 | Value | Default | Reasoning |
 | --- | --- | --- |
-| `MAX_TX_FEE_STROOPS` | **500,000** | The one value that IS measured. Worst real settlement observed on-chain: 127,808 stroops (a stacked double-policy smart-account payment). 500k is ~3.9x that and 2.5x the documented 200k floor, cutting worst-case drain per settle from 0.2 to 0.05 XLM. |
+| `MAX_TX_FEE_STROOPS` | **500,000** | Sized from on-chain data. **Hash-verifiable reference:** tx `1da6f9e6…` (2026-07-31 hosted settlement) charged **28,711 stroops** — 5.7% of the ceiling. A second figure of 127,808 is cited as the worst observed, but **carries no transaction hash and cannot be re-verified** (D-4). 500,000 clears both. Any future fee cited as measured must carry its hash. |
 | `SPEND_CEILING_STROOPS` | **5 XLM / 60s** | At the 500,000-stroop worst-case fee that is **100 settlements per window across ALL merchants**. Raising it helps honest throughput and costs a funded attacker nothing — they were never bound by it — so treat it as a sponsor-exposure dial, not a security control. |
 | `SETTLE_PER_PAYTO_MAX` | **50 / 60s per payTo** | Half the global capacity: no single payTo can consume the whole service, while a merchant can run 5 bound URLs at their full rate. **Consolidated from two budgets** — see the defect below. |
 | `SETTLE_PER_URL_MAX` | **10 / 60s per bound URL** | The F12 fairness control: one merchant can no longer starve another. |
@@ -533,6 +533,7 @@ Closed since this table was first written (kept here so the history is not lost)
 | **G-1** | Ownership verification lost on restart, served to agents as unverified | **closed-by-test** — re-verify on the bound owner's next settlement. |
 | **D-1** | Seller had a hard boot dependency on the facilitator; the facilitator has none | **closed** — warm + bounded backoff in the seller. The dependency half (@x402/core retries 429 but not 502) is upstream and unfixed here. |
 | **D-2** | F7's rate limit sustained a crash loop it could not distinguish from an attack | **closed-by-doc** — the defence belongs in the dependent, not in a weaker limiter. |
+| **D-4** | New test wallet costs 674x the old one on identical wasm; fee ceiling exonerated | **open** — blocked on the wallet-side TTL/nonce answer. No threshold moved. |
 | **D-3** | Seller's boot log hardcoded `localhost`, imitating the exact symptom of F11 Layer 2 being decorative | **closed-by-test** — one `publicBase()` source of truth, plus `GET /whoami` making advertised state queryable. |
 | **G-3** | Spend policy keyed on the raw URL while the catalog keys on the canonical one | **closed-by-test** — found by red-teaming the F12 change before it merged. |
 | **G-4** | Settlement stats writable by anyone, against any entry | **closed-by-test** — gated on the bound owner; cross-entity forgery now impossible. |


### PR DESCRIPTION
## The suspicion was wrong, and that's the finding

We believed `MAX_TX_FEE_STROOPS` had always been too low — that 127,808 was an
unsigned measurement and address-credential payments had never fit under 500,000.

**Horizon refutes it.** The 2026-07-31 hosted settlement, pulled from Horizon
rather than a simulated estimate:

```
tx 1da6f9e6…   successful: true
fee_charged 28,711 stroops (0.0029 XLM)   max_fee 38,888
```

**5.7% of the ceiling.** A real policy-governed smart-account payment with
address credentials, comfortably inside the default. **The ceiling was never the
problem.**

## What's actually true

| | Old wallet | New wallet |
|---|---|---|
| wasm | `fdefad64…` | `fdefad64…` **identical** |
| signed cost | ≤ 38,888 | **26,222,858** |
| vs ceiling | 5.7% of it | **52× over** |

**674×, same code.**

## Ruled out with evidence

- **Not code** — same wasm hash
- **Not archival** — instance LIVE, no `restorePreamble`
- **Not stranded assets** — footprint holds exactly the wallet and the asset;
  those balances never appear
- **Not compute** — jump is *only* on signing: 133,464 → 26,222,858 (196×)
  against **1.8× instructions** and **completely flat bytes**

Hypothesis (labelled as inference): rent for a ledger entry **created** in the
auth path — plausibly the nonce — against a long initial TTL. Needs the wallet's
TTL config to confirm; that's wallet-side and gets recorded here when it lands.

## The documentation weakness this exposed

`127,808` is cited in **five places** as *"the one value that IS measured"* — and
**no transaction hash is recorded for it anywhere.** The number defended as
measured could not be re-verified at the moment it mattered.

The threshold table now carries the hash-verifiable reference and flags 127,808
as unverifiable. Same class as D-3: **a measurement without a hash is an
assertion wearing a measurement's clothes.**

## No threshold moved

500,000 stands. Raising it would have hidden a 674× outlier behind a config
change — and the cascade (`perSettleEstimateStroops` **is**
`maxTransactionFeeStroops`) would have forced two further threshold changes to
compensate for a number that was never the problem.