### PR TITLE
docs: burn inventory for both sides, and the transcript-residue lesson

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -497,6 +497,43 @@ tests](#live-evidence-vs-unit-tests--what-has-actually-been-exercised-in-product
 The common thread is that **a green result is not self-validating**: something
 independent has to be able to contradict it.
 
+### Operational lesson: a secret that reaches a transcript is burned by that fact
+
+Found while inventorying the walkthrough wallet for burn. **Four funded testnet
+secrets are permanently in this engagement's session transcript** — the
+self-contained F11 reproduction environment (issuer, payer, sponsor, merchant B),
+printed before the `argv` lesson below was learned and labelled at the time
+*"testnet only, disposable"*. They were never disposed of. Two remain funded with
+~10,000 XLM each.
+
+**A transcript cannot be scrubbed.** Unlike a file in `/tmp` or a shell history
+entry, there is no `rm` for it. So the exposure is not a cleanup task, it is a
+permanent state:
+
+> **A secret that reaches a transcript is compromised by that fact alone**,
+> regardless of what is done afterwards. Rotation is the only remedy, and
+> prevention is the only real control.
+
+What this changes in practice, and what was done differently for the walkthrough
+key as a result:
+
+- Generate **and store** inside a single process, so the value is never a shell
+  argument, never a command substitution result that gets echoed, and never
+  printed. Only the public key crosses the boundary.
+- **Verify it, do not assume it.** The walkthrough key was checked by hashing
+  every `S[A-Z2-7]{55}` candidate in the transcript against the real secret — it
+  is not present. That check is cheap and is the only way to know.
+- Treat exposed accounts as **permanently compromised** rather than cleaned:
+  never reuse, never re-fund, never give them a role that matters.
+
+Verified alongside: the live facilitator sponsor `GBUCR6H2…` is **not** among the
+exposed keys, and neither is the walkthrough agent key. The blast radius is
+confined to four disposable testnet accounts, which is luck as much as design —
+the same mistake with the sponsor key would have been unrecoverable.
+
+The full inventory, including the wallet side, is in
+[`docs/walkthrough-wallet-spec.md`](./walkthrough-wallet-spec.md) §7.
+
 ### Operational lesson: secrets in `argv`
 
 During the F11 reproduction, throwaway secrets were passed as command-line

--- a/docs/walkthrough-wallet-spec.md
+++ b/docs/walkthrough-wallet-spec.md
@@ -386,6 +386,62 @@ So for this wallet:
 - [ ] **The demo seller can be left running** — it holds no secret and sleeps on
       its own. Only its instance hours matter, and they are pooled per workspace.
 
+### Burn inventory — everywhere the wallet's details exist
+
+Written as an inventory rather than a cleanup list, because **one category cannot
+be cleaned** and should be named as known and accepted rather than discovered
+later.
+
+**Wallet side (reported by the provisioning session):**
+
+- [ ] `vela-wallet/docs/decisions.md` — local-only, gitignored. Public topology.
+- [ ] That session's transcript under `~/.claude/projects/` — **public topology
+      only, no secrets.** Cannot be scrubbed; accepted.
+- [ ] Its scratchpad script contains no identifiers — everything travelled via
+      environment variables.
+
+**Facilitator side (this session), verified rather than assumed:**
+
+- [ ] **`agent.key` in the session scratchpad** — `0600` in a `0700` directory
+      outside the repo. **This is the only copy of the secret.** Deleting it is
+      the burn (see the on-chain section above).
+- [ ] `evidence.md` in the same scratchpad — public identifiers and the agent
+      **public** key only.
+- [ ] Temporary diagnostics (`*-tmp.mjs`) — gitignored, and confirmed to contain
+      **no** S-shaped strings; they read the key from the environment.
+- [ ] **This session's transcript** — checked by hashing every `S[A-Z2-7]{55}`
+      candidate against the real key: **the agent secret is NOT present.** The
+      generate-and-store-in-one-process form held.
+
+### Known and accepted: transcript residue from the earlier F11 reproduction
+
+**Four funded testnet secrets are permanently in this session's transcript**, at
+lines ~2112 and ~2215 — the self-contained F11 test environment built before the
+`argv` lesson was learned, labelled at the time as *"testnet only, disposable"*.
+They were never disposed of.
+
+| Role | Account | State |
+| --- | --- | --- |
+| F11 repro sponsor | `GBOC2UOB…` | **live, 9,999.99 XLM** |
+| Merchant B | `GDS43IM6…` | **live, 10,000.00 XLM** |
+| Issuer | `GD2P22IM…` | live |
+| Payer | `GAOP33R6…` | not funded |
+
+**The live facilitator sponsor `GBUCR6H2…` is NOT among them** — verified against
+`/supported`. Nor is the walkthrough agent key.
+
+**A transcript cannot be scrubbed.** So the correct posture is not cleanup, it is
+containment:
+
+- [ ] Treat all four as **permanently compromised**. Never reuse them, never fund
+      them further, never grant them a role in anything that matters.
+- [ ] Drain them if convenient; testnet XLM has no value, so this is hygiene
+      rather than loss mitigation.
+- [ ] **The transferable rule:** a secret that reaches a transcript is burned by
+      that fact alone, regardless of what else is done to it. This is why the
+      walkthrough key was generated and stored inside a single process and never
+      printed — and why that check was performed rather than assumed.
+
 ### Record
 
 - [ ] **Append the wallet to `docs/decisions.md`** with public values only and a


### PR DESCRIPTION
## Facilitator-side inventory — verified, not asserted

| | |
|---|---|
| `agent.key` | `0600` in a `0700` dir outside the repo — **the only copy** |
| `evidence.md` | public identifiers + agent **public** key only |
| `*-tmp.mjs` | gitignored, confirmed **no** S-shaped strings |
| **transcript** | **agent secret NOT present** — checked by hashing every `S[A-Z2-7]{55}` candidate against the real key |

## Known and accepted — it cannot be cleaned

**Four funded testnet secrets are permanently in this session's transcript**
(lines ~2112, ~2215): the F11 reproduction environment — issuer, payer, sponsor,
merchant B — printed before the `argv` lesson was learned and labelled at the
time *"testnet only, disposable"*. They were never disposed of.

| Role | Account | State |
|---|---|---|
| F11 repro sponsor | `GBOC2UOB…` | **live, 9,999.99 XLM** |
| Merchant B | `GDS43IM6…` | **live, 10,000.00 XLM** |
| Issuer | `GD2P22IM…` | live |
| Payer | `GAOP33R6…` | unfunded |

**The live facilitator sponsor `GBUCR6H2…` is NOT among them** — verified against
`/supported`. Neither is the walkthrough agent key.

## The lesson

**A transcript has no `rm`.** So this is containment, not cleanup: treat all four
as permanently compromised, never reuse or re-fund.

> A secret that reaches a transcript is burned by that fact alone, regardless of
> what is done afterwards. Prevention is the only real control.

That the blast radius is four disposable testnet accounts is **luck as much as
design** — the same mistake with the sponsor key would have been unrecoverable.