### PR TITLE
feat(catalog): G-2 displacement — proof takes an unverified binding

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -12,8 +12,45 @@ identical from the outside and have opposite fixes.
 
 ## 1. "My payments settle, but the catalog still lists my old payment address"
 
-This is **G-2**: a resource URL's `payTo` is bound on first use and there is no
-in-band way to rotate it.
+This is **G-2**: a resource URL's `payTo` is bound on first use.
+
+> ### FIRST: check whether you need to do anything at all
+>
+> Since displacement shipped, **this procedure covers only half the cases it used
+> to.** The other half now resolves itself, and running the manual procedure on
+> it would be wasted work at best.
+>
+> ```
+> curl -sS '<base>/discovery/resources' | python3 -m json.tool | grep -i ownerVerified
+> ```
+>
+> | What you see | What it means | What to do |
+> | --- | --- | --- |
+> | `ownerVerified: false` on the entry | The binding was **never proven**. The rightful owner takes it back **automatically** by settling once, provided their endpoint's own 402 challenge names their address. | **Nothing.** Tell them to settle once and re-check. See below for why it may not have happened yet. |
+> | `ownerVerified: true` | The binding **was proven** by the address currently bound. Displacement will not touch it — deliberately, because proof does not displace proof. | **This procedure.** |
+>
+> **The distinction is proof, not identity.** An unverified binding is arrival
+> order — whoever settled first — which is evidence of nothing, so a claimant who
+> can prove ownership outranks it. A verified binding is evidence, and a domain
+> genuinely changing hands is indistinguishable from a hijack, so that case stays
+> with you.
+>
+> **If it is unverified and displacement has not happened**, the usual reasons, in
+> order of likelihood:
+> - **The merchant has not settled since.** The check fires on their settlement;
+>   nothing runs on a timer.
+> - **Their endpoint does not name the new address in its own 402.** That is the
+>   proof, and without it there is nothing to act on — this is the same condition
+>   that makes the check safe.
+> - **They are inside the cooldown** from a recent failed attempt. Keyed per
+>   claimant, so ask them to wait it out and settle again.
+> - **The URL is not fetchable** — http, a private address, or a route template.
+>   `/health` reports `unverifiableEntries` when this is the case, and procedure 6
+>   covers it.
+>
+> One thing that is NOT a reason: a squatter holding the URL. Displacement exists
+> exactly for that, and the squatter's binding is unverified by construction —
+> they cannot serve a 402 naming themselves from a domain they do not control.
 
 ### Symptom
 
@@ -142,6 +179,12 @@ memory and will overwrite a live hand-edit.
 6. **Start the service.**
 
 ### Verify
