### PR TITLE
tools: assert a merged PR's content is on main

### DIFF
--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -3,10 +3,12 @@
 **As of 2026-08-11, against merged `main` (`d6404e4`).** 323 tests passing, 3
 skipped (the opt-in live gate), typecheck clean, CI gating every PR.
 
-One change is **not** on `main` yet: [#35](https://github.com/Vellar-Wallet/vellar-facilitator/pull/35),
-which re-lands G-13 and G-14 after #34 merged into a branch that had already been
-squashed away. Everything below marked *pending #35* is written, tested and
-mutation-verified, and is not deployed.
+**Everything is on `main`, verified by content rather than by status**
+(`node scripts/verify-merged.mjs 35 36 21 22` → 4 landed). 327 tests passing.
+
+One thing is still outstanding: a **deploy**. G-14 is a live hijack path, `main`
+has the fix, and the running instance does not until the facilitator is
+redeployed.
 
 ---
 
@@ -71,8 +73,8 @@ the risk still exists in a different place. **Open**: still true.
 | **G-10** | Spend ceiling throttles honest throughput **22× earlier than sponsor exposure requires** | **open — pubnet tuning.** Accounting uses the 500,000 estimate against a measured 22,579 charge, so the ceiling refuses the 101st settle having spent ~0.23 of the 5 XLM it names. Fails safe; deliberately unchanged |
 | **G-11** | One resource, several canonical keys | closed-by-test — fixed as a family, and it surfaced the class in §3 |
 | **G-12** | Bindings proven before displacement load as displaceable | **open, self-closing.** One window per binding; recorded in runbook §1 |
-| **G-13** | Error bodies non-conformant with the x402 schemas | closed-by-test — *pending #35* |
-| **G-14** | **payTo identity split — whitespace hijack** | closed-by-test — *pending #35*. **See §2** |
+| **G-13** | Error bodies non-conformant with the x402 schemas | closed-by-test |
+| **G-14** | **payTo identity split — whitespace hijack** | closed-by-test. **See §2** |
 
 ### Deployment findings — D-1…D-4
 
@@ -85,7 +87,7 @@ the risk still exists in a different place. **Open**: still true.
 
 ---
 
-## 2. G-14 — payTo whitespace hijack — **Medium** — closed-by-test *(pending #35)*
+## 2. G-14 — payTo whitespace hijack — **Medium** — closed-by-test, **not yet deployed**
 
 Given its own entry because it is exploitable, it is invisible in the output, and
 nobody scanning for real vulnerabilities should have to read a methodology
@@ -173,6 +175,26 @@ exits non-zero, and `mutations/harness-selftest.json` is a deliberately wrong
 anchor that must always abort. **A verification step that cannot fail loudly is
 not a verification step.**
 
+### 3.4b Content was reported merged and was not there — five times
+
+| | PR | What was lost |
+| --- | --- | --- |
+| 1–3 | #6, #9, #13 | Doc sections; a silent `replace()` no-op, blamed on GitHub's squash for days |
+| 4 | #23 | The D-1…D-3 bodies, which had never landed |
+| 5 | #34 | G-13 and G-14 — **merged into a branch that had been squash-merged 17 minutes earlier** |
+
+**Every catch was incidental**: a test count that looked wrong, a PR title in a
+list, a grep run for another reason. Five incidental catches is not a process.
+
+`scripts/verify-merged.mjs <pr>...` now asserts a merged PR's **content** is on
+main, and is run after every merge. Note what it deliberately does *not* do:
+`git merge-base --is-ancestor <head> main` is useless here, because a squash
+rewrites the branch and the head SHA is never an ancestor — that check fails
+identically for a healthy merge and for #34, so it distinguishes nothing. The
+script checks the base branch, provenance on main, and whether the PR's
+distinctive added lines are actually present. `--selftest` runs it against #34,
+which must always fail; if it ever reports LANDED, the check has regressed.
+
 ### 3.5 Tests that passed for the wrong reason — three times
 
 1. **RA-12** — eight tests green against deliberately broken code; the control
@@ -241,7 +263,7 @@ argument fails with the code.
 | **F12** per-URL / per-payTo budgets | **The one gap.** Needs 11 settles inside 60s; the harness manages 6 at ~8s each. Requires **one funded classic source account per concurrent settler** — sharing one gives `tx_bad_seq`, and the resulting 1-success/10-failure result *looks* like a budget refusing when F12 is log-only on testnet and cannot refuse. Also needs `STELLAR_NETWORK=pubnet` against testnet RPC to see a real 503, or assertion on the `{payTo, wouldReject}` log. Full procedure in runbook §7 |
 | **G-5, G-6, G-7** | Closed structurally by the migration; the states they describe are no longer representable, so there is nothing to demonstrate |
 | **RA-1…RA-8, RA-10…RA-14** | Input-validation and guard logic; a live run adds nothing a mutation-verified test does not |
-| **G-13, G-14** | Written and mutation-verified, **not deployed** — pending #35 |
+| **G-13, G-14** | On `main` and mutation-verified. **Not yet on the running instance** — a deploy is the last step, and G-14 is a live hijack path until then |
 
 ---
 
@@ -251,7 +273,7 @@ argument fails with the code.
 
 | Item | Note |
 | --- | --- |
-| **#35** | Re-land G-13 + G-14. Written, tested, mutation-verified. **Verify by content, not by "merged"** |
+| **Deploy `main`** | G-13 + G-14 are merged and *not running*. `scripts/verify-merged.mjs` confirms they are on `main`; only a redeploy puts them in front of traffic |
 | **F12 live demonstration** | Half a day, needs N funded source accounts. The last control with no live evidence |
 | **The 1-in-3 submission failures** | `settle_exact_stellar_transaction_submission_failed`, `transaction: ""`. Reproduced twice at the same rate (3/11, 3/9). Not the cutover — it fails before the chain sees anything. Costs nothing. Next step: capture the RPC's own error beneath that reason string and re-run against a second provider. **A lead, not a cause** |
 
@@ -283,8 +305,9 @@ reachable here), **G-9** (not reachable in production), **G-12** (self-closing).
 
 ### Blockers — must be true before `STELLAR_NETWORK=pubnet`
 
