### PR TITLE
tools+docs: mutation harness that cannot lie, and displacement proven live

### DIFF
--- a/docs/cutover-turso.md
+++ b/docs/cutover-turso.md
@@ -198,10 +198,65 @@ is right: 6 of the 7 are still inherited.
 | **RA-9** verified flag not trusted from storage | unit tests only | **OBSERVED** — `ownerVerified: false` after load |
 | **F12** per-URL budget | NOT REACHABLE (needs 11 settles/60 s) | unchanged — still needs several funded source accounts |
 
+## 6b. Displacement, PROVEN LIVE — 2026-08-11T09:57–09:59Z
+
+The recovery path, end to end, on the deployed service. No operator touched
+anything.
+
+**Setup, stated as setup.** Displacement needs a binding that was never proven,
+and it needed no hand-clearing to get one — for two reasons worth recording
+separately from the result:
+
+- The live `/quote` binding reads `ownerVerified: false` **on its own**. It was
+  verified before displacement shipped, so its `ownership.verified_at` was never
+  written and the migration added the column as NULL. **Every binding proven
+  before #31 loads as displaceable until its owner settles once more.** That is
+  a real one-time window, and it is safe only because displacement requires
+  *proof* — the sole party who can take such a binding is whoever actually
+  controls the endpoint.
+- The test ran against `…/quote/` (trailing slash), a **genuinely distinct
+  canonical key that the seller genuinely serves** — its 402 names the URL with
+  the slash and names A's payTo. Unbound, so B could take it honestly.
+
+| | |
+| --- | --- |
+| **B squats `/quote/`** | `a4c0bfc5…` — Horizon `successful=True`, fee 22,579, sponsor-paid |
+| Catalog after | `accepts: ['GB74DDOZ…']`, `settlements: 1`, `ownerVerified: false` |
+| **A settles through its own seller** | `66e095d5…` — Horizon `successful=True`, fee 22,579 |
+| Catalog after | `accepts: ['GBJX3E4G…']`, `settlements: 0`, `ownerVerified: TRUE` |
+
+**Three things happened, all automatically:**
+
+1. **`accepts` flipped from the squatter to the real owner.** The same URL that
+   on 2026-08-11 stayed on `GB74DDOZ…` through A's own payment now returns to A
+   on that same payment.
+2. **The stats did not transfer.** B's settlement count went `1 → 0`. The real
+   owner inherited none of the squatter's activity.
+3. **It is now non-displaceable.** `ownerVerified: true` means the durable latch
+   is set, so no future claimant — including B — can take it, whatever they can
+   prove.
+
+The comparison that matters is with the same test four hours earlier, when the
+answer was "the real owner is locked out and its own payment does not correct
+it."
+
+### A gap this surfaced
+
+`…/quote` and `…/quote/` are **separately bindable**. The canonical key is
+`origin + pathname` and does not normalise a trailing slash, so one resource has
+two catalog identities and a squatter can hold the variant its owner never
+settled against. Not exploited here — it was the honest way to get an unbound URL
+— but it is a real hole of the same family as G-3, and it should be **G-11**.
+
 ## 7. The cost is now real
 
-A squat on a bound URL no longer clears itself. The binding above survived a
-container replacement, which is precisely what makes the recovery manual:
-[`operator-runbook.md` §1](./operator-runbook.md), by hand, until the
-displacement variant ships. That is the trade that was accepted, and it is now in
-force rather than pending.
+A squat on a bound URL no longer clears itself. The binding survived a container
+replacement, which is precisely what made recovery manual.
+
+**As of 2026-08-11 that is only half true.** Displacement (§6b) recovers the
+*unverified* case automatically — which is every squat, since a squatter cannot
+serve a 402 naming themselves from a domain they do not control. What remains
+manual is rotating a payTo on a **verified** binding, where proof does not
+displace proof and a domain that genuinely changed hands is indistinguishable
+from a hijack. [`operator-runbook.md` §1](./operator-runbook.md) now opens by
+telling the operator which case they have.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -590,6 +590,65 @@ reintroducing a hardcoded 30 fails it. Note the first version of that test did
 **not** catch the shadow, because no existing case drove one payTo past 30
 settles while its budget was higher.
 