+
+0. **Sanity: you should only be here for a VERIFIED binding.** If
+   `ownerVerified` was `false`, stop and re-read the box at the top of this
+   procedure — you have done by hand what the service would have done on the
+   merchant's next settlement, and you have done it on the weaker evidence of an
+   out-of-band conversation rather than a 402 challenge.
 
 1. `/health` must **not** report a frozen catalog:
    ```

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -883,7 +883,7 @@ change.
 
 | ID | Finding | Why |
 | --- | --- | --- |
-| **G-2** | A bound URL has no `payTo` rotation path | **open** — manual operator procedure documented (runbook §1); the automated fix trades away F11's takeover resistance and is deliberately not built. |
+| **G-2** | A bound URL has no `payTo` rotation path | **half closed.** Displacement (2026-08-11) handles the UNVERIFIED case automatically: a claimant who proves ownership through the resource's own 402 challenge takes a binding that was never proven. The VERIFIED case stays manual (runbook §1) — proof does not displace proof, so a domain that genuinely changed hands is still indistinguishable from a hijack and still an operator decision. |
 | **G-5** | Empty-`accepts` entry loads with no tombstone and is then unclaimable forever | **open** — reachable only by someone who can already write `CATALOG_FILE`. |
 | **G-6** | `MAX_ENTRIES` not enforced on the load path | **open** — a large `CATALOG_FILE` is an unbounded startup memory load. |
 | **G-7** | Bootstrap-derived bindings are seeded in memory but not written | **open** — undercuts the one-boot bootstrap procedure; runbook §2 tells the operator to verify the file before removing the flag. |
@@ -1142,7 +1142,55 @@ being picked here.
 
 </details>
 
-### G-2 — A bound URL has no `payTo` rotation path — **Medium** — **OPEN**
+### G-2 — A bound URL has no `payTo` rotation path — **Medium** — **HALF CLOSED (displacement, 2026-08-11)**
+
+#### What displacement changed, and what it deliberately did not
+
+**The rule.** A settle arrives for a URL whose binding was never verified, and the
+claimant proves ownership by serving a 402 challenge naming their payTo. The URL
+rebinds to them. **Unverified → verified only.**
+
+This is **proof beats no-proof**, not proof beats proof. An unverified binding is
+arrival order — whoever settled first — which is evidence of nothing. A verified
+binding *is* evidence. The takeover case refused as 2C stays refused, and for the
+original reason: a domain changing hands and a domain being hijacked are
+indistinguishable from here.
+
+**Three things it turns out this needed, none of them obvious from the rule:**
+
+1. **A durable `verified_at`, and it is not an RA-9 regression.** `verifiedOwner`
+   lives on the ENTRY and is ephemeral by design. `evictToCap()` drops entries
+   while ownership survives, so a re-catalog after eviction rebuilds the badge as
+   `false` — which would have made **eviction a downgrade primitive**: fill the
+   catalog to `MAX_ENTRIES`, evict the victim, displace their proven binding.
+   Restart had the same effect. Displaceability therefore reads a durable
+   `ownership.verified_at`, while the served badge stays ephemeral and re-derived.
+   Two facts, two lifetimes. Forging the durable one requires database write
+   access, and anyone with that can rewrite `pay_to` directly — strictly less
+   work — so it grants no new capability. **RA-9 is unchanged: the badge is still
+   never trusted from storage.**
+2. **The rows are REPLACED, not updated and not appended.** `pay_to` is half the
+   primary key and a URL may legally carry several rows (a §1 rotation produces
+   `[OLD, NEW]`), so an `UPDATE` would leave the displaced squatter bound as a
+   secondary payee. An append is worse: rows load ordered by `bound_at` and
+   `boundPayTo[0]` is the owner, so the proven claimant would be added *underneath*
+   the party they just displaced. It is `DELETE` + `INSERT` in one batch, and the
+   batch matters — this table is the tombstone record, so a moment with zero rows
+   is a moment when anyone can claim the URL.
+3. **Cooldowns are keyed by (url, payTo), not url.** A per-URL key would let an
+   attacker's failed attempt park the URL and block the real owner's legitimate
+   one — a cheap denial of the recovery path, aimed at the party it exists for.
+
+**Stats are RESET on displacement.** The trust block answers "what is this
+merchant's history", and after displacement the merchant is a different party.
+G-4 established that a bound owner can inflate their own counters, so inheriting
+them would let a squatter manufacture a reputation and hand it to the victim,
+while consumers read someone else's activity as the current merchant's record.
+
+**Still open, and unchanged by this:** rotating a payTo on a **verified** binding.
+That is runbook §1, and the procedure now opens by telling the operator how to
+tell which case they have — because for the unverified half, the right action is
+to do nothing.
 
 Confirmed: once `ownership.set(url, [payTo])` happens, the binding is never
 appended to or replaced except by reading the ownership file from disk. There is

--- a/src/bazaar.ts
+++ b/src/bazaar.ts
@@ -80,6 +80,17 @@ export function registerBazaar(
       // binding internally. The binding is deliberately NOT passed in or handed
       // out — entry.boundPayTo aliases the ownership tombstone, so exposing it
       // would put a durable rebinding primitive one `.push()` away.
+      // G-2 displacement: a claimant who can PROVE ownership takes an unverified
+      // binding. Same fire-and-forget contract as reverify, and for the same
+      // reason — this probes a merchant's endpoint, and settlement must never
+      // wait on it. The two are mutually exclusive in practice: reverify only
+      // acts when the settler IS bound, tryDisplace only when they are NOT.
+      void catalog
+        .tryDisplace(discovered.resourceUrl, requirements.payTo, requirements, discovered, verifyOwnership)
+        .catch((err) => {
+          console.warn(`[bazaar] displacement check failed for ${discovered.resourceUrl}:`, err);
+        });
+
       void catalog
         .reverify(discovered.resourceUrl, requirements.payTo, verifyOwnership)
         .catch((err) => {

--- a/src/catalog.bootstrap-persist.test.ts
+++ b/src/catalog.bootstrap-persist.test.ts
@@ -123,7 +123,7 @@ describe("the ownership bootstrap hatch no longer exists", () => {
     );
     const rows = await readOwnership(url);
     expect(rows, "the binding must be durable before anything relies on it").toEqual([
-      { resourceKey: "https://api.example.com/weather", boundPayTo: ["GOWNER"] },
+      { resourceKey: "https://api.example.com/weather", boundPayTo: ["GOWNER"], everVerified: false },
     ]);
   });
 });

--- a/src/catalog.displacement.test.ts
+++ b/src/catalog.displacement.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { BazaarCatalog } from "./catalog.js";
+import { readOwnership, reopen, tmpStore } from "./store.testkit.js";
+
+// ============================================================================
+// G-2 displacement — proof beats no-proof, and never proof beats proof.
+//
+// THE RULE: a claimant whose payTo appears in the resource's own 402 challenge
+// displaces a binding that was NEVER proven. Unverified -> verified only.
+//
+// An unverified binding is arrival order — whoever settled first — which is not
+// evidence. A verified binding is evidence, and stays. The takeover case refused
+// as 2C is still refused.
+//
+// Every test names the mutation that must break it. This repo's history is the
+// argument for that: Layer 2 was decorative for its whole life while 22 mocked
+// tests stayed green, and a fail-closed path that silently fails open is the
+// failure this whole area exists to prevent.
+// ============================================================================
+
+const URL_V = "https://api.victim.example/quote";
+const A = "GAREALOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const B = "GBSQUATTERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const C = "GCTHIRDPARTYCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC";
+
+function disc(url = URL_V): DiscoveredResource {
+  return {
+    resourceUrl: url,
+    x402Version: 2,
+    discoveryInfo: { input: { type: "http", method: "GET" } },
+  } as unknown as DiscoveredResource;
+}
+function reqs(payTo: string, asset = "CASSET"): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset,
+    amount: "1",
+    payTo,
+    maxTimeoutSeconds: 60,
+  } as unknown as PaymentRequirements;
+}
+
+/** A verifier that answers `match` only for the addresses the endpoint really
+ *  names — i.e. a real 402 challenge, not a rubber stamp. */
+function endpointNaming(...owners: string[]) {
+  const calls: { url: string; payTos: string[] }[] = [];
+  return {
+    calls,
+    fn: async (url: string, payTos: string[]) => {
+      calls.push({ url, payTos });
+      return payTos.some((p) => owners.includes(p)) ? ("match" as const) : ("mismatch" as const);
+    },
+  };
+}
+
+describe("G-2 — the scenario demonstrated live on 2026-08-11", () => {
+  it("empty catalog, B binds unverified, A displaces B and accepts flips to A", async () => {
+    // This is the walkthrough, reproduced: B settled first against an empty
+    // catalog and took the victim's URL; A — the real owner, settling through
+    // its own seller — was locked out and its own payment did not correct it.
+    //
+    // MUTATION THAT MUST BREAK THIS: delete the `verdict !== "match"` early
+    // return in tryDisplace, or remove the tryDisplace call from bazaar.ts. The
+    // binding stays on B and `accepts` never flips.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+
+    // B settles first. TOFU binds the victim's URL to the squatter.
+    expect(await catalog.upsertFromPayment(disc(), reqs(B)), "B wins the race").toBe(true);
+    expect(catalog.isBound(URL_V, B)).toBe(true);
+    expect(catalog.isEverVerified(URL_V), "arrival order is not proof").toBe(false);
+
+    // A settles. The upsert is refused — A is not bound — exactly as observed.
+    expect(await catalog.upsertFromPayment(disc(), reqs(A)), "the real owner is refused").toBe(false);
+    expect(catalog.list().items[0]!.accepts.map((x) => x.payTo)).toEqual([B]);
+
+    // The endpoint is A's, and its 402 names A.
+    const v = endpointNaming(A);
+    const outcome = await catalog.tryDisplace(URL_V, A, reqs(A), disc(), v.fn);
+
+    expect(outcome).toBe("displaced");
+    expect(v.calls[0]!.payTos, "the probe asks about the CLAIMANT, not the bound set").toEqual([A]);
+    expect(catalog.isBound(URL_V, A), "A owns it").toBe(true);
+    expect(catalog.isBound(URL_V, B), "B does not, and is not a secondary payee either").toBe(false);
+    expect(
+      catalog.list().items[0]!.accepts.map((x) => x.payTo),
+      "accepts flipped to A",
+    ).toEqual([A]);
+    expect(catalog.isVerifiedOwner(URL_V), "and it is verified, because we just proved it").toBe(true);
+  });
+
+  it("a squatter's endpoint cannot rubber-stamp itself into keeping the URL", async () => {
+    // The probe passes ONLY the claimant's address. If it passed the bound set,
+    // a squatter's own endpoint could answer "match" for the address it names
+    // and the check would confirm whatever it was already told.
+    //
+    // MUTATION: pass `[...entry.boundPayTo, claimant]` to verify(). This test
+    // then displaces to C on an endpoint that names only B.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+
+    const v = endpointNaming(B); // the endpoint names the SQUATTER
+    expect(await catalog.tryDisplace(URL_V, C, reqs(C), disc(), v.fn)).toBe("refused");
+    expect(catalog.isBound(URL_V, B), "unchanged").toBe(true);
+    expect(catalog.isBound(URL_V, C)).toBe(false);
+  });
+});
+
+describe("one-way — proof never displaces proof", () => {
+  it("a VERIFIED binding is never displaceable, even by a claimant who proves ownership", async () => {
+    // The 2C takeover case, still refused. A domain that changes hands is
+    // indistinguishable from a hijack, so the answer stays "an operator decides".
+    //
+    // MUTATION: remove the `everVerified.has(key)` gate in tryDisplace. C then
+    // takes a URL whose owner had proven ownership — which is the whole property
+    // this design refuses to give up.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(A));
+    await catalog.reverify(URL_V, A, endpointNaming(A).fn);
+    expect(catalog.isEverVerified(URL_V)).toBe(true);
+
+    const v = endpointNaming(C); // C genuinely controls the endpoint now
+    expect(await catalog.tryDisplace(URL_V, C, reqs(C), disc(), v.fn)).toBe("skipped");
+    expect(v.calls.length, "and it must not even PROBE — a refusal it cannot act on is wasted traffic").toBe(0);
+    expect(catalog.isBound(URL_V, A)).toBe(true);
+  });
+
+  it("EVICTION cannot downgrade a verified binding back to displaceable", async () => {
+    // THE ATTACK THIS FILE EXISTS FOR.
+    //
+    // `verifiedOwner` lives on the ENTRY and is ephemeral by design (RA-9).
+    // evictToCap() drops entries while ownership survives, so a re-catalog after
+    // eviction rebuilds the entry with `verifiedOwner: false`. If displaceability
+    // read that flag, an attacker could fill the catalog to MAX_ENTRIES, evict
+    // the victim, and displace a binding that HAD been proven.
+    //
+    // MUTATION: make tryDisplace gate on `entry.verifiedOwner` instead of
+    // `this.everVerified`. This test then displaces a proven binding.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(A));
+    await catalog.reverify(URL_V, A, endpointNaming(A).fn);
+
+    // Simulate the eviction: the entry is gone, the ownership row is not.
+    // Re-catalog rebuilds the badge as false, which is correct and is the trap.
+    catalog.evictForTest(URL_V);
+    await catalog.upsertFromPayment(disc(), reqs(A));
+    expect(catalog.isVerifiedOwner(URL_V), "the badge really did reset — this is the setup, not a bug").toBe(
+      false,
+    );
+
+    const v = endpointNaming(C);
+    expect(
+      await catalog.tryDisplace(URL_V, C, reqs(C), disc(), v.fn),
+      "the durable latch outlives the badge",
+    ).toBe("skipped");
+    // AND IT MUST NOT PROBE. Without this line the test passes even when the
+    // gate reads the badge, because the post-probe re-check catches it anyway —
+    // so the binding is safe but the facilitator has still made an outbound
+    // request to a claimant-chosen URL on behalf of an attempt that could never
+    // succeed. Bounding that traffic is the entire reason the gates come before
+    // the fetch. (Found by mutation: gating on `entry.verifiedOwner` left all 13
+    // green until this assertion existed.)
+    expect(v.calls.length, "refused BEFORE the fetch, not after").toBe(0);
+    expect(catalog.isBound(URL_V, A)).toBe(true);
+  });
+
+  it("the latch survives a RESTART, so displacement cannot be retried after one", async () => {
+    // MUTATION: drop `verified_at` from the ownership schema, or stop calling
+    // latchVerified in reverify. After the restart everVerified is empty and the
+    // proven binding is displaceable again — a downgrade anyone can trigger by
+    // waiting for the free tier to spin down.
+    const { store, url } = tmpStore();
+    const first = await BazaarCatalog.create(store);
+    await first.upsertFromPayment(disc(), reqs(A));
+    await first.reverify(URL_V, A, endpointNaming(A).fn);
+    await first.flush();
+
+    const restarted = await BazaarCatalog.create(reopen(url));
+    expect(restarted.isVerifiedOwner(URL_V), "the badge is NOT restored (RA-9)").toBe(false);
+    expect(restarted.isEverVerified(URL_V), "but displaceability is").toBe(true);
+    expect(await restarted.tryDisplace(URL_V, C, reqs(C), disc(), endpointNaming(C).fn)).toBe("skipped");
+    expect(restarted.isBound(URL_V, A)).toBe(true);
+  });
+});
+
+describe("the ownership rows — neither an UPDATE nor an append", () => {
+  it("displacement REPLACES every row, so the squatter is not left as a secondary payee", async () => {
+    // MUTATION: change displaceOwnership's DELETE+INSERT batch to a bare INSERT.
+    // B survives as a second row, and since rows load ordered by bound_at, B
+    // stays boundPayTo[0] — the owner — with A merely added alongside. The
+    // displacement would report success and change nothing that matters.
+    const { store, url } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+    await catalog.tryDisplace(URL_V, A, reqs(A), disc(), endpointNaming(A).fn);
+
+    const rows = await readOwnership(url);
+    expect(rows, "exactly one binding, and it is the proven one").toEqual([
+      { resourceKey: URL_V, boundPayTo: [A], everVerified: true },
+    ]);
+  });
+
+  it("the URL is never left with zero ownership rows", async () => {
+    // This table IS the tombstone record: "has this URL ever been bound" is "is
+    // there a row". A moment with zero rows is a moment when anyone can claim it.
+    //
+    // MUTATION: split the batch into two calls — DELETE, then INSERT. Between
+    // them the URL has no owner. The window is invisible in-process and real
+    // across a network.
+    const { store, url } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+    await catalog.tryDisplace(URL_V, A, reqs(A), disc(), endpointNaming(A).fn);
+    expect((await readOwnership(url)).length, "never zero").toBe(1);
+  });
+
+  it("a failed displacement write leaves the binding UNCHANGED", async () => {
+    // MUTATION: move `this.ownership.set(key, [claimant])` above the store write,
+    // or drop the try/catch. The binding moves in memory with nothing durable
+    // behind it, and the next restart silently reverts it — a rebinding that
+    // "worked" and then undid itself.
+    const { store, url } = tmpStore();
+    await store.init();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    (catalog as unknown as { store: { displaceOwnership: () => Promise<void> } }).store.displaceOwnership =
+      () => Promise.reject(new Error("store down"));
+
+    expect(await catalog.tryDisplace(URL_V, A, reqs(A), disc(), endpointNaming(A).fn)).toBe("refused");
+    expect(catalog.isBound(URL_V, B), "still B in memory").toBe(true);
+    expect((await readOwnership(url))[0]!.boundPayTo, "and still B on disk").toEqual([B]);
+    expect(err.mock.calls.some((c) => /displacement write FAILED/.test(String(c[0])))).toBe(true);
+    err.mockRestore();
+  });
+});
+
+describe("stats — reset, because the merchant changed", () => {
+  it("the displaced owner's settlement history does not transfer to the new one", async () => {
+    // G-4 established that a bound owner can inflate their own stats. If those
+    // survived a displacement, a squatter could manufacture a reputation and
+    // hand it to the victim — and consumers would read numbers describing
+    // someone else's activity as the current merchant's track record.
+    //
+    // MUTATION: keep the existing entry instead of deleting it before the
+    // re-ingest (drop `this.entries.delete(key)`). The counters carry over.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+    for (let i = 0; i < 5; i++) catalog.recordSettlement(URL_V, `CPAYER${i}`, B);
+    expect(
+      (catalog.list().items[0] as unknown as { trust: { settlements: number } }).trust.settlements,
+    ).toBe(5);
+
+    await catalog.tryDisplace(URL_V, A, reqs(A), disc(), endpointNaming(A).fn);
+
+    const trust = (catalog.list().items[0] as unknown as { trust: Record<string, number> }).trust;
+    expect(trust.settlements, "not the squatter's five").toBe(0);
+    expect(trust.uniquePayers).toBe(0);
+    expect(trust.observedSettlements).toBe(0);
+  });
+});
+
+describe("cooldowns — an attacker can only rate-limit themselves", () => {
+  it("is keyed by (url, payTo): a failed attempt does not block the real owner", async () => {
+    // MUTATION: key displaceState on `key` alone. C's failed probe then parks
+    // the URL, and A — the real owner — is refused for the whole cooldown. That
+    // hands an attacker a cheap denial of the recovery path, mounted against the
+    // very party the recovery exists for.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+
+    // C tries and fails; the endpoint names A.
+    expect(await catalog.tryDisplace(URL_V, C, reqs(C), disc(), endpointNaming(A).fn, 1_000)).toBe("refused");
+    // A tries immediately afterwards, inside C's cooldown window.
+    expect(
+      await catalog.tryDisplace(URL_V, A, reqs(A), disc(), endpointNaming(A).fn, 1_001),
+      "the real owner is not caught in someone else's cooldown",
+    ).toBe("displaced");
+  });
+
+  it("the SAME claimant is held off after a refusal, bounding probes at a victim", async () => {
+    // Each check is an outbound fetch at someone else's endpoint, so a settler
+    // repeating a claim must not be able to drive traffic there.
+    //
+    // MUTATION: remove the cooldown check. The second call probes again
+    // immediately, and an attacker settling in a loop turns the facilitator into
+    // a request amplifier pointed at the victim.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+    const v = endpointNaming(A); // C will never match
+
+    expect(await catalog.tryDisplace(URL_V, C, reqs(C), disc(), v.fn, 1_000)).toBe("refused");
+    expect(await catalog.tryDisplace(URL_V, C, reqs(C), disc(), v.fn, 1_001)).toBe("skipped");
+    expect(v.calls.length, "exactly one probe, not two").toBe(1);
+  });
+});
+
+describe("displacement does not weaken what it sits next to", () => {
+  it("a frozen catalog rebinds nothing", async () => {
+    // MUTATION: remove the frozen check. A store outage — during which ownership
+    // could not be loaded — becomes a window in which URLs can be rebound, which
+    // is fail-open at the exact moment nobody can see the state.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(), reqs(B));
+    (catalog as unknown as { frozen: string }).frozen = "ownership-unreachable";
+    expect(await catalog.tryDisplace(URL_V, A, reqs(A), disc(), endpointNaming(A).fn)).toBe("skipped");
+    expect(catalog.isBound(URL_V, B)).toBe(true);
+  });
+
+  it("a templated key is never probed", async () => {
+    // MUTATION: drop the isTemplatedKey guard. The facilitator GETs a literal
+    // `:symbol` at the merchant's origin.
+    const url = "https://api.victim.example/quote/:symbol";
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    await catalog.upsertFromPayment(disc(url), reqs(B));
+    const v = endpointNaming(A);
+    expect(await catalog.tryDisplace(url, A, reqs(A), disc(url), v.fn)).toBe("skipped");
+    expect(v.calls.length).toBe(0);
+  });
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -423,6 +423,27 @@ export class BazaarCatalog {
    * and never on the wire (no attacker-forceable signal for consumers). */
   private readonly verifyState = new Map<string, { verdict: OwnershipVerdict; at: number }>();
   private readonly verifyInFlight = new Set<string>();
+  /**
+   * Keys whose binding has EVER been proven by Layer 2. Loaded from the durable
+   * `ownership.verified_at`, not from the entry — see the schema note in
+   * store.ts. This is the one-way latch that makes displacement safe: a binding
+   * in this set can never be displaced, by anyone, ever.
+   *
+   * NOT `entry.verifiedOwner`. That flag is ephemeral by design (RA-9) and is
+   * rebuilt as `false` after an eviction or a restart, so reading it here would
+   * make eviction a downgrade primitive.
+   */
+  private readonly everVerified = new Set<string>();
+  /**
+   * Displacement cooldowns, keyed by (url, payTo) rather than url.
+   *
+   * A per-URL key would let an attacker's failed attempt park the URL and block
+   * the REAL owner's legitimate attempt for the whole cooldown — a cheap denial
+   * of the recovery path, mounted by the same party the recovery exists to undo.
+   * Per-claimant means an attacker can only ever rate-limit themselves.
+   */
+  private readonly displaceState = new Map<string, { verdict: OwnershipVerdict; at: number }>();
+  private readonly displaceInFlight = new Set<string>();
   // G-7's `ownershipSeededDuringLoad` flag is GONE along with the bootstrap
   // hatch. The hatch existed only because an ownership FILE could be absent
   // while a catalog FILE was present — an ambiguity between "first upgrade" and
@@ -474,7 +495,10 @@ export class BazaarCatalog {
       );
       return catalog; // empty + frozen
     }
-    for (const b of bindings) catalog.ownership.set(b.resourceKey, b.boundPayTo);
+    for (const b of bindings) {
+      catalog.ownership.set(b.resourceKey, b.boundPayTo);
+      if (b.everVerified) catalog.everVerified.add(b.resourceKey);
+    }
     await catalog.load(opts.maxEntries ?? MAX_ENTRIES);
     return catalog;
   }
@@ -599,6 +623,10 @@ export class BazaarCatalog {
       this.verifyState.set(key, { verdict, at: now });
       if (verdict === "match") {
         this.setVerifiedOwner(key, true);
+        // Latch it DURABLY too. The badge above is ephemeral by design; this is
+        // what stops the binding being displaced after the next eviction or
+        // restart, when the badge will read false again.
+        await this.latchVerified(key, settlingPayTo);
       } else if (verdict === "mismatch") {
         console.warn(
           `[catalog] ownership MISMATCH on re-verify for ${key}: the resource's 402 challenge no longer ` +
