### PR TITLE
docs: sweep the post-Turso stale claims, and record the trust deferral's chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,34 @@ misconfiguration:
 "trust": { "verification": "unknown", "acceptsVerification": ["unknown"], … }
 ```
 
-The verdicts come from a **verification API that is deployed nowhere**. It is a
-worker-service in the Vellar wallet repository, blocked on that repo's M5
-multisig attestor: no attestor key, no worker deployment, no verdict source. So
-`VERIFICATION_API_URL` is deliberately unset, and every verdict degrades to
+The verdicts come from a **verification API that is deployed nowhere**, and this
+is a **deliberate deferral with a known dependency chain**, not an oversight or a
+missing config value:
+
+```
+  trust badges  ←  a verdict source
+                     ←  worker-service deployed        (needs a Docker host)
+                          ←  ATTESTOR_SECRET_KEY       (needs an attestor)
+                               ←  M5 multisig design   (unresolved)
+```
+
+Each link is blocked by the one below it, and the bottom one is a design decision
+in the wallet repository, not a deployment task here. **Nothing about this is
+switching on soon**, and it will not be switched on to produce testnet badges —
+turning it on for a demo would mean standing up a Docker host and minting an
+attestor key ahead of the multisig design that is supposed to govern it, which
+inverts the thing the attestor exists for.
+
+So `VERIFICATION_API_URL` is deliberately unset, and every verdict degrades to
 `"unknown"` — the honest default, since the alternative is asserting a trust
 level nothing backs. Tracked as **F4-ts**.
+
+Two prerequisites are being done in the wallet repo regardless, because they are
+defects in the API's design rather than in its deployment: **per-record
+timestamps** (the current response has none, so "newest verdict" falls back to
+array order) and **endpoint authentication** (it is unauthenticated, which would
+make it a trust root anyone could impersonate). Neither produces a badge here;
+both must be true before one would be worth trusting.
 
 **What this does NOT mean.** Two different things in that block are called
 "verified", and only one of them is inert:

--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -195,6 +195,43 @@ script checks the base branch, provenance on main, and whether the PR's
 distinctive added lines are actually present. `--selftest` runs it against #34,
 which must always fail; if it ever reports LANDED, the check has regressed.
 
+### 3.4c Documentation describing behaviour a shipped change removed
+
+Same shape as the seller's hardcoded `localhost` boot log and the
+`bindLoadedEntry` comment that described a path which did not exist — **but in
+the highest-traffic location in the repository**, the README a developer reads
+first.
+
+It said: *"an empty catalog after an idle period is expected — not a fault"*,
+because spin-down destroyed the container's filesystem. True when written. False
+the moment durable storage shipped — the catalog now survives, verified across a
+42-second cold start. So the README was **telling a developer that a symptom is
+normal when it had become a signal that something is wrong**, which is worse than
+saying nothing: it actively stops the investigation that would find the fault.
+
+**The sweep after the change was partial, and one stale claim was the tell.**
+Checking the rest found more, all of it in documents read as current instruction
+rather than as history:
+
+- **runbook §1** — I rewrote its SQL steps and left the preamble telling the
+  operator to get "shell access to the instance and its persistent disk" and stop
+  the service before editing "the ownership file". My own partial sweep, three
+  days after writing the fix.
+- **runbook §2** — an entire migration procedure for `CATALOG_OWNERSHIP_BOOTSTRAP`,
+  a flag that no longer exists, describing files that no longer exist. **Deleted
+  rather than banner-ed**: under pressure an operator reads the steps, not the
+  disclaimer above them.
+- **runbook §3, §5** — instructions to delete "the ownership file", and the same
+  false "empty catalog is expected" claim.
+- **guide.md** — a startup command setting `CATALOG_FILE`, which is now ignored
+  with a warning.
+
+**The rule:** a change that removes a behaviour is not finished when the code
+lands. Grep the docs for the vocabulary of the thing you removed — the *file*,
+the *flag*, the *disk* — and treat every hit in an instructional document as a
+defect. Hits in dated records (briefs, walkthroughs, decision logs) are correct
+and should stay; they describe what was true when written.
+
 ### 3.5 Tests that passed for the wrong reason — three times
 
 1. **RA-12** — eight tests green against deliberately broken code; the control
@@ -290,7 +327,7 @@ argument fails with the code.
 
 | Item | Note |
 | --- | --- |
-| **F4-ts** | Blocked on the wallet repo's M5 multisig attestor. Chain: badge ← worker deployed ← `ATTESTOR_SECRET_KEY` ← M5 |
+| **F4-ts** | **Deferred deliberately, not pending.** Chain: trust badge ← a verdict source ← worker-service deployed (needs a Docker host) ← `ATTESTOR_SECRET_KEY` (needs an attestor) ← M5 multisig design (unresolved). Each link is blocked by the one below, and the bottom is a wallet-repo design decision. **It will not be switched on to produce testnet badges** — that would mean minting an attestor key ahead of the multisig design meant to govern it. Two prerequisites proceed regardless because they are design defects rather than deployment ones: per-record timestamps, and endpoint authentication |
 
 ### Deferred, with reasons
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -17,7 +17,7 @@ roles, two scripts, both in `examples/`.
 ## 1. Start the facilitator
 
 ```sh