+### Pattern: `String.replace()` silently no-ops — and it has now cost us twice
+
+**Twice is not an accident, it is a tool that needed changing.** Recording both,
+because "once" reads as carelessness and "twice" reads as a defect in the method.
+
+`String.prototype.replace()` returns the **original string** when the pattern
+does not match. No throw, no warning. Every hand-written script in this
+engagement had the same shape:
+
+```js
+src = src.replace(anchor, mutated);   // anchor wrong -> silent no-op
+runTests();                            // they pass, because nothing changed
+report("the mutation did not break anything");
+```
+
+That output is **identical** for "the code is unprotected" and "the test caught
+it" — opposite conclusions, same evidence.
+
+| | When | What it produced | How it was caught |
+| --- | --- | --- | --- |
+| **1** | 2026-08-10 | A doc script anchored on text from a then-unmerged PR. Sections vanished from three merges. **GitHub's squash was blamed for days.** | Reading the script, after the third recurrence |
+| **2** | 2026-08-11 | The displacement run reported **two mutations as surviving that had never executed** | Suspicion — the results looked wrong — not process |
+
+Both were caught by luck. So the check is now **structural**, in
+`scripts/mutate.mjs`: a mutation whose anchor is **absent or ambiguous ABORTS**
+and can never be reported as surviving, and an aborted run exits non-zero.
+Ambiguity aborts too — replacing the first of several matches mutates something
+other than what the label claims. `mutations/harness-selftest.json` is a
+deliberately wrong anchor that must always abort; if it ever reports a result,
+the harness itself has regressed.
+
+The general lesson, beyond this one function: **a verification step that cannot
+fail loudly is not a verification step.** The mutation run existed to check the
+tests, and for two entries it was checking nothing while printing the same output
+as success.
+
+### Lesson: a control's value can live in the work it prevents, not the outcome
+
+Found underneath the second incident, and it is the more interesting half.
+
+Gating displacement on the **ephemeral** `entry.verifiedOwner` instead of the
+durable latch left **all thirteen tests green**. The binding was never
+displaced — a second `everVerified` check after the probe caught it. So by
+outcome, the mutant was equivalent.
+
+It was not. Before that second check, the facilitator had already **fetched a
+claimant-chosen URL** on behalf of an attempt that could never succeed. Bounding
+that traffic is the entire reason the gates sit *before* the fetch: without it, a
+settler repeating a claim turns the facilitator into a request amplifier pointed
+at a victim's origin.
+
+**A test that asserts only the outcome cannot see a control whose purpose is
+preventing the work.** The fix was one line — assert the probe count is zero, not
+just that the binding held — and the same shape applies to every gate in
+`reverify` and `tryDisplace`: each exists to *avoid* an outbound request, so each
+needs an assertion about requests, not only about state. This is the same family
+as RA-12's decorative tests, arriving from a different direction: there the tests
+never armed the control; here they armed it and measured the wrong thing.
+
 ### Pattern: rationale in comments rots because nothing tests it
 
 Three comments in this repo have now asserted something untrue:
@@ -891,6 +950,8 @@ change.
 | **G-9** | `verified_only` silently ignored when no trust resolver is injected | **open** — not reachable in production; `server.ts` always constructs one. |
 | **F4-ts** | Verification API is not deployed at all; the worker-service has never run hosted | **external, blocked on wallet-repo M5** — not a missing field. Chain: badge ← worker deployed ← `ATTESTOR_SECRET_KEY` ← M5 multisig attestor. |
 | **G-10** | The spend ceiling throttles honest throughput **22× earlier than sponsor exposure requires** | **open — pubnet tuning, deliberately NOT changed.** Spend is accounted at the ESTIMATE (500,000) while the measured CHARGED fee is 22,579, so the ceiling refuses the 101st settle in a window having actually spent **~0.23 XLM of the 5 XLM it names — 4.5%**. It **fails safe**, and the over-count is deliberate (`server.ts:344`: the real simulated fee is not exposed on the verify response). But the dial does not mean what its name implies. Fixing it means either exposing the bid to the policy or setting the estimate from measurement — both are pubnet decisions with real downside if the estimate ever *under*-counts, which is why nothing is being changed on the strength of one wallet's measurement. |
