### PR TITLE
diagnose the 1-in-3 settle failures; fix pagination.total; keep-alive arithmetic

### DIFF
--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -232,6 +232,23 @@ the *flag*, the *disk* — and treat every hit in an instructional document as a
 defect. Hits in dated records (briefs, walkthroughs, decision logs) are correct
 and should stay; they describe what was true when written.
 
+### 3.4d A status that reads as a pass because nothing ran
+
+Retargeting PR #40 from a squashed-away base to `main` left it showing
+**`MERGEABLE / CLEAN` with no checks at all**. `ci.yml` triggers on
+`pull_request` against `main`, and *changing a PR's base does not re-emit that
+event* — so the PR looked green at a glance while having never been tested
+against the branch it was about to merge into.
+
+Same family as the rest of this section: **an artifact that reads as a pass
+because the check did not run.** It is the mutation harness's absent anchor and
+the "merged" PR that never landed, arriving a third way.
+
+**The fix is a nudge, not a tool:** close and reopen the PR, which emits a fresh
+`pull_request` event and runs CI. Worth doing on any retargeted PR before merging
+it — otherwise a stacked PR can reach `main` having only ever been tested against
+its parent branch.
+
 ### 3.5 Tests that passed for the wrong reason — three times
 
 1. **RA-12** — eight tests green against deliberately broken code; the control
@@ -304,6 +321,56 @@ argument fails with the code.
 
 ---
 
+## 4b. The keep-alive — arithmetic, and the number I cannot supply
+
+The cold start is the most-hit annoyance. The workflow exists with its schedule
+removed; whether to restore it is arithmetic, and one input is not mine to read.
+
+**What draws instance hours.** Render's free tier is **750 hours per WORKSPACE
+per month**, shared. **Free web services and private services draw hours.**
+**Static sites and managed Postgres draw none.** So the divisor is the count of
+free *web/private services*, not the count of things in the dashboard — which is
+why it may well be 4–5 rather than 8.
+
+**Count it here:** Dashboard → the service list → count only rows typed **Web
+Service** or **Private Service** whose plan is **Free**. I cannot enumerate your
+account, and guessing the divisor is the one part of this that would be
+invention.
+
+**Cost of keeping this one warm:**
+
+| Window | Hours/month | Share of the 750 pool |
+| --- | --- | --- |
+| 2 h/day | 60 | 8% |
+| 4 h/day | 120 | 16% |
+| 6 h/day | 180 | 24% |
+| 8 h/day | 240 | 32% |
+| 12 h/day | 360 | 48% |
+| 20 h/day | 600 | **80%** |
+
+**Headroom per service, by divisor:**
+
+| Free web services | Hours each | If run continuously |
+| --- | --- | --- |
+| 3 | 250 | 8.3 h/day |
+| 4 | 188 | 6.2 h/day |
+| **5** | **150** | **5.0 h/day** |
+| 8 | 94 | 3.1 h/day |
+
+**Proposal, if the divisor is 4 or 5:** a **4 h/day weekday window** — 120
+h/month, 16% of the pool, comfortably inside a 150–188 h share even if every
+other service ran flat out. Cron `*/10 8-11 * * 1-5` (a ten-minute ping through a
+four-hour window; the idle timeout is 15 minutes, so ten leaves margin).
+
+**Do not restore it if the divisor is 8 or more.** At 94 h each, a 120 h window
+is already over budget on its own, and the failure mode is not a slow demo — it
+is **every free service in the workspace suspended**, including unrelated
+production ones.
+
+**Whatever is chosen, record the divisor and the arithmetic next to the cron**,
+because the number that makes it safe is invisible from the workflow file and
+will not be re-derived by whoever next edits it.
+
 ## 5. What is open, and who owns it
 
 ### Mine to finish
@@ -312,7 +379,7 @@ argument fails with the code.
 | --- | --- |
 | **Deploy `main`** | G-13 + G-14 are merged and *not running*. `scripts/verify-merged.mjs` confirms they are on `main`; only a redeploy puts them in front of traffic |
 | **F12 live demonstration** | Half a day, needs N funded source accounts. The last control with no live evidence |