-SPONSOR_SECRET_KEY=S... PORT=4100 CATALOG_FILE=./data/catalog.json npm start
+SPONSOR_SECRET_KEY=S... PORT=4100 CATALOG_DB_URL=file:./data/catalog.db npm start
 ```
 
 Sanity: `curl localhost:4100/health`, then `curl localhost:4100/supported` —

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -110,17 +110,19 @@ that agents are directed to pay an attacker.
 
 ### Steps
 
-You need shell access to the instance and its persistent disk. The catalog is a
-single-instance file store, so there is no coordination to do — but the service
-**must be stopped**, because `saveOwnership()` rewrites the whole file from
-memory and will overwrite a live hand-edit.
+You need the Turso database, not shell access to the instance — the catalog has
+lived in libSQL since 2026-08-11. **The service does not need to be stopped.**
+Ownership writes are per-binding rows now rather than a whole-file rewrite, so
+there is nothing that will clobber your edit wholesale.
 
-1. **Stop the service.** Not a restart — it must not be running during the edit.
+One race is worth knowing about: a **displacement** can rewrite the same rows if
+the URL is unverified and someone proves ownership while you are editing. If you
+are here for a verified binding (which is the only case this procedure covers —
+see the box above), displacement cannot touch it and there is no race at all.
 
-2. **Locate the ownership file.** It is always the catalog path plus
-   `.ownership`. With the shipped `CATALOG_FILE`:
+1. **Open the database.**
    ```
-   /var/data/bazaar-catalog.json.ownership
+   turso db shell <database>
    ```
 
 3. **Back the ownership rows up.** There are no files any more — the catalog
@@ -269,76 +271,39 @@ The service starts, `/health` returns 200, settlements work — and the catalog
 serves nothing. On boot the logs contain:
 
 ```