+| **G-11** | The canonical key does not normalise a **trailing slash**, so `…/quote` and `…/quote/` are separately bindable | **open, found 2026-08-11.** One resource, two catalog identities. A squatter can hold the variant its owner never settled against, and the owner's own binding does not protect it. Same family as G-3 (which stripped the query string but not this). Low severity while displacement can recover it, but it doubles every URL's attack surface for free. |
+| **G-12** | Bindings proven BEFORE displacement shipped load as displaceable | **open, one-time.** `ownership.verified_at` was added by the displacement migration and back-fills as NULL, so a pre-existing verified binding is displaceable until its owner settles once more and re-proves. Safe in practice — displacement requires proof, so only whoever controls the endpoint can act — but it silently reopens the 2C takeover case for exactly one window per binding. Closes itself as owners settle. |
 | **RA-14r** | RFC 6052 non-`/96` NAT64 offsets | deferred; not reachable in the current deployment. |
 | **F5** | Settle/confirm reconciliation | deferred; integration-level. |
 | **F8** | Unvalidated operator-supplied URLs | deferred; operator-supplied, not attacker-supplied. |

--- a/mutations/catalog.json
+++ b/mutations/catalog.json
@@ -1,0 +1,86 @@
+[
+  {
+    "label": "one-way gate removed (proof no longer protects proof)",
+    "file": "src/catalog.ts",
+    "find": "    // THE ONE-WAY GATE. Read from the durable latch, never from the badge.\n    if (this.everVerified.has(key)) return \"skipped\";",
+    "replace": "",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "gate on the ephemeral badge instead of the durable latch",
+    "file": "src/catalog.ts",
+    "find": "    // THE ONE-WAY GATE. Read from the durable latch, never from the badge.\n    if (this.everVerified.has(key)) return \"skipped\";",
+    "replace": "    if (entry.verifiedOwner) return \"skipped\";",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "probe the bound set as well as the claimant",
+    "file": "src/catalog.ts",
+    "find": "verdict = await verify(key, [claimant]);",
+    "replace": "verdict = await verify(key, [...entry.boundPayTo, claimant]);",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "stop latching verification durably",
+    "file": "src/catalog.ts",
+    "find": "        await this.latchVerified(key, settlingPayTo);",
+    "replace": "",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "inherit the displaced owner's stats",
+    "file": "src/catalog.ts",
+    "find": "    this.entries.delete(key);\n    await this.upsertFromPayment(discovered, requirements);",
+    "replace": "    await this.upsertFromPayment(discovered, requirements);",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "cooldown keyed on url alone",
+    "file": "src/catalog.ts",
+    "find": "const cooldownKey = `${key}\\u0000${claimant}`;",
+    "replace": "const cooldownKey = key;",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "drop the displacement cooldown entirely",
+    "file": "src/catalog.ts",
+    "find": "    if (last && now - last.at < cooldownFor(last.verdict)) return \"skipped\";\n\n    this.displaceInFlight.add(cooldownKey);",
+    "replace": "    this.displaceInFlight.add(cooldownKey);",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "displacement appends instead of replacing",
+    "file": "src/store.ts",
+    "find": "          { sql: \"DELETE FROM ownership WHERE resource_key = ?\", args: [resourceKey] as InArgs },\n",
+    "replace": "",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "rebind while the catalog is frozen",
+    "file": "src/catalog.ts",
+    "find": "    if (this.frozen === \"ownership-unreachable\" || this.frozen === \"ownership-invalid\") return \"skipped\";\n",
+    "replace": "",
+    "test": "src/catalog.displacement.test.ts"
+  },
+  {
+    "label": "bindOwnership fire-and-forget (G-7 reintroduced)",
+    "file": "src/catalog.ts",
+    "find": "await this.store.bindAndUpsertEntry(",
+    "replace": "void this.store.bindAndUpsertEntry(",
+    "test": "src/store.durability.test.ts"
+  },
+  {
+    "label": "drop LIMIT from loadEntries (G-6 reopened)",
+    "file": "src/store.ts",
+    "find": "ORDER BY last_updated DESC LIMIT ?",
+    "replace": "ORDER BY last_updated DESC",
+    "test": "src/store.durability.test.ts"
+  },
+  {
+    "label": "retry a deterministic store failure",
+    "file": "src/store.ts",
+    "find": "      if (err instanceof StoreInvalidError) throw err; // deterministic \u2014 do not retry\n",
+    "replace": "",
+    "test": "src/store.durability.test.ts"
+  }
+]