-| **The 1-in-3 submission failures** | `settle_exact_stellar_transaction_submission_failed`, `transaction: ""`. Reproduced twice at the same rate (3/11, 3/9). Not the cutover — it fails before the chain sees anything. Costs nothing. Next step: capture the RPC's own error beneath that reason string and re-run against a second provider. **A lead, not a cause** |
+| **The 1-in-3 submission failures** | **DIAGNOSED 2026-08-11**, see [`diagnosis-settle-failures.md`](./diagnosis-settle-failures.md). 9 of 10 failures are the RPC returning **`TRY_AGAIN_LATER`** to `sendTransaction`; 1 is `txBadSeq`. Ruled out: the facilitator, the scheme library's logic, sponsor contention, and — by testing five never-used accounts, one of which still failed — shared-source contention, which had been the leading hypothesis. **The finding underneath: a status named "try again later" is converted into a terminal failure.** Not fixed; options and a recommendation are in the doc |
 
 ### Yours
 

--- a/docs/diagnosis-settle-failures.md
+++ b/docs/diagnosis-settle-failures.md
@@ -1,0 +1,104 @@
+# Diagnosis — the 1-in-3 settle failures
+
+**2026-08-11. Diagnosis only; nothing about the failure path is changed.**
+
+Roughly one settle in three failed with
+`settle_exact_stellar_transaction_submission_failed` and an empty `transaction`,
+at a stable rate across two sessions (3/11, 3/9). We had a name and no cause,
+because the cause was being discarded.
+
+---
+
+## Why the cause was invisible
+
+`@x402/stellar` throws away the RPC's answer:
+
+```js
+const sendResult = await server.sendTransaction(txToSubmit);
+if (sendResult.status !== "PENDING") {
+  return { success: false, transaction: "",
+           errorReason: "settle_exact_stellar_transaction_submission_failed", payer };
+}
+```
+
+`sendResult` carries `status`, `errorResult` (a `TransactionResult` XDR naming
+the exact ledger-level failure), `diagnosticEvents` and `latestLedger`. **All of
+it is dropped and replaced with one constant string.** Every distinct cause
+arrives at the operator looking identical.
+
+So the fix was not to guess harder. `scripts/rpc-tap.mjs` forwards Soroban
+JSON-RPC and logs the `sendTransaction` response verbatim, decoding `errorResult`
+XDR. Nothing in production changed; the tap sits between a **local** facilitator
+and the same public RPC.
+
+*(It serves TLS with a throwaway self-signed cert, because `@stellar/stellar-sdk`
+refuses an `http://` RPC endpoint outright. The cert was deleted after the run.)*
+
+## What the network actually said
+
+17 submissions, 10 failures:
+
+| Status | Count | What it is |
+| --- | --- | --- |
+| **`TRY_AGAIN_LATER`** | **9** | RPC-level. No `errorResult`, no ledger entry, nothing spent |
+| `ERROR` → `txBadSeq` | 1 | Sequence contention on a shared source account |
+
+## What this rules in and out
+
+**RULED OUT — the facilitator, and the scheme library's own logic.** The
+transaction never enters a ledger. Neither our code nor the library's signing,
+fee-bumping or policy handling is involved in the outcome; both merely relay a
+refusal from the RPC.
+
+**RULED OUT — sponsor sequence contention.** The sponsor signs the fee bump, not
+the inner transaction's sequence. And `txBadSeq` names the *inner* source.
+
+**RULED OUT — shared-source contention as the explanation.** This was the leading
+hypothesis and it is wrong. It explains exactly one of ten failures. The decisive
+test: five settles, each from **its own freshly funded, never-used account** — one
+still failed with `TRY_AGAIN_LATER`. A virgin account's first-ever transaction
+cannot have a sequence conflict.
+
+**RULED IN — the RPC declining to forward the transaction**, for reasons it does
+not state. `TRY_AGAIN_LATER` is 9 of 10 failures, carries no `errorResult`, and
+happens to transactions that are individually valid.
+
+**NOT ESTABLISHED — whether retrying is the sanctioned response.** The name
+implies it and the absence of an `errorResult` supports it, but
+[the RPC reference](https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/sendTransaction)
+lists `TRY_AGAIN_LATER` among the allowed values **without defining it**, and no
+authoritative source was found describing when it occurs or what a client should
+do. Recorded as unconfirmed rather than assumed — this is the same discipline
+that retracted D-4.
+
+## The finding underneath
+
+**A status literally named "try again later" is being converted into a terminal
+failure.** Whatever its precise trigger, the facilitator gives up on it, the
+buyer sees a settlement that failed, and nothing conveys that a second attempt
+would probably have worked.
+
+That is a defect **regardless** of what causes the status — and it is the
+library's behaviour, not ours.
+
+## Options, none taken
+
+| | Change | Cost | Risk |
+| --- | --- | --- | --- |
+| **A** | Retry `sendTransaction` on `TRY_AGAIN_LATER` with backoff, inside our settle path | Needs the status, which the library hides — so it means re-implementing submission or patching upstream | Retrying a submission is not free: if the first attempt did land, a retry risks a duplicate. `DUPLICATE` is a distinct status, which suggests the RPC handles it, but that is unverified |
+| **B** | Surface the real status to the caller, do not retry | Small. Requires the same access to `sendResult` | None. Turns an opaque failure into an actionable one, and clients can retry on their own terms |
+| **C** | Document "retry on this error" for buyers | Done — `using-it.md` | Leaves every client to rediscover it |
+| **D** | Report upstream | Free | Not in our control |
+
+**Recommended: B, then A only if the duplicate question is settled.** B is the
+honest version of the problem — the information exists and is thrown away — and
+it does not require deciding whether a retry is safe. C is already shipped, so
+buyers are not blocked either way.
+
+## Rate
+
+The local reproduction failed 10 of 17 (59%), against ~33% in production. Both
+runs were back-to-back settles, so the local rate being higher is consistent with
+load-related refusal, but this is one afternoon on one RPC and the numbers are
+not a measurement of anything stable. **Do not quote 59% as a property of the
+network.**