-1. **#35 merged and verified on `main` by content.** G-14 is a live hijack path
-   and it is not deployed. Non-negotiable.
+1. **G-14 actually deployed.** It is merged and verified on `main`; the running
+   instance does not have it. A live hijack path closed in the repo is not
+   closed. Non-negotiable.
 2. **F12 demonstrated, or explicitly accepted as unproven in writing.** It is the
    only control with no live evidence, and pubnet is where it stops being
    log-only and starts refusing real money. Shipping a control whose first real

--- a/scripts/verify-merged.mjs
+++ b/scripts/verify-merged.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Assert that a merged PR's CONTENT is actually on main.
+//
+// WHY THIS EXISTS. Five times in this engagement, content was reported merged
+// and was not on main. Every catch was incidental — a test count that looked
+// wrong, a PR title in a list, a grep run for another reason. Two mechanisms
+// were eventually identified:
+//
+//   1. A doc script anchored on text that did not exist, so `String.replace()`
+//      silently no-opped and the "merged" PR carried no change (#6, #9, #13,
+//      and the D-1..D-3 bodies in #23).
+//   2. A STACKED PR merged into its parent branch AFTER the parent had already
+//      been squash-merged to main, so the child landed somewhere unreachable
+//      (#34 — reported MERGED, 17 minutes after its base was squashed away).
+//
+// `scripts/mutate.mjs` made the first class impossible to report as a pass.
+// This is the same problem one level up.
+//
+// ── WHY NOT `git merge-base --is-ancestor <head> main` ──────────────────────
+// Because this repo squash-merges. A squash rewrites the branch into one new
+// commit, so the PR's head SHA is NEVER an ancestor of main — the check reports
+// failure for perfectly healthy merges, and would have reported the same failure
+// for #34. A check that fails identically for the good and the bad case carries
+// no information. Ancestry is used here only when a real merge commit exists.
+//
+// What actually distinguishes the cases is CONTENT: did the lines this PR added
+// arrive in main's copy of those files?
+//
+// Usage:
+//   node scripts/verify-merged.mjs 35 36 21 22
+//   node scripts/verify-merged.mjs --selftest    # 34 must FAIL
+//
+// Exit 0 only if every PR passes. Run it after every merge.
+
+import { execFileSync } from "node:child_process";
+
+const sh = (cmd, args) => execFileSync(cmd, args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 });
+const gh = (args) => JSON.parse(sh("gh", args));
+
+/** Lines a human would recognise: long enough to be distinctive, not scaffolding. */
+function distinctiveAdditions(patch) {
+  const byFile = new Map();
+  let file = null;
+  for (const line of patch.split("\n")) {
+    const m = /^\+\+\+ b\/(.+)$/.exec(line);
+    if (m) {
+      file = m[1];
+      if (!byFile.has(file)) byFile.set(file, []);
+      continue;
+    }
+    if (!file || !line.startsWith("+") || line.startsWith("+++")) continue;
+    const body = line.slice(1).trim();
+    // Skip scaffolding that legitimately recurs everywhere and would pass by
+    // coincidence: braces, imports, short fragments, pure punctuation.
+    if (body.length < 25) continue;
+    if (/^(import |export \{|\}|\);|\* |\/\/ |# )/.test(body)) continue;
+    byFile.get(file).push(body);
+  }
+  return byFile;
+}
+
+function verify(pr) {
+  const meta = gh(["pr", "view", String(pr), "--json", "state,mergedAt,baseRefName,headRefOid,mergeCommit,title"]);
+  const problems = [];
+  const notes = [];
+
+  if (meta.state !== "MERGED") problems.push(`state is ${meta.state}, not MERGED`);
+
+  // CHECK 1 — the base. This alone catches the stacked-squash case: #34 was
+  // MERGED, but into `fix/g11-canonical-key`, not into main.
+  if (meta.baseRefName !== "main") {
+    problems.push(
+      `merged into "${meta.baseRefName}", NOT main — if that branch was squash-merged first, this content is unreachable`,
+    );
+  }
+
+  // CHECK 2 — provenance on main. A squash commit referencing (#N), or a real
+  // merge commit that is an ancestor.
+  const squash = sh("git", ["log", "origin/main", "--oneline", `--grep=(#${pr})`, "-1"]).trim();
+  const mergeSha = meta.mergeCommit?.oid;
+  let ancestor = false;
+  if (mergeSha) {
+    try {
+      execFileSync("git", ["merge-base", "--is-ancestor", mergeSha, "origin/main"], { stdio: "ignore" });
+      ancestor = true;
+    } catch {
+      /* not an ancestor */
+    }
+  }
+  if (!squash && !ancestor) problems.push(`no commit on main references (#${pr}) and no merge commit is an ancestor`);
+  else notes.push(squash ? `on main as ${squash.split(" ")[0]}` : `merge commit ${mergeSha.slice(0, 8)} is an ancestor`);
+
+  // CHECK 3 — the content itself. The only check that would have caught the
+  // silent-no-op class, where the PR was merged into main correctly and simply
+  // contained nothing.
+  const patch = sh("gh", ["pr", "diff", String(pr), "--patch"]);
+  const additions = distinctiveAdditions(patch);
+  let filesChecked = 0;
+  for (const [file, lines] of additions) {
+    if (lines.length === 0) continue;
+    filesChecked++;
+    let current;
+    try {
+      current = sh("git", ["show", `origin/main:${file}`]);
+    } catch {
+      problems.push(`${file}: added by this PR but absent from main`);
+      continue;
+    }
+    const landed = lines.filter((l) => current.includes(l)).length;
+    if (landed === 0) {
+      problems.push(`${file}: NONE of its ${lines.length} distinctive added lines are in main`);
+    } else if (landed < lines.length * 0.5) {
+      notes.push(`${file}: only ${landed}/${lines.length} added lines present — later edits, or a partial landing`);
+    }
+  }
+  if (filesChecked === 0) notes.push("no substantive additions to verify (deletions/renames only)");
+
+  return { pr, title: meta.title, problems, notes };
+}
+
+const selftest = process.argv.includes("--selftest");
+const prs = selftest ? [34] : process.argv.slice(2).filter((a) => /^\d+$/.test(a));
+if (prs.length === 0) {
+  console.error("usage: node scripts/verify-merged.mjs <pr>...   |   --selftest");
+  process.exit(2);
+}
+
+let failed = 0;
+for (const pr of prs) {
+  const r = verify(pr);
+  const ok = r.problems.length === 0;
+  if (!ok) failed++;
+  console.log(`\n  ${ok ? "LANDED" : "NOT LANDED"}  #${r.pr}  ${r.title.slice(0, 62)}`);
+  for (const n of r.notes) console.log(`            · ${n}`);
+  for (const p of r.problems) console.log(`      FAIL  ${p}`);
+}
+
+if (selftest) {
+  // #34 is the known-bad case, preserved deliberately: MERGED, but into a branch
+  // that had already been squashed away. If this ever reports LANDED, the check
+  // has regressed and cannot be trusted on a real merge.
+  const pass = failed === 1;
+  console.log(`\n  SELF-TEST: #34 must NOT land — ${pass ? "correct" : "REGRESSED, this script is not trustworthy"}`);
+  process.exit(pass ? 0 : 1);
+}
+
+console.log(`\n  ${prs.length} PR(s) checked, ${failed} not landed.`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Five times content was reported merged and wasn't. **Every catch was incidental** — a test count that looked wrong, a PR title in a list, a grep run for another reason.

| | PR | Lost |
|---|---|---|
| 1–3 | #6, #9, #13 | Doc sections — silent `replace()` no-op, blamed on GitHub's squash for days |
| 4 | #23 | The D-1…D-3 bodies, which had never landed |
| 5 | #34 | G-13 + G-14 — merged into a branch squash-merged **17 minutes earlier** |

`scripts/mutate.mjs` made the first class impossible to report as a pass. This is the same problem one level up.

## What it deliberately does NOT do

**`git merge-base --is-ancestor <head> main`.** This repo squash-merges, so a PR's head SHA is *never* an ancestor. That check reports failure for all four healthy merges **and** for #34 — it distinguishes nothing. A check that fails identically in the good and bad case carries no information.

## What it checks

1. **Base branch is `main`** — catches #34 on its own
2. **Provenance**: a squash commit referencing `(#N)`, or a merge commit that is an ancestor
3. **Content**: the PR's distinctive added lines are present in main's copy of each file — the only check that catches the silent-no-op class, where the PR merged correctly and contained nothing

`--selftest` runs it against #34, which must always fail. If it ever reports LANDED, the check has regressed — same design as `mutations/harness-selftest.json`.

```
$ node scripts/verify-merged.mjs 35 36 21 22
  LANDED  #35 …    · on main as e1002c6
  LANDED  #36 …    · on main as 8044a33
  LANDED  #21 …    · on main as 2920305
  LANDED  #22 …    · on main as 96555f7
  4 PR(s) checked, 0 not landed.

$ node scripts/verify-merged.mjs --selftest
  NOT LANDED  #34 …
      FAIL  merged into "fix/g11-canonical-key", NOT main
      FAIL  no commit on main references (#34)
  SELF-TEST: #34 must NOT land — correct
```

Closing doc updated: everything reads as landed, and the last open item is a **deploy** — pubnet blocker 1 reworded from *"merge #35"* to *"actually deployed"*, because a hijack path closed in the repo is not closed.