--- a/mutations/harness-selftest.json
+++ b/mutations/harness-selftest.json
@@ -1,0 +1,9 @@
+[
+  {
+    "label": "SELF-TEST: a wrong anchor must ABORT, never be reported as surviving",
+    "file": "src/catalog.ts",
+    "find": "this.anchorThatDoesNotExist();",
+    "replace": "",
+    "test": "src/catalog.displacement.test.ts"
+  }
+]

--- a/scripts/mutate.mjs
+++ b/scripts/mutate.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Mutation harness — applies a source mutation, runs a test file, restores.
+//
+// WHY THIS EXISTS AS A TOOL RATHER THAN AN AD-HOC SCRIPT.
+//
+// `String.prototype.replace()` returns the ORIGINAL STRING when the pattern does
+// not match. It does not throw, it does not warn. Every ad-hoc mutation script
+// written by hand in this repo has had the same shape:
+//
+//     src = src.replace(anchor, mutated);   // if `anchor` is wrong: silent no-op
+//     run the tests                          // they pass, because nothing changed
+//     report "the mutation did not break anything"
+//
+// That reads identically to "this code is not covered by the mutation" and to
+// "the test caught it" — the two conclusions are opposite and the output is the
+// same. It has produced a wrong result TWICE in this repo:
+//
+//   1. 2026-08-10 — a doc-writing script anchored on text from an unmerged PR.
+//      Sections were silently dropped from three merges and blamed on GitHub's
+//      squash before the real cause was found.
+//   2. 2026-08-11 — the displacement mutation run reported TWO mutations as
+//      "survived" that had never executed. Both were caught by suspicion, not by
+//      process. One of them, once actually applied, revealed a genuinely weak
+//      test.
+//
+// Twice is not an accident. So the anchor check is structural here: a mutation
+// whose anchor is absent, or ambiguous, ABORTS. It can never be reported as a
+// surviving mutation, because it never runs.
+//
+// Usage:
+//   node scripts/mutate.mjs mutations/<name>.json
+//
+// Each mutation file is a JSON array of:
+//   { "label": "...", "file": "src/x.ts", "find": "...", "replace": "...",
+//     "test": "src/x.test.ts", "expect": "fail" }
+//
+// `expect` defaults to "fail": the point of a mutation is that a test catches
+// it. A mutation that is EXPECTED to survive (an equivalent mutant) must say so
+// explicitly with "pass", so that equivalence is a claim someone wrote down
+// rather than a silence.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const spec = process.argv[2];
+if (!spec) {
+  console.error("usage: node scripts/mutate.mjs <mutations.json>");
+  process.exit(2);
+}
+
+const mutations = JSON.parse(readFileSync(spec, "utf8"));
+const results = [];
+let aborted = 0;
+
+for (const m of mutations) {
+  const expect = m.expect ?? "fail";
+  const original = readFileSync(m.file, "utf8");
+
+  // STRUCTURAL ANCHOR CHECK — the whole point of this file.
+  const occurrences = original.split(m.find).length - 1;
+  if (occurrences === 0) {
+    console.error(`\n  ABORT  ${m.label}\n         anchor not found in ${m.file} — this mutation never ran.`);
+    aborted++;
+    continue;
+  }
+  if (occurrences > 1) {
+    // Ambiguity is as bad as absence: replacing the first of several matches
+    // mutates something other than what the label claims.
+    console.error(
+      `\n  ABORT  ${m.label}\n         anchor matches ${occurrences}x in ${m.file} — ambiguous, so which line ` +
+        `was mutated is unknown. Narrow it.`,
+    );
+    aborted++;
+    continue;
+  }
+
+  writeFileSync(m.file, original.replace(m.find, m.replace));
+  let passed;
+  try {
+    execFileSync("npx", ["vitest", "run", m.test, "--silent"], { stdio: "pipe" });
+    passed = true;
+  } catch {
+    passed = false;
+  } finally {
+    writeFileSync(m.file, original); // restore before anything else can run
+  }
+
+  const survived = passed;
+  const ok = expect === "fail" ? !survived : survived;
+  results.push({ label: m.label, survived, ok });
+  console.log(`  ${ok ? "OK    " : "SURVIVED"}  ${m.label}${ok ? "" : "   <-- the test did NOT catch this"}`);
+}
+
+const bad = results.filter((r) => !r.ok).length;
+console.log(
+  `\n  ${results.length} mutation(s) run, ${bad} unexpected, ${aborted} aborted before running.` +
+    (aborted ? "\n  An aborted mutation is NOT a passing one — fix the anchor and re-run." : ""),
+);
+process.exit(bad || aborted ? 1 : 0);


