### PR TITLE
fix(store): one round trip per binding — the Tokyo/Oregon hop breaks the chatty form

### DIFF
--- a/docs/brief-turso-migration.md
+++ b/docs/brief-turso-migration.md
@@ -282,11 +282,60 @@ the broken version is not evidence:
 
 ---
 
-## 7. The four numbers — APPROVED 2026-08-11
+## 6b. Latency — Tokyo database, Oregon service
 
-All four as proposed. They live in `PROPOSED_TIMINGS` (`src/store.ts`) so a
-review is one diff, and so none of them can acquire a second, quietly-different
-value the way `SETTLE_RATE_MAX` once shadowed `SETTLE_PER_PAYTO_MAX`.
+The database was created in **ap-northeast-1 (Tokyo)** and the service runs in
+**Oregon**: ~100–150ms each way, ~250ms round trip. Checked against that rather
+than assumed, because the numbers were already merged.
+
+**What the settle path actually costs.** `bindOwnership` is awaited **only on
+first catalog** — so the transpacific cost is paid **once per URL, not once per
+payment**:
+
+| | Added to the settle response |
+| --- | --- |
+| **First** settlement for a URL | **one round trip, ~250ms** |
+| Every later settlement | **zero** — the entry write is debounced and fire-and-forget |
+
+Against a measured ~8s end-to-end settle that is ~3% on one settlement per URL,
+and it lands *after* the payment is final on-chain. Boot costs two round trips
+(~500ms) against a ~35s cold start.
+
+**The timeout holds — but only after a change.** `bindAndUpsertEntry` was an
+*interactive* transaction: open, execute, execute, commit — up to four round
+trips, ~1s of a 2s budget spent on protocol before the query runs. It is now a
+single `batch(..., "write")`, which libSQL wraps in an implicit transaction, so
+the atomicity guarantee is unchanged and the cost is one request. **2,000ms then
+carries ~8× headroom.**
+
+Two problems that fix independently of distance:
+
+- an interactive transaction holds a **write lock** until it commits (libSQL
+  times it out at 5s), so concurrent first-settles for *different* URLs
+  serialised on it — each holding it for ~1s across the Pacific;
+- our timeout raced the whole block, so a timeout abandoned an **open**
+  transaction and the rollback never ran. A batch has nothing to leave open.
+
+**The backoff's first step moved 200ms → 500ms.** At a ~250ms baseline, 200ms
+retried before a merely-slow network could have answered — a second attempt at
+the same instant rather than a wait for the condition to pass. These fire only at
+**boot**; nothing on the settle path retries, so no payment can be lengthened by
+them. Worst case to freeze: ~11.5s.
+
+**The bigger lever, if you want it:** the catalog is empty, so recreating the
+database in a region near Oregon costs nothing to migrate and takes the round
+trip from ~250ms to ~10–20ms. The batch change is right either way — it is a
+correctness fix as much as a latency one — but region choice is the difference
+between "fine" and "not a consideration".
+
+## 7. The four numbers — APPROVED 2026-08-11, one revised
+
+All four as proposed, with **one revised after the region was known**: the retry
+backoff is now **500/1000/2000**, not 200/600/1800 (§6b). They live in
+`PROPOSED_TIMINGS` (`src/store.ts`) so a review is one diff, and so none of them
+can acquire a second, quietly-different value the way `SETTLE_RATE_MAX` once
+shadowed `SETTLE_PER_PAYTO_MAX`. The backoff is pinned by a test, which is what
+caught the change rather than letting it pass silently.
 
 1. **Connection/query timeout to Turso on the settle path.** Recommend **2000 ms**
    — it sits after on-chain settlement, so it delays a response but cannot fail a

