### PR TITLE
fix(G-13): re-land the spec-conformance and identity work that never reached main

### DIFF
--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -626,6 +626,50 @@ fail loudly is not a verification step.** The mutation run existed to check the
 tests, and for two entries it was checking nothing while printing the same output
 as success.
 
+### Class: one identity, several derivations, no test that they agree
+
+**This is the finding. The trailing slash was an instance of it**, and so was
+G-3, and they were eighteen days apart without anyone noticing they were the same
+thing.
+
+The shape: a value that IS an identity — it decides who owns what, or which
+bucket a limit counts against — gets derived independently at more than one call
+site. Each site is tested against its own definition, both pass, and they agree
+only while the inputs happen to be ones where the definitions coincide.
+
+Two confirmed instances:
+
+| Identity | Derivation A | Derivation B | Why nobody noticed |
+| --- | --- | --- | --- |
+| **resource URL** | `upsertFromPayment` keyed on the **raw advertised URL** | `recordSettlement`, `isBoundResource`, `isBound`, `isVerifiedOwner`, `setVerifiedOwner` and the spend policy keyed on the **canonical** form | The demo seller reports one stable URL in its 402, so raw and canonical were the same string in every test and every live run |
+| **payTo** | `policyBucketKey` **trimmed** and length-capped it | the catalog compared the **raw string** | No input with surrounding whitespace was ever tried |
+
+Both were exploitable, and neither was a corner case:
+
+- The URL split meant a second spelling was a second catalog identity — a
+  stranger could hold `…/quote/` while the owner held `…/quote` (**found live**).
+- The payTo split meant `"G… "` and `"G…"` were ONE rate-limit bucket and TWO
+  catalog identities. A padded copy of a victim's address binds their URL to
+  something that **renders identically** in `/discovery/resources` while their
+  own clean address reads as "not bound" — locked out by whitespace.
+
+**G-3 is the tell.** It was reported and fixed as "the spend policy keys on the
+raw URL while the catalog keys on the canonical one". The fix corrected the
+policy. Nobody asked the next question — *is the catalog actually doing what we
+just assumed it does?* — and the answer was no, for another eighteen days.
+
+**The rule, now enforced by test:** an identity has ONE derivation, exported, and
+every consumer calls it. Where two consumers genuinely cannot share code, there
+is a test that runs both over the same corpus and asserts they agree
+(`src/identity.agreement.test.ts`). Testing each side against its own definition
+is what produced this twice.
+
+**Where else this was checked, and found clean:** `asset` and `network` are
+compared verbatim and never used as a map key or a rate-limit bucket; `payer` is
+only ever counted into a Set for `uniquePayers`, never used for authorisation.
+`network` has a single derivation (`config.network`) with one consumer each in
+the policy and the error bodies.
+
 ### Lesson: a control's value can live in the work it prevents, not the outcome
 
 Found underneath the second incident, and it is the more interesting half.
@@ -950,7 +994,7 @@ change.
 | **G-9** | `verified_only` silently ignored when no trust resolver is injected | **open** — not reachable in production; `server.ts` always constructs one. |
 | **F4-ts** | Verification API is not deployed at all; the worker-service has never run hosted | **external, blocked on wallet-repo M5** — not a missing field. Chain: badge ← worker deployed ← `ATTESTOR_SECRET_KEY` ← M5 multisig attestor. |
 | **G-10** | The spend ceiling throttles honest throughput **22× earlier than sponsor exposure requires** | **open — pubnet tuning, deliberately NOT changed.** Spend is accounted at the ESTIMATE (500,000) while the measured CHARGED fee is 22,579, so the ceiling refuses the 101st settle in a window having actually spent **~0.23 XLM of the 5 XLM it names — 4.5%**. It **fails safe**, and the over-count is deliberate (`server.ts:344`: the real simulated fee is not exposed on the verify response). But the dial does not mean what its name implies. Fixing it means either exposing the bid to the policy or setting the estimate from measurement — both are pubnet decisions with real downside if the estimate ever *under*-counts, which is why nothing is being changed on the strength of one wallet's measurement. |