--- a/mutations/pagination.json
+++ b/mutations/pagination.json
@@ -1,0 +1,16 @@
+[
+  {
+    "label": "total not adjusted after verified_only (the bug)",
+    "file": "src/server.ts",
+    "find": "        pagination: { ...response.pagination, total: Math.max(0, response.pagination.total - dropped) },",
+    "replace": "        pagination: response.pagination,",
+    "test": "src/server.pagination.test.ts"
+  },
+  {
+    "label": "reduction applied unconditionally (under-reports normal paging)",
+    "file": "src/server.ts",
+    "find": "    if (q.verified_only === \"true\") {\n      const before = items.length;",
+    "replace": "    if (true) {\n      const before = items.length;",
+    "test": "src/server.pagination.test.ts"
+  }
+]

--- a/scripts/rpc-tap.mjs
+++ b/scripts/rpc-tap.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Diagnostic RPC tap — forwards Soroban JSON-RPC and logs what the network
+// ACTUALLY said when a submission fails.
+//
+// WHY. Roughly one settle in three fails with
+// `settle_exact_stellar_transaction_submission_failed` and an empty
+// `transaction`. That reason string is manufactured by @x402/stellar, which
+// discards the RPC response that explains it:
+//
+//     const sendResult = await server.sendTransaction(txToSubmit);
+//     if (sendResult.status !== "PENDING") {
+//       return { success: false, transaction: "",
+//                errorReason: "settle_exact_stellar_transaction_submission_failed", payer };
+//     }
+//
+// `sendResult` carries `status`, `errorResult` (a TransactionResult XDR naming
+// the exact ledger-level failure), `diagnosticEvents`, and `latestLedger`. All
+// of it is thrown away. We have a name and a stable rate and no cause, because
+// the cause never leaves that function.
+//
+// This does not fix anything and does not change production. It sits between the
+// facilitator and the RPC so the response is visible:
+//
+//     node scripts/rpc-tap.mjs                       # listens on :8899
+//     STELLAR_RPC_URL=http://localhost:8899 npm start
+//
+// Then drive settlements until one fails and read the log. Nothing here is
+// intended to ship.
+
+import http from "node:http";
+import https from "node:https";
+import { readFileSync } from "node:fs";
+import { xdr } from "@stellar/stellar-sdk";
+
+const PORT = Number(process.env.TAP_PORT ?? 8899);
+const UPSTREAM = process.env.TAP_UPSTREAM ?? "https://soroban-testnet.stellar.org";
+
+let sends = 0;
+let failures = 0;
+
+/** Decode the TransactionResult XDR the RPC returns on a rejected submission.
+ *  This is the actual answer — txBAD_SEQ, txINSUFFICIENT_FEE, txTOO_LATE and so
+ *  on each imply a completely different cause and a different fix. */
+function decodeErrorResult(b64) {
+  try {
+    const r = xdr.TransactionResult.fromXDR(b64, "base64");
+    const out = { code: r.result().switch().name, feeCharged: r.feeCharged().toString() };
+    try {
+      const inner = r.result().results?.();
+      if (Array.isArray(inner)) out.opCodes = inner.map((o) => o.tr?.().switch?.().name ?? o.switch().name);
+    } catch {
+      /* not all result types carry operation results */
+    }
+    return out;
+  } catch (e) {
+    return { undecodable: String(e?.message ?? e), raw: b64?.slice(0, 120) };
+  }
+}
+
+// TLS, because @stellar/stellar-sdk refuses an http RPC endpoint outright
+// ("Cannot connect to insecure Soroban RPC server if `allowHttp` isn't set").
+// A self-signed cert plus NODE_TLS_REJECT_UNAUTHORIZED=0 on the facilitator is
+// the smallest way through for a local diagnostic. Never do either in anger.
+const TLS_KEY = process.env.TAP_TLS_KEY;
+const TLS_CERT = process.env.TAP_TLS_CERT;
+const makeServer = (handler) =>
+  TLS_KEY && TLS_CERT
+    ? https.createServer({ key: readFileSync(TLS_KEY), cert: readFileSync(TLS_CERT) }, handler)
+    : http.createServer(handler);
+
+const server = makeServer((req, res) => {
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", async () => {
+    let method = "?";
+    try {
+      method = JSON.parse(body)?.method ?? "?";
+    } catch {
+      /* not JSON — forward anyway */
+    }
+    const started = Date.now();
+    try {
+      const upstream = await fetch(UPSTREAM, {
+        method: req.method,
+        headers: { "content-type": "application/json" },
+        body: req.method === "POST" ? body : undefined,
+      });
+      const text = await upstream.text();
+      const ms = Date.now() - started;
+
+      if (method === "sendTransaction") {
+        sends++;
+        let parsed;
+        try {
+          parsed = JSON.parse(text);
+        } catch {
+          /* fall through to the raw log below */
+        }
+        const r = parsed?.result;
+        const status = r?.status ?? "(no result)";
+        if (status !== "PENDING") {
+          failures++;
+          console.error(
+            `\n[tap] SUBMISSION NOT PENDING  (${failures}/${sends} sends)  ${ms}ms  http ${upstream.status}`,
+          );
+          console.error(`[tap]   status        ${status}`);
+          if (r?.errorResult) console.error(`[tap]   errorResult   ${JSON.stringify(decodeErrorResult(r.errorResult))}`);
+          if (r?.errorResultXdr) console.error(`[tap]   errorResultXdr ${JSON.stringify(decodeErrorResult(r.errorResultXdr))}`);
+          if (r?.latestLedger) console.error(`[tap]   latestLedger  ${r.latestLedger}`);
+          if (r?.diagnosticEvents?.length) console.error(`[tap]   diagnostics   ${r.diagnosticEvents.length} event(s)`);
+          if (parsed?.error) console.error(`[tap]   jsonrpc error ${JSON.stringify(parsed.error)}`);
+          if (!parsed) console.error(`[tap]   raw           ${text.slice(0, 400)}`);
+        } else {
+          console.error(`[tap] sendTransaction PENDING  (${sends} sends, ${failures} failed)  ${ms}ms`);
+        }
+      }
+
+      res.writeHead(upstream.status, { "content-type": "application/json" });
+      res.end(text);
+    } catch (err) {
+      // A transport failure to the upstream is itself a candidate cause, so it
+      // is logged rather than silently converted into a 502.
+      console.error(`[tap] UPSTREAM TRANSPORT FAILURE on ${method}: ${String(err?.message ?? err)}`);
+      res.writeHead(502, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: String(err?.message ?? err) }));
+    }
+  });
+});
+
+server.listen(PORT, () => {
+  console.error(`[tap] forwarding :${PORT} -> ${UPSTREAM}`);
+  console.error(`[tap] point the facilitator at it:  STELLAR_RPC_URL=http://localhost:${PORT}`);
+});