-[catalog] ownership store at <path>.ownership is missing or unreadable — ...
+[catalog] ownership could not be loaded (ownership-unreachable|ownership-invalid) — ...
 ```
 
-and `/health` reports `catalogFrozen: "ownership-unreadable"`.
+and `/health` reports `catalogFrozen: "ownership-unreachable"` or
+`"ownership-invalid"`.
 
 ### Confirm
 
-This is the deliberate fail-closed behaviour. A catalog file **without** its
-companion ownership file is ambiguous: it is what a first upgrade to a persistent
-disk looks like, and it is also what an attacker deleting the ownership file
-looks like. The service refuses to guess.
+> **UPDATED 2026-08-11. The migration case this procedure was written for no
+> longer exists.** It handled "a catalog file with no companion ownership file",
+> which was ambiguous between a first upgrade and an attacker deleting the file.
+> One database cannot be half-present, so that state is unreachable and
+> `CATALOG_OWNERSHIP_BOOTSTRAP` is gone. If you have set it, the service warns and
+> ignores it.
+>
+> **The two states you can actually be in are named in the freeze reason**, and
+> they want opposite responses:
+>
+> | `catalogFrozen` | Meaning | Do |
+> | --- | --- | --- |
+> | `"ownership-unreachable"` | The store did not answer, after retries | **Wait.** Usually transient. Restart once it answers. Do not restart in a loop |
+> | `"ownership-invalid"` | The store ANSWERED with something unusable | **Investigate the data.** A restart will produce the same result — a row is malformed, or the schema is not what the code expects |
+>
+> Fail-closed itself is unchanged and deliberate: serving entries whose ownership
+> did not load would mean serving entries with no enforceable ownership, which is
+> F11 disabled at the moment nobody is watching.
 
-Determine which one you are in:
-
-- **Did someone just attach a disk, or restore only the catalog file from a
-  backup?** Then it is a migration.
-- **Did the ownership file exist and then stop existing, with no deploy?** Treat
-  it as tampering and investigate before continuing.
-
-### Steps — first boot on a NEW disk (nothing to migrate)
-
-If the disk is brand new and there was never a catalog file, there is nothing to
-do: with **neither** file present the loader treats it as a genuinely fresh start
-and the catalog comes up empty and unfrozen. You will not see the symptom above.
-
-### Steps — migration case (a catalog file exists, no ownership file)
-
-This is the state the **first boot after attaching a disk** produces if a catalog
-file was restored alongside it.
-
-1. **Confirm where the catalog file came from.** Bootstrap trusts it to name each
-   resource's owner. It grants **no more trust than that file already had** — but
-   if it was tampered with, this makes the tampering durable. If you cannot
-   account for the file, delete it and start empty instead; the catalog rebuilds
-   from settlements.
-
-2. Set `CATALOG_OWNERSHIP_BOOTSTRAP=1` **in the Render dashboard**, not in
-   `render.yaml` — it is deliberately not declared there so it cannot be left on
-   by a merge.
-
-3. **Start the service once.** It warns on every boot while the flag is set, and
-   now also logs how many bindings it wrote:
-
-   ```
-   [catalog] wrote N ownership binding(s) derived during load to <path>.ownership
-   ```
-
-4. **Verify the file exists and is complete before going further:**
-
-   ```sh
-   cat /var/data/bazaar-catalog.json.ownership | python3 -m json.tool | head
-   ```
-
-   It must contain one `{resource, boundPayTo}` row per catalog entry. Spot-check
-   that a `boundPayTo` matches the address that resource actually bills to — this
-   is your only chance to catch a wrong owner before it becomes durable.
-
-5. **Remove `CATALOG_OWNERSHIP_BOOTSTRAP` and restart.** Do not skip this. While
-   it is set, the fail-closed protection against a missing or deleted ownership
-   store is DISABLED, so a later deletion would silently re-derive bindings from
-   whatever the catalog file says at that moment.
-
-6. **Confirm the removal took**: `/health` must report no `catalogFrozen`, and
-   the boot logs must no longer contain `CATALOG_OWNERSHIP_BOOTSTRAP`.
-
-> **G-7 (fixed).** Bindings derived during load used to be seeded in memory and
-> never written, so the migration silently persisted nothing and the *next* boot
-> failed closed again. They are now flushed once after load, and step 3's log
-> line is the confirmation. If you are running a build from before that fix, keep
-> the flag set for one more boot rather than restarting without it.
+**The migration steps that used to live here have been DELETED, not banner-ed.**
+They described attaching a disk, restoring a catalog file, and running a one-boot
+`CATALOG_OWNERSHIP_BOOTSTRAP` flag — none of which exists any more. A procedure
+nobody can follow is worse than no procedure: under pressure an operator reads the
+steps, not the disclaimer above them. If you need the history it is in
+`docs/brief-turso-migration.md` and the git log.
 
 ### Verify
 
@@ -349,9 +314,8 @@ expected entries.
 
 ### Sibling trap: `SPONSOR_HARD_FLOOR_STROOPS`, set by hand and never reverted
 
-Filed here deliberately, beside `CATALOG_OWNERSHIP_BOOTSTRAP`, because it is the
-**same shape of hazard** and will be encountered by someone who has forgotten
-both.
+Filed here deliberately, because it is the **same shape of hazard** as the
+retired flags above: a dashboard variable that outlives the reason it was set.
 
 Testing the balance guard (F3) means raising `SPONSOR_HARD_FLOOR_STROOPS` above
 the sponsor's actual balance so `/settle` refuses, then reverting. The trap:
@@ -362,9 +326,9 @@ the sponsor's actual balance so `/settle` refuses, then reverting. The trap:
 > the facilitator refuses **every settlement, permanently**, with a perfectly
 > healthy `/health`.
 
-`CATALOG_OWNERSHIP_BOOTSTRAP` at least warns loudly on every boot while set. This
-one does not warn at all — it is strictly worse, and the only defence is the
-revert step.
+The retired variables (`CATALOG_FILE`, `CATALOG_OWNERSHIP_BOOTSTRAP`) at least
+warn loudly on every boot if they are still set. This one does not warn at all —
+it is strictly worse, and the only defence is the revert step.
 
 **Procedure:**
 
@@ -459,15 +423,15 @@ cataloged.
 ### Steps
 
 There is currently **no reset path** (**G-8**). Ownership tombstones are never
-removed, and deleting the ownership file to clear them trips procedure 2 —
+removed, and deleting the ownership rows to clear them trips procedure 2 —
 turning a partial outage into a full catalog freeze, and discarding every
 ownership binding you have.
 
-Do not delete the ownership file to "fix" this.
+Do not delete the ownership rows to "fix" this.
 
 Escalate. Reaching 100,000 tombstones requires 100,000 distinct settled URLs, so
 if you see this without that volume of legitimate traffic, treat it as an attack
-on catalog availability and preserve the ownership file for analysis.
+on catalog availability and preserve the ownership rows for analysis.
 
 ---
 
@@ -561,12 +525,24 @@ The output names the stage. Read it literally:
 
 ## 5. "The catalog is empty after the service was idle"
 
-**This is designed behaviour on the free tier.** Render spins a free web service
-down after 15 minutes without traffic, and spin-down destroys the container's
-filesystem — which is where `CATALOG_FILE` and its ownership store live. Entries
-and bindings go with it.
+> **UPDATED 2026-08-11 — THIS IS NO LONGER EXPECTED.** It used to be: the catalog
+> lived on the container's filesystem, and spin-down destroys the container. It
+> now lives in libSQL/Turso, verified live across a **42-second cold start** with
+> the binding intact.
+>
+> **So an empty catalog after an idle period now means something is wrong.**
+> Check, in order:
+>
+> 1. `/health` for `catalogFrozen` — if set, you are in procedure 2, not here.
+> 2. `CATALOG_DB_URL` is actually set. Unset means in-memory, and the service says
+>    so loudly at boot: *"running IN-MEMORY … lost on every restart"*.
+> 3. The boot log for `[catalog] entries could not be loaded, starting empty`,
+>    which is entries failing while ownership succeeded.
+>
+> Only the **cold-start latency** below is still expected behaviour.
 
-**Do not treat it as a fault, and do not fix it with a keep-alive.**
+**The latency is designed behaviour on the free tier**, and is not fixed with a
+keep-alive.
 
 `.github/workflows/keepalive.yml` exists and is deliberately left with no
 `schedule:` trigger. Free instance hours are pooled per **workspace** (750/month,


### PR DESCRIPTION
## The stale claim was the tell

The README told developers an empty catalog after idle is *"expected — not a fault"*, because spin-down destroys the filesystem. True when written; **false the moment durable storage shipped**.

So it was telling someone a symptom is **normal** when it had become a signal that something is **wrong** — worse than silence, because it stops the investigation that would find the fault. Same shape as the seller's hardcoded `localhost` boot log and the `bindLoadedEntry` comment, but in the highest-traffic location in the repo.

## One stale claim meant a partial sweep — and it was

All in documents read as *current instruction*, not history:

| Where | What |
|---|---|
| **runbook §1** | I rewrote its SQL steps and left the preamble saying get *"shell access to the instance and its persistent disk"* and stop the service before editing *"the ownership file"*. My own partial sweep, three days after writing the fix |
| **runbook §2** | An entire migration procedure for `CATALOG_OWNERSHIP_BOOTSTRAP` — a flag that no longer exists, describing files that no longer exist. **Deleted, not banner-ed**: under pressure an operator reads the steps, not the disclaimer above them |
| **runbook §3** | Instructions to delete "the ownership file" to clear tombstones |
| **runbook §5** | The same false claim — now inverted into a checklist of what an empty catalog actually means |
| **guide.md** | A startup command setting `CATALOG_FILE`, now ignored with a warning |

Hits in **dated records** (briefs, walkthroughs, decision logs) were left alone — they describe what was true when written, which is what a record is for.

Register entry **3.4c** carries the rule: *a change that removes a behaviour is not finished when the code lands. Grep the docs for the vocabulary of what you removed, and treat every hit in an instructional document as a defect.*

## Trust layer — a deferral with a named chain

```
trust badges ← a verdict source
              ← worker-service deployed   (needs a Docker host)
                 ← ATTESTOR_SECRET_KEY    (needs an attestor)
                    ← M5 multisig design  (unresolved)
```

Each link is blocked by the one below, and the bottom is a **wallet-repo design decision**, not a deployment task here. Stated plainly that it **is not switching on soon** and **will not be switched on to produce testnet badges** — that would mean minting an attestor key ahead of the multisig design meant to govern it, inverting what the attestor is for.

Two prerequisites proceed regardless, because they're defects in the API's *design* rather than its deployment: **per-record timestamps** (none today, so "newest" falls back to array order) and **endpoint authentication** (unauthenticated — it would be a trust root anyone could impersonate). Neither produces a badge here; both must hold before one would be worth trusting.