-| **G-13** | Facilitator error bodies do not conform to the x402 `SettleResponse` schema | **open — decision pending, not a defect of convenience.** The spec (`specs/x402-specification-v2.md` §5.3) marks `success`, `transaction` and `network` **Required**, with `errorReason` optional. Our refusals return `{error, reason}` and omit all three. That is why `HTTPFacilitatorClient` cannot build a structured `SettleError` and degrades to a generic throw — the seller-side symptom fixed in #28 was this, seen from the other end. **Conformance is the argument, not error ergonomics.** Deliberately NOT changed: it alters what every x402 client receives, so it is an owner decision rather than a maintenance one. |
+| **G-13** | Facilitator error bodies did not conform to the x402 `SettleResponse` / `VerifyResponse` schemas | **CLOSED-BY-TEST 2026-08-11.** All six error paths now carry the required fields — `success`/`transaction`/`network` on `/settle` (§5.3), `isValid` on `/verify` (§5.4) — with the legacy `error`/`reason` kept alongside so the change is strictly additive. This is what makes `HTTPFacilitatorClient` build a structured `SettleError` instead of a generic throw, so **#28's seller-side workaround becomes partly redundant**: the seller no longer has to dig a reason out of an error string, though its empty-body guard stays as defence for other facilitators. *(was: open — conformance, not convenience)* The spec (`specs/x402-specification-v2.md` §5.3) marks `success`, `transaction` and `network` **Required**, with `errorReason` optional. Our refusals return `{error, reason}` and omit all three. That is why `HTTPFacilitatorClient` cannot build a structured `SettleError` and degrades to a generic throw — the seller-side symptom fixed in #28 was this, seen from the other end. **Conformance is the argument, not error ergonomics.** Deliberately NOT changed: it alters what every x402 client receives, so it is an owner decision rather than a maintenance one. |
 | **G-11** | The canonical key did not normalise a **trailing slash**, so `…/quote` and `…/quote/` were separately bindable | **CLOSED-BY-TEST 2026-08-11.** Fixed as a family, not an instance — and the fix surfaced a larger one underneath: `upsertFromPayment` keyed the entry map on the merchant's RAW advertised URL while `recordSettlement`, `isBoundResource` and the spend policy all keyed on the canonical form. They agreed only because the demo seller reports one stable URL. G-3 fixed the policy side of that split; this side had been left behind. Old rows re-canonicalise on load, so no migration step. *(was: open, found 2026-08-11)* One resource, two catalog identities. A squatter can hold the variant its owner never settled against, and the owner's own binding does not protect it. Same family as G-3 (which stripped the query string but not this). Low severity while displacement can recover it, but it doubles every URL's attack surface for free. |
 | **G-12** | Bindings proven BEFORE displacement shipped load as displaceable | **open, one-time.** `ownership.verified_at` was added by the displacement migration and back-fills as NULL, so a pre-existing verified binding is displaceable until its owner settles once more and re-proves. Safe in practice — displacement requires proof, so only whoever controls the endpoint can act — but it silently reopens the 2C takeover case for exactly one window per binding. Closes itself as owners settle. |
 | **RA-14r** | RFC 6052 non-`/96` NAT64 offsets | deferred; not reachable in the current deployment. |

--- a/docs/walkthrough-results.md
+++ b/docs/walkthrough-results.md
@@ -92,7 +92,28 @@ settlements   3 -> 3      uniquePayers 1 -> 1      observed 3 -> 3
 
 A rejected upsert credited the victim with nothing.
 