--- a/src/server.pagination.test.ts
+++ b/src/server.pagination.test.ts
@@ -1,0 +1,81 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+import { createTrustResolver } from "./trust.js";
+
+// `pagination.total` must describe what the caller can actually page through.
+//
+// The catalog computes `total` before the trust layer exists, so a
+// `verified_only` filter applied afterwards left `items: []` sitting beside
+// `total: 1` — a response that contradicts itself. Small, and the cost is not
+// small: a client that catches one number lying has no reason to trust the
+// settlement counts either.
+
+const testConfig = {
+  port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(), maxTransactionFeeStroops: 500_000,
+  catalogDbUrl: undefined, catalogDbAuthToken: undefined, verificationApiUrl: undefined,
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 50, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 250_000_000, hardFloorStroops: 100_000_000, intervalMs: 60_000 },
+};
+
+function disc(url: string): DiscoveredResource {
+  return {
+    resourceUrl: url,
+    x402Version: 2,
+    discoveryInfo: { input: { type: "http", method: "GET" } },
+  } as unknown as DiscoveredResource;
+}
+function reqs(payTo: string): PaymentRequirements {
+  return {
+    scheme: "exact", network: "stellar:testnet", asset: "CASSET",
+    amount: "1", payTo, maxTimeoutSeconds: 60,
+  } as unknown as PaymentRequirements;
+}
+
+describe("pagination.total counts what the caller can page through", () => {
+  it("verified_only reduces total, not just items", async () => {
+    // MUTATION THAT MUST BREAK THIS: return `{ ...response, items }` without
+    // adjusting pagination. `total` then reports the unfiltered count and the
+    // response contradicts itself — which is the bug this fixes, and exactly
+    // what the hosted instance did (`items: []` alongside `total: 1`).
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(disc("https://a.example/one"), reqs("GA"));
+    await catalog.upsertFromPayment(disc("https://b.example/two"), reqs("GB"));
+
+    // No verification API configured, which is the deployed reality: every
+    // verdict is "unknown", so verified_only filters everything out.
+    const trust = createTrustResolver({ verificationApiUrl: undefined, rpcUrl: "https://rpc.invalid" });
+    const app = await buildServer(buildFacilitator(testConfig), catalog, trust);
+
+    const unfiltered = (await app.inject({ method: "GET", url: "/discovery/resources" })).json();
+    expect(unfiltered.items.length, "precondition: two entries").toBe(2);
+    expect(unfiltered.pagination.total).toBe(2);
+
+    const filtered = (
+      await app.inject({ method: "GET", url: "/discovery/resources?verified_only=true" })
+    ).json();
+    expect(filtered.items.length, "nothing is verified here").toBe(0);
+    expect(
+      filtered.pagination.total,
+      "total must agree with items — a self-contradicting page teaches clients to trust nothing in it",
+    ).toBe(0);
+  });
+
+  it("an unfiltered request is untouched", async () => {
+    // MUTATION: apply the reduction unconditionally. Ordinary paging then
+    // under-reports and clients stop early, silently missing resources.
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(disc("https://a.example/one"), reqs("GA"));
+    const trust = createTrustResolver({ verificationApiUrl: undefined, rpcUrl: "https://rpc.invalid" });
+    const app = await buildServer(buildFacilitator(testConfig), catalog, trust);
+
+    const body = (await app.inject({ method: "GET", url: "/discovery/resources" })).json();
+    expect(body.items.length).toBe(1);
+    expect(body.pagination.total, "unfiltered total is the catalog count").toBe(1);
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -283,7 +283,21 @@ export async function buildServer(
     });
     if (!trust) return response;
     let items = await annotateTrust(response.items, trust, (url) => catalog.isVerifiedOwner(url));
-    if (q.verified_only === "true") items = filterVerifiedOnly(items);
+    if (q.verified_only === "true") {
+      const before = items.length;
+      items = filterVerifiedOnly(items);
+      // `total` must describe what the caller can actually page through. The
+      // catalog computes it before the trust layer exists, so a verified_only
+      // filter applied afterwards used to leave `items: []` sitting next to
+      // `total: 1` — a response that contradicts itself, which invites a client
+      // to distrust every other number in it. Reduced by what this page dropped.
+      const dropped = before - items.length;
+      return {
+        ...response,
+        items,
+        pagination: { ...response.pagination, total: Math.max(0, response.pagination.total - dropped) },
+      };
+    }
     return { ...response, items };
   });
 


### PR DESCRIPTION
## 1. The 1-in-3 failures — diagnosed, not fixed

The cause was being **discarded**. `@x402/stellar` takes the RPC's `sendTransaction` response — `status`, `errorResult` XDR, `diagnosticEvents`, `latestLedger` — and replaces all of it with one constant string, so every distinct cause reaches the operator looking identical.

`scripts/rpc-tap.mjs` forwards the JSON-RPC and logs it verbatim. **17 submissions, 10 failures:**

| Status | Count | |
|---|---|---|
| **`TRY_AGAIN_LATER`** | **9** | RPC-level. No `errorResult`, no ledger entry, nothing spent |
| `ERROR` → `txBadSeq` | 1 | sequence contention |

**Ruled out:** the facilitator, the scheme library's logic, sponsor contention — and **shared-source contention, which was the leading hypothesis and is wrong.** It explains 1 of 10. The decisive test: five settles each from its own **freshly funded, never-used** account; one still failed. A virgin account's first transaction cannot have a sequence conflict.

**Not established:** whether retrying is sanctioned. The [RPC reference](https://developers.stellar.org/docs/data/apis/rpc/api-reference/methods/sendTransaction) lists `TRY_AGAIN_LATER` among allowed values **without defining it**. Recorded as unconfirmed rather than assumed.

**The finding underneath:** a status named *"try again later"* is converted into a terminal failure — a defect regardless of what triggers it. Four options with costs; recommendation is to **surface the status before considering a retry**, since a retry raises a duplicate-submission question that is itself unverified. **Nothing on the failure path changed.**

Two harness artefacts caught on the way, both mine, reported as such: nine straight failures from using the sink account as *both* sponsor and `SIM_SOURCE_ACCOUNT`, and the `txBadSeq`.

## 2. `pagination.total`

Now counts **after** the filter. No more `items: []` beside `total: 1`. Two mutations verified — not adjusting it, and adjusting it *unconditionally* (which would under-report ordinary paging and make clients stop early).

## 3. Keep-alive — arithmetic, minus one input

**Only free web/private services draw hours; static sites and Postgres draw none** — which is why your divisor may be 4–5 rather than 8. I can't enumerate your account, and guessing the divisor is the one part that would be invention.

| Divisor | Hours each | Continuous |
|---|---|---|
| 4 | 188 | 6.2 h/day |
| 5 | 150 | 5.0 h/day |
| 8 | 94 | 3.1 h/day |

**Proposal at divisor 4–5:** 4 h/day weekday window = 120 h/month, 16% of the pool. `*/10 8-11 * * 1-5`. **Do not restore at divisor ≥ 8** — 120 h is already over a 94 h share, and the failure mode is every free service in the workspace suspended.

## 4. Register

A retargeted PR shows `MERGEABLE / CLEAN` **with no checks**, because changing a base doesn't re-emit `pull_request`. Same family — a status that reads as a pass because nothing ran. Close-and-reopen is the nudge.

329 tests.