--- a/src/store.durability.test.ts
+++ b/src/store.durability.test.ts
@@ -203,7 +203,10 @@ describe("fail closed, with the right diagnosis", () => {
     ).rejects.toBeInstanceOf(StoreUnreachableError);
 
     expect(attempts, "first attempt plus the approved 3 retries").toBe(4);
-    expect(sleeps, "the approved backoff, in order").toEqual([200, 600, 1800]);
+    // Pinned deliberately. The first step is 500ms, not 200ms, because the
+    // baseline round trip to Tokyo is ~250ms and a 200ms backoff retried before
+    // a merely-slow network could have answered.
+    expect(sleeps, "the approved backoff, in order").toEqual([500, 1000, 2000]);
   });
 
   it("an INVALID store is never retried — the same query returns the same bad answer", async () => {
@@ -268,6 +271,46 @@ describe("fail closed, with the right diagnosis", () => {
     // recordSettlement is the settlement-side call; it must not throw either.
     expect(() => catalog.recordSettlement(URL_A, "CPAYER", "GANY")).not.toThrow();
     vi.restoreAllMocks();
+  });
+});
+
+describe("round trips — the cost that only shows up across an ocean", () => {
+  it("a first binding costs exactly ONE request, not an interactive transaction", async () => {
+    // MUTATION — restore the interactive form: `client.transaction("write")`,
+    // two execute()s, commit(). This test then counts 4 calls instead of 1, and
+    // sees a transaction() opened.
+    //
+    // Why a test and not a comment: the difference is invisible locally, where
+    // four round trips cost microseconds. It is only expensive at distance, and
+    // an in-datacenter test run would never notice a regression back to the
+    // chatty form. With the database in Tokyo and the service in Oregon
+    // (~250ms), four round trips is ~1s of a 2s timeout spent on protocol.
+    const { store, url } = tmpStore();
+    await store.init();
+    const inner = reopen(url) as unknown as { client: Record<string, unknown> };
+    const calls: string[] = [];
+    const real = inner.client;
+    inner.client = new Proxy(real, {
+      get(target, prop: string) {
+        const v = (target as Record<string, unknown>)[prop];
+        if (typeof v === "function" && ["batch", "execute", "transaction"].includes(prop)) {
+          return (...args: unknown[]) => {
+            calls.push(prop);
+            return (v as (...a: unknown[]) => unknown).apply(target, args);
+          };
+        }
+        return v;
+      },
+    }) as Record<string, unknown>;
+
+    await (inner as unknown as { bindAndUpsertEntry: typeof store.bindAndUpsertEntry }).bindAndUpsertEntry(
+      { resourceKey: URL_A, boundPayTo: ["GOWNER"] },
+      { resourceKey: URL_A, payload: "{}", lastUpdated: 1 },
+    );
+
+    expect(calls, "one batch, no interactive transaction").toEqual(["batch"]);
+    // ...and it is still atomic: the batch really wrote both rows.
+    expect(await readOwnership(url)).toEqual([{ resourceKey: URL_A, boundPayTo: ["GOWNER"] }]);
   });
 });
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -103,9 +103,19 @@ export interface StoreTimings {
 }
 
 export const PROPOSED_TIMINGS: StoreTimings = {
+  // Holds at transpacific distance BECAUSE every store operation is now a single
+  // round trip. At ~250ms Oregon<->Tokyo that is ~8x headroom. It did NOT hold
+  // against the interactive transaction this replaced (~1s of protocol inside a
+  // 2s budget), which is why the shape changed rather than the number.
   timeoutMs: 2_000,
   retryAttempts: 3,
-  retryBackoffMs: [200, 600, 1_800],
+  // First step raised 200 -> 500 so it is at least ONE round trip. At a ~250ms
+  // baseline, a 200ms backoff retried before a merely-slow network could have
+  // answered — it was a second attempt at the same instant rather than a wait
+  // for the condition to pass. These fire only at BOOT (loadOwnership /
+  // loadEntries); nothing on the settle path retries, so this cannot lengthen a
+  // payment. Worst case to freeze: 4 attempts x 2s + 3.5s of backoff = ~11.5s.
+  retryBackoffMs: [500, 1_000, 2_000],
 };
 
 /** Anything that is not clearly a bad answer is treated as unreachable, because
@@ -263,26 +273,48 @@ export class LibsqlCatalogStore implements CatalogStore {
     });
   }
 
+  /**
+   * ONE ROUND TRIP, and that is the whole point of using batch() here.
+   *
+   * This was an INTERACTIVE transaction — `transaction("write")`, two
+   * `execute()`s, `commit()` — which is a "chat" with the database: up to four
+   * round trips. Fine across a datacenter, wrong across an ocean. With the
+   * database in Tokyo and the service in Oregon (~250ms round trip) that is
+   * ~1s of the 2s timeout spent on protocol alone, before the query runs.
+   *
+   * batch(..., "write") gives the SAME atomicity — libSQL wraps a batch in an
+   * implicit transaction, committing all statements or rolling back all of them
+   * — in a single request. Nothing is traded away for the latency.
+   *
+   * Two further problems the interactive version had, independent of distance:
+   *
+   *   - An interactive transaction holds a WRITE LOCK on the database until it
+   *     commits (libSQL times it out after 5s). Concurrent first-settles for
+   *     DIFFERENT URLs therefore serialise on that lock, and across a
+   *     transpacific hop each one holds it for ~1s.
+   *   - Our own timeout raced the whole block, so a timeout abandoned an OPEN
+   *     transaction: the rollback in the catch never ran, and the lock was held
+   *     until the server timed it out. A batch is one request with nothing to
+   *     leave open.
+   */
   async bindAndUpsertEntry(binding: StoredOwnership, entry: StoredEntryRow): Promise<void> {
-    await this.run(async () => {
-      const tx = await this.client.transaction("write");
-      try {
-        await tx.execute({
-          sql: "INSERT INTO ownership (resource_key, pay_to, bound_at) VALUES (?, ?, ?)",
-          args: [binding.resourceKey, binding.boundPayTo[0] ?? "", Date.now()] as InArgs,
-        });
-        await tx.execute({
-          sql: `INSERT INTO entry (resource_key, payload, last_updated) VALUES (?, ?, ?)
-                ON CONFLICT(resource_key) DO UPDATE SET payload = excluded.payload,
-                                                        last_updated = excluded.last_updated`,
-          args: [entry.resourceKey, entry.payload, entry.lastUpdated] as InArgs,
-        });
-        await tx.commit();
-      } catch (err) {
-        await tx.rollback().catch(() => {});
-        throw err;
-      }
-    });
+    await this.run(() =>
+      this.client.batch(
+        [
+          {
+            sql: "INSERT INTO ownership (resource_key, pay_to, bound_at) VALUES (?, ?, ?)",
+            args: [binding.resourceKey, binding.boundPayTo[0] ?? "", Date.now()] as InArgs,
+          },
+          {
+            sql: `INSERT INTO entry (resource_key, payload, last_updated) VALUES (?, ?, ?)
+                  ON CONFLICT(resource_key) DO UPDATE SET payload = excluded.payload,
+                                                          last_updated = excluded.last_updated`,
+            args: [entry.resourceKey, entry.payload, entry.lastUpdated] as InArgs,
+          },
+        ],
+        "write",
+      ),
+    );
   }
 
   async saveEntries(rows: StoredEntryRow[]): Promise<void> {


### PR DESCRIPTION
Answering the latency question changed the code, so here it is rather than a "holds, go ahead".

## The timeout holds — but only after this change

`bindAndUpsertEntry` was an **interactive transaction**: open, execute, execute, commit. libSQL's own docs call that a *"chat"* with the database and warn it *"can impact performance on high-latency… databases"*. At ~250ms Oregon↔Tokyo that's **~1s of a 2s budget spent on protocol** before the query runs.

Now a single `batch(..., "write")` — which libSQL wraps in an implicit transaction, so **atomicity is unchanged** and the cost is one request. 2,000ms carries **~8× headroom** instead of ~2×.

Two problems this fixes independent of distance:

- an interactive transaction holds a **write lock** until commit (5s server timeout), so concurrent first-settles for *different* URLs serialised on it — each holding it ~1s across the Pacific;
- our timeout raced the whole block, so a timeout **abandoned an open transaction** — the rollback in the `catch` never ran, and the lock was held until the server killed it. A batch has nothing to leave open.

## Backoff: 200 → 500ms first step

At a ~250ms baseline, a 200ms backoff retried *before a merely-slow network could have answered* — a second attempt at the same instant rather than a wait for the condition to pass. These fire **only at boot**; nothing on the settle path retries, so no payment can be lengthened. Worst case to freeze ~11.5s.

The pinning test failed on this change, which is the test doing its job — approved numbers don't move silently.

## What a settle actually costs

`bindOwnership` is awaited **only on first catalog**, so the transpacific cost is **once per URL, not once per payment**:

| | Added to the settle response |
|---|---|
| **First** settlement for a URL | ~250ms (one round trip) |
| Every later settlement | **zero** — entry writes are debounced, fire-and-forget |

~3% of a measured ~8s settle, on one settlement per URL, landing *after* the payment is final on-chain. Boot costs two round trips against a ~35s cold start.

## Tests

285 passing. New test **counts round trips** by proxying the client, mutation-verified against a revert to the interactive form. It exists because the difference is **invisible locally** — four round trips cost microseconds in-process, so a regression to the chatty shape would never be caught by a test run in one datacenter.