-### G-3 — canonical resource key
+### G-3 — canonical resource key — **DOWNGRADED 2026-08-11: this did not test what it claimed**
+
+> **The evidence below is real, and it does not demonstrate catalog
+> canonicalisation.** Two settles with different query strings produced one
+> entry — but `upsertFromPayment` keyed the entry map on the merchant's RAW
+> advertised URL, and the seller reports one stable URL in its own 402 regardless
+> of the query. So the query string never reached the catalog, and one entry was
+> the only possible outcome whether or not the catalog canonicalised anything.
+>
+> **What it actually demonstrated:** the seller advertises a stable resource URL.
+> Worth knowing, not what was claimed.
+>
+> **What was genuinely proven, and where:** G-3's fix was to the SPEND POLICY key
+> (`server.ts`), and that is covered by unit tests which do exercise the
+> canonicaliser. The catalog half was fixed on 2026-08-11 under G-11 — it had
+> been keying on the raw URL the entire time.
+>
+> Downgraded under the same standard applied to everything else here. A test that
+> passes for a reason other than the one claimed is the RA-12 failure mode, and
+> it does not get an exemption for being ours.
+
+### G-3 — canonical resource key (as originally recorded)
 
 Two settles with different query strings
 (`867632de…`, `0fb01358…`, both `successful: true`, 22,579 each):

--- a/mutations/identity.json
+++ b/mutations/identity.json
@@ -1,0 +1,44 @@
+[
+  {
+    "label": "policyBucketKey reimplements the rule (drops trim)",
+    "file": "src/server.ts",
+    "find": "  return BazaarCatalog.canonicalPayTo(payTo) ?? \"<no-payto>\";",
+    "replace": "  return typeof payTo === \"string\" && payTo.length ? payTo : \"<no-payto>\";",
+    "test": "src/identity.agreement.test.ts"
+  },
+  {
+    "label": "upsert stops canonicalising payTo (padded copy hijack)",
+    "file": "src/catalog.ts",
+    "find": "    const payTo = BazaarCatalog.canonicalPayTo(requirements.payTo);\n    if (payTo === undefined) {",
+    "replace": "    const payTo = requirements.payTo as string | undefined;\n    if (payTo === undefined) {",
+    "test": "src/identity.agreement.test.ts"
+  },
+  {
+    "label": "junk payTo is bound instead of refused",
+    "file": "src/catalog.ts",
+    "find": "    if (typeof payTo !== \"string\") return undefined;\n    const trimmed = payTo.trim();\n    if (trimmed.length === 0 || trimmed.length > MAX_PAYTO_LEN) return undefined;\n    return trimmed;",
+    "replace": "    return String(payTo);",
+    "test": "src/identity.agreement.test.ts"
+  },
+  {
+    "label": "isBound reverts to the raw url",
+    "file": "src/catalog.ts",
+    "find": "    return this.entries.get(BazaarCatalog.canonicalResourceKey(resourceUrl))?.boundPayTo.includes(payTo) ?? false;",
+    "replace": "    return this.entries.get(resourceUrl)?.boundPayTo.includes(payTo) ?? false;",
+    "test": "src/identity.agreement.test.ts"
+  },
+  {
+    "label": "isVerifiedOwner reverts to the raw url",
+    "file": "src/catalog.ts",
+    "find": "    return this.entries.get(BazaarCatalog.canonicalResourceKey(resourceUrl))?.verifiedOwner ?? false;",
+    "replace": "    return this.entries.get(resourceUrl)?.verifiedOwner ?? false;",
+    "test": "src/identity.agreement.test.ts"
+  },
+  {
+    "label": "setVerifiedOwner reverts to the raw url",
+    "file": "src/catalog.ts",
+    "find": "    const entry = this.entries.get(BazaarCatalog.canonicalResourceKey(resourceUrl));",
+    "replace": "    const entry = this.entries.get(resourceUrl);",
+    "test": "src/identity.agreement.test.ts"
+  }
+]

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -38,6 +38,9 @@ const MAX_ACCEPTS = 20;
 /** Max ownership tombstones. At this cap the catalog FREEZES new bindings
  * rather than forgetting ownership — see `frozen`. */
 const MAX_TOMBSTONES = 100_000;