@@ -621,6 +649,150 @@ export class BazaarCatalog {
    * only when this is true. */
   isVerifiedOwner(resourceUrl: string): boolean {
     return this.entries.get(resourceUrl)?.verifiedOwner ?? false;
+  }
+
+  /** TEST ONLY — drop an entry the way evictToCap does, keeping ownership. The
+   *  eviction path is otherwise only reachable by filling the catalog to
+   *  MAX_ENTRIES, which a unit test cannot afford, and the interaction between
+   *  eviction and displaceability is exactly what must be asserted. */
+  evictForTest(resourceUrl: string): void {
+    this.entries.delete(BazaarCatalog.canonicalResourceKey(resourceUrl));
+  }
+
+  /** True when this URL's binding has ever been proven, and is therefore not
+   *  displaceable. Durable; survives eviction and restart. */
+  isEverVerified(resourceUrl: string): boolean {
+    return this.everVerified.has(BazaarCatalog.canonicalResourceKey(resourceUrl));
+  }
+
+  /** Latch a proven binding as permanently non-displaceable. In-memory first so
+   *  the guarantee holds even if the store write fails — the failure mode we
+   *  accept here is a binding that is MORE protected than the row says, never
+   *  less. (bindOwnership takes the opposite trade for the opposite reason: an
+   *  unpersisted binding must not be treated as established.) */
+  private async latchVerified(key: string, payTo: string): Promise<void> {
+    this.everVerified.add(key);
+    if (!this.store) return;
+    try {
+      await this.store.markVerified(key, payTo, Date.now());
+    } catch (err) {
+      console.error(
+        `[catalog] could not persist the verified latch for ${key} — it holds for this process, but a ` +
+          `restart will reopen the binding to displacement until the owner settles again: ${String(
+            (err as Error)?.message ?? err,
+          )}`,
+      );
+    }
+  }
+
+  /**
+   * G-2 displacement — the ONLY path by which a bound URL changes hands without
+   * an operator.
+   *
+   * THE RULE: a claimant who PROVES ownership (their payTo appears in the
+   * resource's own 402 challenge) displaces a binding that was never proven.
+   * Unverified → verified only.
+   *
+   * This is proof-beats-no-proof, NOT proof-beats-proof. An unverified binding
+   * is arrival order — whoever settled first — which is not evidence of
+   * anything. A verified binding IS evidence, and stays put: the takeover case
+   * refused as 2C is still refused, because no amount of proof displaces proof.
+   *
+   * Fires from onAfterSettle, fire-and-forget, for the same reason G-1 does:
+   * settlement must never wait on, nor fail because of, a merchant's endpoint.
+   * So the settle that TRIGGERS a displacement is still refused by
+   * upsertFromPayment (the claimant is not yet bound); the rebinding lands
+   * moments later and their next settlement is accepted normally. Displacement
+   * recovers the URL, it does not retroactively accept the payment that
+   * revealed the problem.
+   */
+  async tryDisplace(
+    rawResourceUrl: string,
+    claimant: string,
+    requirements: PaymentRequirements,
+    discovered: DiscoveredResource,
+    verify: (url: string, payTos: string[]) => Promise<OwnershipVerdict>,
+    now: number = Date.now(),
+  ): Promise<"displaced" | "refused" | "skipped"> {
+    const key = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
+    const entry = this.entries.get(key);
+    // No entry: this is a first catalog, which TOFU handles. Nothing to displace.
+    if (!entry) return "skipped";
+    if (!claimant) return "skipped";
+    // Already bound: an ordinary settlement, not a claim.
+    if (entry.boundPayTo.includes(claimant)) return "skipped";
+    // THE ONE-WAY GATE. Read from the durable latch, never from the badge.
+    if (this.everVerified.has(key)) return "skipped";
+    // An empty binding has no claimant to displace and no proof to weigh; it is
+    // the tampered state bindLoadedEntry warns about, not a live URL.
+    if (entry.boundPayTo.length === 0) return "skipped";
+    // A templated key would GET a literal `:symbol`. Never probe it.
+    if (isTemplatedKey(key)) return "skipped";
+    // A frozen catalog must not rebind anything.
+    if (this.frozen === "ownership-unreachable" || this.frozen === "ownership-invalid") return "skipped";
+
+    const cooldownKey = `${key}\u0000${claimant}`;
+    if (this.displaceInFlight.has(cooldownKey)) return "skipped";
+    const last = this.displaceState.get(cooldownKey);
+    if (last && now - last.at < cooldownFor(last.verdict)) return "skipped";
+
+    this.displaceInFlight.add(cooldownKey);
+    let verdict: OwnershipVerdict;
+    try {
+      // Probe for the CLAIMANT's address alone. Passing the bound set would ask
+      // "does this endpoint name anyone we know", which a squatter's own
+      // endpoint could answer yes to.
+      verdict = await verify(key, [claimant]);
+    } catch {
+      this.displaceState.set(cooldownKey, { verdict: "unverifiable", at: now });
+      return "refused";
+    } finally {
+      this.displaceInFlight.delete(cooldownKey);
+    }
+    this.displaceState.set(cooldownKey, { verdict, at: now });
+    if (verdict !== "match") return "refused";
+
+    // Re-check the latch: the probe was awaited, and a concurrent re-verify may
+    // have proven the incumbent while we were off the CPU. Losing that race
+    // would displace a binding that had become non-displaceable mid-flight.
+    if (this.everVerified.has(key)) return "skipped";
+
+    const displaced = [...entry.boundPayTo];
+    if (this.store) {
+      try {
+        await this.store.displaceOwnership(key, claimant, now);
+      } catch (err) {
+        console.error(
+          `[catalog] displacement write FAILED for ${key} — binding UNCHANGED: ${String(
+            (err as Error)?.message ?? err,
+          )}`,
+        );
+        return "refused";
+      }
+    }
+    this.ownership.set(key, [claimant]);
+    this.everVerified.add(key);
+
+    // STATS ARE RESET, not inherited.
+    //
+    // The trust block answers "what is this merchant's history", and after a
+    // displacement the merchant is a DIFFERENT PARTY. Carrying the squatter's
+    // counters over would hand the real owner a reputation they did not earn
+    // and consumers a number that describes someone else's activity — the exact
+    // dishonesty RA-13 exists to avoid, except self-inflicted rather than
+    // merely unverifiable. Dropping the entry and re-ingesting through the
+    // normal validated path is what performs the reset: stats start at zero,
+    // and `accepts` is rebuilt from the claimant's own requirements instead of
+    // being filtered out of the squatter's.
+    this.entries.delete(key);
+    await this.upsertFromPayment(discovered, requirements);
+    this.setVerifiedOwner(key, true);
+    console.warn(
+      `[catalog] DISPLACED ${key}: ${displaced.join(", ")} -> ${claimant}. The previous binding was never ` +
+        `verified; the new one proved ownership through the resource's own 402 challenge and is now ` +
+        `permanently non-displaceable. Settlement stats were RESET — they described the previous binding.`,
+    );
+    return "displaced";
   }
 
   /** Record the Layer 2 402-challenge verdict for a URL. `match` marks the

--- a/src/store.durability.test.ts
+++ b/src/store.durability.test.ts
@@ -178,7 +178,9 @@ describe("atomicity — the thing two files could not express", () => {
       ],
     });
     const rows = await readOwnership(url);
-    expect(rows).toEqual([{ resourceKey: URL_A, boundPayTo: ["GOLD", "GNEW"] }]);
+    // everVerified false: neither row has been proven, so this binding is still
+    // displaceable — an operator rotation is not evidence of ownership.
+    expect(rows).toEqual([{ resourceKey: URL_A, boundPayTo: ["GOLD", "GNEW"], everVerified: false }]);
   });
 });
 
@@ -310,7 +312,9 @@ describe("round trips — the cost that only shows up across an ocean", () => {
 
     expect(calls, "one batch, no interactive transaction").toEqual(["batch"]);
     // ...and it is still atomic: the batch really wrote both rows.
-    expect(await readOwnership(url)).toEqual([{ resourceKey: URL_A, boundPayTo: ["GOWNER"] }]);
+    expect(await readOwnership(url)).toEqual([
+      { resourceKey: URL_A, boundPayTo: ["GOWNER"], everVerified: false },
+    ]);
   });
 });
 

--- a/src/store.testkit.ts
+++ b/src/store.testkit.ts
@@ -66,6 +66,12 @@ export class FailingStore implements CatalogStore {
   saveEntries(rows: StoredEntryRow[]): Promise<void> {
     return this.inner.saveEntries(rows);
   }
+  markVerified(resourceKey: string, payTo: string, at: number): Promise<void> {
+    return this.inner.markVerified(resourceKey, payTo, at);
+  }
+  displaceOwnership(resourceKey: string, newPayTo: string, at: number): Promise<void> {
+    return this.inner.displaceOwnership(resourceKey, newPayTo, at);
+  }
   close(): Promise<void> {
     return this.inner.close();
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -48,6 +48,9 @@ export interface StoredOwnership {
   /** Canonical resource key: origin + pathname, no query (G-3). */
   resourceKey: string;
   boundPayTo: string[];
+  /** True when ANY row for this key carries a verified_at. Gates displacement
+   *  only; never served, and never the source of the `ownerVerified` badge. */
+  everVerified?: boolean;
 }
 
 export interface StoredEntryRow {
@@ -84,6 +87,12 @@ export interface CatalogStore {
   /** Debounced bulk entry write. Entries are reconstructible from settlement
    *  traffic, so coalescing is safe here and is NOT safe for ownership. */
   saveEntries(rows: StoredEntryRow[]): Promise<void>;
+  /** Record that Layer 2 proved this binding. Makes it non-displaceable, for
+   *  good. */
+  markVerified(resourceKey: string, payTo: string, at: number): Promise<void>;
+  /** Replace every binding for a URL with one proven claimant. See the
+   *  implementation for why this is neither an UPDATE nor a plain INSERT. */
+  displaceOwnership(resourceKey: string, newPayTo: string, at: number): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -168,10 +177,35 @@ const SCHEMA = [
   // `bound_at` orders them: the first row is the TOFU winner, later rows are
   // operator-added, and load order must be stable because boundPayTo[0] is
   // treated as the owner.
+  // `verified_at` is NULL until Layer 2 has returned `match` for this binding at
+  // least once. Non-null means "this binding has PROVEN ownership", which makes
+  // it permanently NON-DISPLACEABLE.
+  //
+  // WHY THIS IS DURABLE WHEN RA-9 SAYS VERIFICATION IS NOT. They are two
+  // different facts and only one of them is served:
+  //
+  //   entry.verifiedOwner  the BADGE consumers read. Still ephemeral, still
+  //                        re-derived by G-1 on every boot, still never trusted
+  //                        from storage. RA-9 is unchanged.
+  //   ownership.verified_at  whether this binding may be DISPLACED. Durable,
+  //                        never served, never in an API response.
+  //
+  // It has to be durable because the badge is not. `verifiedOwner` lives on the
+  // ENTRY, and evictToCap() drops entries while ownership survives — so a
+  // re-catalog after eviction rebuilds the entry with `verifiedOwner: false`.
+  // If displaceability read that flag, EVICTION WOULD BE A DOWNGRADE PRIMITIVE:
+  // fill the catalog to MAX_ENTRIES, evict the victim, and their proven binding
+  // becomes displaceable again. Restart has the same effect for the same reason.
+  //
+  // And it grants an attacker nothing new: forging `verified_at` requires write
+  // access to this database, and anyone with that can rewrite `pay_to` directly,
+  // which is strictly less work. The F6 boundary already covers it — see the
+  // relocation note in docs/security-audit.md.
   `CREATE TABLE IF NOT EXISTS ownership (
      resource_key TEXT NOT NULL,
      pay_to       TEXT NOT NULL,
      bound_at     INTEGER NOT NULL,
+     verified_at  INTEGER,
      PRIMARY KEY (resource_key, pay_to)
    )`,
   // Catalog entries. Reconstructible from settlement traffic, hence the weaker
@@ -218,6 +252,17 @@ export class LibsqlCatalogStore implements CatalogStore {
 
   async init(): Promise<void> {
     for (const stmt of SCHEMA) await this.run(() => this.client.execute(stmt));
+    // CREATE TABLE IF NOT EXISTS does NOT add a column to a table that already
+    // exists, so a database created before displacement shipped keeps the old
+    // three-column shape and every query naming verified_at fails. Checked
+    // against sqlite's own catalog rather than attempted-and-caught, because
+    // "duplicate column name" would otherwise be swallowed by the same handler
+    // that swallows real errors.
+    const cols = await this.run(() => this.client.execute("PRAGMA table_info(ownership)"));
+    if (!cols.rows.some((r) => r.name === "verified_at")) {
+      console.warn("[store] migrating: adding ownership.verified_at (pre-displacement database)");
+      await this.run(() => this.client.execute("ALTER TABLE ownership ADD COLUMN verified_at INTEGER"));
+    }
   }
 
   /**
@@ -234,12 +279,15 @@ export class LibsqlCatalogStore implements CatalogStore {
    */
   async loadOwnership(): Promise<StoredOwnership[]> {
     const res = await this.run(() =>
-      this.client.execute("SELECT resource_key, pay_to FROM ownership ORDER BY resource_key, bound_at, rowid"),
+      this.client.execute(
+        "SELECT resource_key, pay_to, verified_at FROM ownership ORDER BY resource_key, bound_at, rowid",
+      ),
     );
     // Grouped, ORDER preserved: boundPayTo[0] is the TOFU winner and is treated
     // as the owner everywhere downstream, so a load that reordered them would
     // silently hand ownership to an operator-added address.
     const byKey = new Map<string, string[]>();
+    const verified = new Set<string>();
     for (const r of res.rows) {
       const key = r.resource_key;
       const payTo = r.pay_to;
@@ -251,8 +299,17 @@ export class LibsqlCatalogStore implements CatalogStore {
       const list = byKey.get(key);
       if (list) list.push(payTo);
       else byKey.set(key, [payTo]);
+      // ANY verified row makes the whole binding non-displaceable. A URL whose
+      // owner was proven and who then had a second address added by the runbook
+      // §1 rotation must not become displaceable because the newer row carries
+      // no proof of its own.
+      if (r.verified_at !== null && r.verified_at !== undefined) verified.add(key);
     }
-    return [...byKey.entries()].map(([resourceKey, boundPayTo]) => ({ resourceKey, boundPayTo }));
+    return [...byKey.entries()].map(([resourceKey, boundPayTo]) => ({
+      resourceKey,
+      boundPayTo,
+      everVerified: verified.has(resourceKey),
+    }));
   }
 
   /** G-6 CLOSES HERE: the cap is enforced on the LOAD path by the query itself. */
@@ -327,6 +384,60 @@ export class LibsqlCatalogStore implements CatalogStore {
                                                         last_updated = excluded.last_updated`,
           args: [r.resourceKey, r.payload, r.lastUpdated] as InArgs,
         })),
+        "write",
+      ),
+    );
+  }
+
+  async markVerified(resourceKey: string, payTo: string, at: number): Promise<void> {
+    await this.run(() =>
+      this.client.execute({
+        // Only if not already set: the FIRST proof is the one that matters, and
+        // rewriting the timestamp on every re-verification would turn a
+        // permanent fact into a moving one.
+        sql: "UPDATE ownership SET verified_at = ? WHERE resource_key = ? AND pay_to = ? AND verified_at IS NULL",
+        args: [at, resourceKey, payTo] as InArgs,
+      }),
+    );
+  }
+
+  /**
+   * Replace every binding for a URL with one proven claimant — DELETE then
+   * INSERT, in a single atomic batch.
+   *
+   * Why not UPDATE. The same reason runbook §1 forbids it, arriving from the
+   * other direction: `pay_to` is half the primary key, and a URL may legally
+   * carry SEVERAL rows (a §1 rotation produces `[OLD, NEW]`). An UPDATE would
+   * rewrite one row and silently leave the others bound, so the displaced
+   * squatter would remain an acceptable payee — the exact thing displacement
+   * exists to end.
+   *
+   * Why not a plain INSERT. Rows load ordered by `bound_at`, and
+   * `boundPayTo[0]` is the owner downstream. Appending would leave the squatter
+   * FIRST, so the proven claimant would be added as a secondary address on a
+   * URL still owned by the party they just displaced. Worse than doing nothing.
+   *
+   * Why one batch. The DELETE must never be observable without the INSERT. This
+   * table IS the tombstone record — "has this URL ever been bound" is "is there
+   * a row" — so a moment with zero rows is a moment when the URL is open to
+   * first-writer claim by anyone. libSQL wraps a batch in an implicit
+   * transaction, so that moment cannot be observed and, on failure, does not
+   * happen at all.
+   *
+   * The new row is born verified: we only get here because Layer 2 just returned
+   * `match` for this payTo. That is what makes displacement ONE-WAY — the
+   * result is immediately non-displaceable by the next claimant.
+   */
+  async displaceOwnership(resourceKey: string, newPayTo: string, at: number): Promise<void> {
+    await this.run(() =>
+      this.client.batch(
+        [
+          { sql: "DELETE FROM ownership WHERE resource_key = ?", args: [resourceKey] as InArgs },
+          {
+            sql: "INSERT INTO ownership (resource_key, pay_to, bound_at, verified_at) VALUES (?, ?, ?, ?)",
+            args: [resourceKey, newPayTo, at, at] as InArgs,
+          },
+        ],
         "write",
       ),
     );


### PR DESCRIPTION
**The rule:** a settle arrives for a URL whose binding was never verified, the claimant proves ownership by serving a 402 challenge naming their payTo, the URL rebinds to them. **Unverified → verified only.**

Proof beats no-proof, **not** proof beats proof. An unverified binding is *arrival order*, which is evidence of nothing. A verified binding is evidence and stays — 2C is still refused.

## Three things the rule doesn't imply

**1. A durable `verified_at`, and it is not an RA-9 regression.**

`verifiedOwner` lives on the **entry** and is ephemeral by design. `evictToCap()` drops entries while ownership survives, so a re-catalog after eviction rebuilds the badge as `false`. Gating displaceability on that flag would have made **eviction a downgrade primitive** — fill the catalog to `MAX_ENTRIES`, evict the victim, displace their *proven* binding. Restart had the same effect.

So displaceability reads a durable `ownership.verified_at`; the served badge stays ephemeral and re-derived. **Two facts, two lifetimes.** Forging the durable one needs database write access, and anyone with that can rewrite `pay_to` directly — strictly less work. No new capability, and **RA-9 is unchanged**: the badge is still never trusted from storage.

**2. The rows are REPLACED — not updated, not appended.**

`pay_to` is half the primary key and a URL may legally carry several rows (a §1 rotation produces `[OLD, NEW]`), so an `UPDATE` leaves the displaced squatter bound as a **secondary payee**. An append is worse: rows load ordered by `bound_at` and `boundPayTo[0]` is the owner, so the proven claimant lands *underneath* the party they just displaced.

`DELETE` + `INSERT` in **one batch** — and the batch matters: this table is the tombstone record, so a moment with zero rows is a moment when anyone can claim the URL.

**3. Cooldowns keyed by (url, payTo).** A per-URL key would let an attacker's failed attempt park the URL and block the real owner's legitimate one — a cheap denial of the recovery path, aimed at the party it exists for.

## Stats are reset

The trust block answers *"what is this merchant's history"*, and after displacement the merchant is a **different party**. G-4 established a bound owner can inflate their own counters, so inheriting them would let a squatter manufacture a reputation and hand it to the victim.

## Tests — 298 passing, 13 new, 9 mutations verified

**Two of them didn't, at first.** My first mutation harness didn't assert its anchors, so two "surviving" mutations were silent `str.replace()` no-ops — the exact trap this repo has hit before. Fixing it showed **one test was genuinely too weak**: gating on the ephemeral badge left all 13 green, because the post-probe re-check caught it anyway. The binding was safe, but the facilitator had already made an outbound request to a claimant-chosen URL on behalf of an attempt that could never succeed. The eviction test now asserts **zero probes**.

Includes the exact scenario demonstrated live on 2026-08-11: empty catalog → B binds unverified → A settles and is refused → A displaces B, `accepts` flips to A.

## Runbook

§1 now opens with **how to tell whether to act at all** — `ownerVerified: false` means the owner takes it back by settling once, and the manual procedure is for the verified case only.