### PR DESCRIPTION
## Displacement, end to end on the deployed service

| | |
|---|---|
| **B squats `/quote/`** | `a4c0bfc5…` Horizon `successful`, sponsor-paid |
| after | `accepts: ['GB74DDOZ…']`, `settlements: 1`, `ownerVerified: false` |
| **A settles through its own seller** | `66e095d5…` Horizon `successful` |
| after | `accepts: ['GBJX3E4G…']`, `settlements: 0`, `ownerVerified: TRUE` |

`accepts` flipped to the real owner, **stats did not transfer** (1 → 0), and it is now permanently non-displaceable. No operator touched anything. Four hours earlier the same test ended with *"the real owner is locked out and its own payment does not correct it."*

## Setup, stated as setup — and both halves are findings

No hand-clearing was needed, for two reasons worth their own IDs:

**G-12** — the live binding reads `ownerVerified: false` **on its own**, because it was proven *before* displacement shipped and `verified_at` back-fills as NULL. **Every pre-#31 binding is displaceable until its owner settles once more.** Safe in practice — displacement requires proof, so only whoever controls the endpoint can act — but it reopens the 2C case for one window per binding.

**G-11** — the test ran against `…/quote/`, a genuinely distinct canonical key the seller genuinely serves. Which means **`…/quote` and `…/quote/` are separately bindable**: one resource, two catalog identities, and a squatter can hold the variant its owner never settled against. Same family as G-3, which stripped the query string but not this.

## The harness

`String.replace()` returns the **original string** when the pattern doesn't match — no throw, no warning. A wrong anchor prints exactly what a surviving mutation prints: opposite conclusions, identical output.

**That has cost us twice, both times caught by luck:**

| | When | What it produced |
|---|---|---|
| 1 | 2026-08-10 | Doc script anchored on unmerged text; sections vanished from three merges and **GitHub's squash was blamed for days** |
| 2 | 2026-08-11 | The displacement run reported **two mutations as surviving that had never executed** |

So `scripts/mutate.mjs` makes it structural: absent **or ambiguous** anchor → **ABORT**, non-zero exit, never reportable as surviving. `mutations/harness-selftest.json` is a deliberately wrong anchor that must always abort. All 12 real mutations re-run and pass.

## And the lesson underneath

Gating on the ephemeral badge left **all 13 tests green** — a post-probe re-check caught it, so by *outcome* the mutant was equivalent. It wasn't: the facilitator had already fetched a claimant-chosen URL for an attempt that could never succeed, and bounding that traffic is why the gates sit *before* the fetch.

**A test asserting only the outcome cannot see a control whose purpose is preventing the work.** Same family as RA-12's decorative tests, from the other direction.