+/** Longest string that can be a payTo identity. Shared by the catalog and the
+ *  spend policy — see BazaarCatalog.canonicalPayTo. */
+export const MAX_PAYTO_LEN = 128;
 /** G-1 retry floors. A `mismatch` is a DEFINITE answer, so retrying it buys
  * nothing but outbound traffic — 24h makes it effectively terminal while still
  * self-healing after a legitimate operator rotation. An `unverifiable` is
@@ -652,6 +655,32 @@ export class BazaarCatalog {
    * Degrades to the raw string on an unparseable url — this is client-supplied,
    * so it must not throw, and a non-url simply cannot match a binding.
    */
+  /**
+   * The ONE derivation of a payTo identity.
+   *
+   * G-11's real finding was not the trailing slash, it was that one identity had
+   * two derivations that agreed only by luck. payTo was the same shape: the
+   * spend policy trimmed it and capped it at 128 chars (`policyBucketKey`, added
+   * to stop attacker-minted buckets), while the catalog compared the raw string
+   * — so `"G… "` and `"G…"` were ONE rate-limit bucket and TWO catalog
+   * identities.
+   *
+   * That is a hijack variant, not a curiosity: a padded copy of a victim's
+   * address binds a URL to something that renders identically in
+   * `/discovery/resources` while the victim's own clean address is "not bound"
+   * and locked out forever.
+   *
+   * Returns undefined for anything that cannot be an identity. Callers decide
+   * what that means — the policy collapses it into one shared bucket, the
+   * catalog refuses the upsert — but they no longer decide what the identity IS.
+   */
+  static canonicalPayTo(payTo: unknown): string | undefined {
+    if (typeof payTo !== "string") return undefined;
+    const trimmed = payTo.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_PAYTO_LEN) return undefined;
+    return trimmed;
+  }
+
   static canonicalResourceKey(rawUrl: string): string {
     try {
       const u = new URL(rawUrl);
@@ -943,6 +972,19 @@ export class BazaarCatalog {
     // spelling is precisely when raw and canonical diverge.
     const key = BazaarCatalog.canonicalResourceKey(discovered.resourceUrl);
     const existing = this.entries.get(key);
+
+    // One derivation, shared with the spend policy. An unusable payTo is refused
+    // outright rather than bound: a binding nobody can ever match is a URL
+    // permanently removed from its owner.
+    const payTo = BazaarCatalog.canonicalPayTo(requirements.payTo);
+    if (payTo === undefined) {
+      console.warn(
+        `[catalog] rejected upsert for ${key}: payTo is not a usable identity ` +
+          `(non-string, empty, or over ${MAX_PAYTO_LEN} chars)`,
+      );
+      return false;
+    }
+    requirements = { ...requirements, payTo };
 
     // F3: an evicted entry leaves its ownership tombstone behind, so a URL that
     // was cached out cannot be reclaimed by a different payTo. This is what stops

--- a/src/identity.agreement.test.ts
+++ b/src/identity.agreement.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { BazaarCatalog, MAX_PAYTO_LEN } from "./catalog.js";
+import { policyBucketKey } from "./server.js";
+import { tmpStore } from "./store.testkit.js";
+
+// ============================================================================
+// THE CLASS, not the instances.
+//
+// G-11 was reported as "the canonical key does not strip a trailing slash". The
+// actual finding was structural: ONE IDENTITY HAD SEVERAL DERIVATIONS, and they
+// agreed only because one seller happened to report one stable URL.
+//
+//   resource url   upsertFromPayment keyed on the RAW advertised url, while
+//                  recordSettlement / isBoundResource / the spend policy all
+//                  keyed on the canonical form. G-3 fixed the policy side; this
+//                  side was never checked against it.
+//   payTo          policyBucketKey trimmed and length-capped it; the catalog
+//                  compared the raw string. So `"G… "` and `"G…"` were ONE
+//                  rate-limit bucket and TWO catalog identities.
+//
+// Neither had a test that the derivations agreed, because each was tested
+// against its own definition. This file tests the AGREEMENT, which is the only
+// thing that was ever actually load-bearing.
+// ============================================================================
+
+const OWNER = "GAOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function disc(url: string): DiscoveredResource {
+  return {
+    resourceUrl: url,
+    x402Version: 2,
+    discoveryInfo: { input: { type: "http", method: "GET" } },
+  } as unknown as DiscoveredResource;
+}
+function reqs(payTo: unknown): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CASSET",
+    amount: "1",
+    payTo,
+    maxTimeoutSeconds: 60,
+  } as unknown as PaymentRequirements;
+}
+
+describe("payTo — one derivation, shared", () => {
+  const corpus: unknown[] = [
+    OWNER,
+    ` ${OWNER}`,
+    `${OWNER} `,
+    `\t${OWNER}\n`,
+    "",
+    "   ",
+    "G".repeat(MAX_PAYTO_LEN),
+    "G".repeat(MAX_PAYTO_LEN + 1),
+    undefined,
+    null,
+    42,
+    { payTo: OWNER },
+    ["G"],
+  ];
+
+  it("the catalog and the spend policy agree on every input, including the junk", () => {
+    // MUTATION: reinstate a second copy of the rule in policyBucketKey — e.g.
+    // drop the .trim(). The padded variants then disagree: one bucket, two
+    // identities, which is the hijack described above.
+    //
+    // policyBucketKey is not exported (it is a route-level detail), so the
+    // agreement is asserted through the derivation both sides now call. The
+    // point is that there IS only one, and this test fails the moment a second
+    // appears that disagrees.
+    // THE AGREEMENT ITSELF. Both sides are called and compared on the same
+    // corpus — this is the assertion that never existed, and its absence is what
+    // let the two drift apart while each stayed green against its own definition.
+    for (const input of corpus) {
+      const catalogIdentity = BazaarCatalog.canonicalPayTo(input);
+      const policyBucket = policyBucketKey(input);
+      expect(policyBucket, `disagreement for ${JSON.stringify(input)}`).toBe(
+        catalogIdentity ?? "<no-payto>",
+      );
+    }
+    expect(BazaarCatalog.canonicalPayTo(` ${OWNER} `), "whitespace is not identity").toBe(OWNER);
+    expect(BazaarCatalog.canonicalPayTo(OWNER)).toBe(OWNER);
+    expect(BazaarCatalog.canonicalPayTo(""), "empty is not an identity").toBeUndefined();
+    expect(BazaarCatalog.canonicalPayTo(42), "non-strings are not identities").toBeUndefined();
+    expect(BazaarCatalog.canonicalPayTo("G".repeat(MAX_PAYTO_LEN + 1)), "over the cap").toBeUndefined();
+  });
+
+  it("a padded copy of the owner's address cannot become a second identity", async () => {
+    // THE HIJACK VARIANT. Before the fix this bound the URL to a string that
+    // renders identically in /discovery/resources while the owner's own clean
+    // address read as "not bound" — locked out of their URL, permanently,
+    // by something invisible on screen.
+    //
+    // MUTATION: remove the canonicalPayTo call from upsertFromPayment. The
+    // padded form becomes a distinct identity and this fails.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    expect(await catalog.upsertFromPayment(disc("https://api.example.com/q"), reqs(` ${OWNER}`))).toBe(true);
+
+    // The clean address must be the SAME owner, not a stranger.
+    expect(catalog.isBound("https://api.example.com/q", OWNER), "one identity").toBe(true);
+    // A second settle by the SAME (now canonical) owner is an ordinary update,
+    // not a refused hijack — which is the whole point: they are one party.
+    expect(
+      await catalog.upsertFromPayment(disc("https://api.example.com/q"), reqs(OWNER)),
+      "and the owner is not locked out of their own URL",
+    ).toBe(false);
+    expect(catalog.isBound("https://api.example.com/q", OWNER), "still theirs").toBe(true);
+  });
+
+  it("an unusable payTo is REFUSED, never bound", async () => {
+    // A binding nobody can ever match removes the URL from its owner for good.
+    // MUTATION: return the raw value instead of undefined for junk. The upsert
+    // succeeds and the URL is bound to something unmatched by any real payment.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    for (const junk of ["", "   ", "G".repeat(MAX_PAYTO_LEN + 1), 42, null]) {
+      expect(
+        await catalog.upsertFromPayment(disc("https://api.example.com/junk"), reqs(junk)),
+        `${JSON.stringify(junk)} must not bind`,
+      ).toBe(false);
+    }
+    expect(catalog.size, "nothing was cataloged").toBe(0);
+  });
+});
+
+describe("resource url — one derivation, shared", () => {
+  it("every keyed call site agrees with upsertFromPayment", async () => {
+    // MUTATION: revert any one of upsertFromPayment / isBound / isVerifiedOwner /
+    // setVerifiedOwner to the raw url. That call site then disagrees with the
+    // others for any spelling where raw != canonical, which is exactly the state
+    // that went unnoticed for the whole engagement.
+    const { store } = tmpStore();
+    const catalog = await BazaarCatalog.create(store);
+    const CANON = "https://api.example.com/quote";
+    await catalog.upsertFromPayment(disc(CANON), reqs(OWNER));
+
+    for (const spelling of [
+      CANON,
+      "https://api.example.com/quote/",
+      "https://api.example.com//quote",
+      "https://API.EXAMPLE.COM/quote",
+      "https://api.example.com/quote?x=1",
+      "https://api.example.com/qu%6Fte",
+    ]) {
+      expect(catalog.isBound(spelling, OWNER), `isBound: ${spelling}`).toBe(true);
+      expect(catalog.isBoundResource(spelling, OWNER), `isBoundResource: ${spelling}`).toBe(true);
+      expect(catalog.recordSettlement(spelling, "CPAYER", OWNER), `recordSettlement: ${spelling}`).toBe(true);
+      // setVerifiedOwner/isVerifiedOwner round-trip through the same key.
+      // Both directions must use the spelling, or a raw-keyed reader passes by
+      // being handed the canonical form it was going to look up anyway.
+      catalog.setVerifiedOwner(spelling, true);
+      expect(catalog.isVerifiedOwner(spelling), `isVerifiedOwner: ${spelling}`).toBe(true);
+      expect(catalog.isVerifiedOwner(CANON), `setVerifiedOwner: ${spelling}`).toBe(true);
+      catalog.setVerifiedOwner(spelling, false);
+    }
+    expect(catalog.size, "and it was one resource the whole time").toBe(1);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,6 +68,10 @@ export async function buildServer(
   policy?: SpendPolicy,
   hardening: HardeningOptions = {},
   balanceGuard?: BalanceGuard,
+  /** CAIP-2 network id, echoed in conformant error bodies (G-13, spec §5.3
+   *  marks it Required). The production call site passes config.network; the
+   *  default keeps the many test call sites terse and is asserted to match. */
+  network: string = "stellar:testnet",
 ) {
   const bodyLimit = hardening.bodyLimitBytes ?? DEFAULT_BODY_LIMIT;
   // Fix 2: a body-limit floor for /verify and /settle (well under Fastify's 1 MiB
@@ -139,18 +143,24 @@ export async function buildServer(
   app.post<{ Body: FacilitatorRequestBody }>("/verify", async (request, reply) => {
     const { paymentPayload, paymentRequirements } = request.body ?? {};
     if (!paymentPayload || !paymentRequirements) {
-      return reply
-        .status(400)
-        .send({ error: "invalid_body", detail: "paymentPayload and paymentRequirements are required" });
+      return reply.status(400).send(
+        verifyError("invalid_body", {
+          error: "invalid_body",
+          detail: "paymentPayload and paymentRequirements are required",
+        }),
+      );
     }
     // Fix 2: shed obviously-malformed payloads at the route, before spending an
     // RPC simulation. /verify is the free amplification path (an invalid payload
     // still costs one simulation upstream), so reject anything whose transaction
     // isn't parseable XDR without a network round-trip.
     if (!isParseableTransactionXdr(paymentPayload)) {
-      return reply
-        .status(400)
-        .send({ error: "invalid_payload", detail: "payload.transaction is not a parseable transaction envelope" });
+      return reply.status(400).send(
+        verifyError("invalid_payload", {
+          error: "invalid_payload",
+          detail: "payload.transaction is not a parseable transaction envelope",
+        }),
+      );
     }
     return facilitator.verify(paymentPayload, paymentRequirements);
   });
@@ -158,24 +168,35 @@ export async function buildServer(
   app.post<{ Body: FacilitatorRequestBody }>("/settle", async (request, reply) => {
     const { paymentPayload, paymentRequirements } = request.body ?? {};
     if (!paymentPayload || !paymentRequirements) {
-      return reply
-        .status(400)
-        .send({ error: "invalid_body", detail: "paymentPayload and paymentRequirements are required" });
+      return reply.status(400).send(
+        settleError(network, "invalid_body", {
+          error: "invalid_body",
+          detail: "paymentPayload and paymentRequirements are required",
+        }),
+      );
     }
     // Re-audit: shed unsubmittable payloads BEFORE reserving spend budget,
     // symmetric with /verify. Junk costs the sponsor no XLM, so it must not be
     // able to consume the global ceiling and refuse real settlement.
     if (!isParseableTransactionXdr(paymentPayload)) {
-      return reply
-        .status(400)
-        .send({ error: "invalid_payload", detail: "payload.transaction is not a parseable transaction envelope" });
+      return reply.status(400).send(
+        settleError(network, "invalid_payload", {
+          error: "invalid_payload",
+          detail: "payload.transaction is not a parseable transaction envelope",
+        }),
+      );
     }
     // Fix 3: refuse settle when the sponsor is below the hard balance floor —
     // fees would fail on-chain anyway. Discovery is unaffected. A failed/absent
     // balance check leaves settle allowed (fail open).
     if (balanceGuard && !balanceGuard.settleAllowed()) {
       request.log.error({ balanceStatus: balanceGuard.status() }, "[balance] settle refused: sponsor below hard floor");
-      return reply.status(503).send({ error: "settlement_refused", reason: "sponsor_balance_low" });
+      return reply.status(503).send(
+        settleError(network, "sponsor_balance_low", {
+          error: "settlement_refused",
+          reason: "sponsor_balance_low",
+        }),
+      );
     }
     // Fix 1: consult the spend policy before spending sponsor XLM. On pubnet a
     // tripped per-payTo rate limit or global spend ceiling refuses with 503; on
@@ -210,9 +231,12 @@ export async function buildServer(
           { payTo: payToKey, reason: verdict.reason },
           "[policy] settle refused",
         );
-        return reply
-          .status(503)
-          .send({ error: "settlement_refused", reason: verdict.reason });
+        return reply.status(503).send(
+          settleError(network, verdict.reason ?? "spend_policy", {
+            error: "settlement_refused",
+            reason: verdict.reason,
+          }),
+        );
       }
       if (verdict.wouldReject) {
         request.log.warn(
@@ -305,12 +329,39 @@ export async function buildServer(
  * attacker-chosen keys. Anything that is not a plausibly-shaped Stellar address
  * string collapses into one shared bucket, which cannot earn free settles.
  */
-const MAX_PAYTO_KEY_LEN = 128;
-function policyBucketKey(payTo: unknown): string {
-  if (typeof payTo !== "string") return "<no-payto>";
-  const trimmed = payTo.trim();
-  if (trimmed.length === 0 || trimmed.length > MAX_PAYTO_KEY_LEN) return "<no-payto>";
-  return trimmed;
+/**
+ * G-13 — x402 conformance for facilitator error responses.
+ *
+ * `x402-specification-v2.md` §5.3 marks `success`, `transaction` and `network`
+ * REQUIRED on a SettleResponse (`transaction` is the empty string when
+ * settlement failed), and §5.4 marks `isValid` REQUIRED on a VerifyResponse.
+ * Our refusals returned `{error, reason}` and omitted all of them.
+ *
+ * That is not an ergonomics problem, it is non-conformance, and it had a
+ * concrete cost: `HTTPFacilitatorClient` requires `"success" in data` before it
+ * will build a structured `SettleError` (`@x402/core/http`, index.js:1120).
+ * Without the field it throws a GENERIC error instead, whose message happens to
+ * carry the body as text — which is why every facilitator refusal reached the
+ * seller as an unexplained empty 402 until the seller was patched to dig the
+ * reason out of an error string. Conformance fixes that at the source, for every
+ * client, not just the one seller we control.
+ *
+ * The legacy `error`/`reason` fields are KEPT alongside. Extra fields are
+ * permitted, and removing them would break anything already reading them —
+ * including our own seller. This change is strictly additive.
+ */
+function settleError(network: string, errorReason: string, extra: Record<string, unknown> = {}) {
+  return { success: false, transaction: "", network, errorReason, ...extra };
+}
+function verifyError(invalidReason: string, extra: Record<string, unknown> = {}) {
+  return { isValid: false, invalidReason, ...extra };
+}
+
+export function policyBucketKey(payTo: unknown): string {
+  // Delegates to the SAME derivation the catalog uses. It used to reimplement
+  // the rule, which is how the two drifted: identical intent, two copies, no
+  // test that they agreed. See BazaarCatalog.canonicalPayTo.
+  return BazaarCatalog.canonicalPayTo(payTo) ?? "<no-payto>";
 }
 
 /**
@@ -382,7 +433,15 @@ if (isDirectRun) {
   });
   balanceGuard.start();
 
-  const app = await buildServer(buildFacilitator(config), catalog, trust, policy, {}, balanceGuard);
+  const app = await buildServer(
+    buildFacilitator(config),
+    catalog,
+    trust,
+    policy,
+    {},
+    balanceGuard,
+    config.network,
+  );
   app.listen({ port: config.port, host: config.host }).catch((err) => {
     app.log.error(err);
     process.exit(1);


### PR DESCRIPTION
**#34 is marked merged and its content is not on `main`.** Re-landing it unchanged.

## What happened

| | |
|---|---|
| **10:45:40** | #33 **squash-merged into `main`** — G-11 only |
| **11:02:16** | #34 merged into `fix/g11-canonical-key` — a branch that had already been squashed away |

GitHub's "merged" is truthful; it just wasn't into `main`. **My error:** I retargeted #34 to stack on #33 to clear a conflict, then advised merging #33 first. With *squash* merges that ordering strands the child — the parent's squash captures the branch as it stood, and a child merging afterwards lands nowhere reachable. A stacked child must merge **before** the parent, or be retargeted to `main` after.

## Content

Identical to #34, cherry-picked onto `main`, no edits:

- **G-13** — all six error paths carry the spec-required fields (`success`/`transaction`/`network` per §5.3, `isValid` per §5.4), legacy `error`/`reason` kept alongside so it stays additive.
- **The payTo identity split** — `policyBucketKey` trimmed while the catalog compared raw, so `"G… "` and `"G…"` were one rate-limit bucket and two catalog identities.
- **`identity.agreement.test.ts`** — runs both derivations over one corpus and asserts they agree.

327 tests, typecheck clean, 6/6 mutations caught.

## Verifying it landed

Because "merged" was not enough this time, the check after merge is content, not status:

```
git merge-base --is-ancestor <sha> origin/main
grep -c canonicalPayTo src/catalog.ts
```