### PR TITLE
feat: turn the keep-alive back on, against measured headroom

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,16 +1,15 @@
 ## Keep-alive ping for the hosted testnet facilitator.
 ##
-## WHY THIS EXISTS — it is not a latency tweak.
+## WHY THIS EXISTS — and what it is NOT, since that changed.
 ##
-## Render spins a Free web service down after 15 minutes without inbound
-## traffic. Spinning down DESTROYS the container, and with it the ephemeral
-## filesystem holding CATALOG_FILE and its companion ownership store. So every
-## idle period wipes the Bazaar catalog: a seller's listing disappears and the
-## trust-on-first-use URL bindings reset, reopening the claim race.
+## It used to be the *emptiness* fix: the catalog lived on the container's
+## filesystem, and spin-down destroyed it. That is no longer true. The catalog is
+## in libSQL/Turso and survives a container replacement — verified live across a
+## 42-second cold start with the ownership binding intact.
 ##
-## Keeping the instance awake is therefore the *emptiness* fix for what a
-## developer actually experiences, not merely a cold-start fix. Between deploys,
-## the catalog survives.
+## So this is now purely a LATENCY fix, and should be judged as one. The first
+## request after 15 minutes idle takes ~50 seconds (42 s measured). Nothing is
+## lost by sleeping; a developer just waits.
 ##
 ## THE BUDGET, and why this is not 24/7 by default.
 ##
@@ -82,6 +81,43 @@ name: keepalive
 # and re-do the arithmetic against the CURRENT number of free web services.
 on:
   workflow_dispatch: {}
+  # ENABLED 2026-08-11, against MEASURED headroom rather than a divisor.
+  #
+  # Billing showed 19.37 h consumed 11 days into the cycle across NINE services
+  # — projecting to ~53 h/month, 7% of the pool. The 750-hour limit had been
+  # treated as a binding constraint for a day and a half of decisions; actual
+  # usage was 2.6% of it. See docs/closing-state.md §3.4e.
+  #
+  # THE ARITHMETIC (750 h/workspace/month, ~30.44 days):
+  #
+  #    8h/day ->  244 h   total  297 h   40% of pool   margin 453 h
+  #   12h/day ->  365 h   total  418 h   56%           margin 332 h
+  #   16h/day ->  487 h   total  540 h   72%           margin 210 h   <- chosen
+  #   20h/day ->  609 h   total  662 h   88%           margin  88 h
+  #   24h/day ->  731 h   total  784 h  105%           OVER BUDGET
+  #
+  # NOTE THE LAST ROW. Even with ~700 hours spare, a single always-on Free
+  # service does not fit: 24/7 is 731 h by itself, 97% of the pool before
+  # anything else runs. "We have plenty spare" and "we can leave it on" are
+  # different claims.
+  #
+  # 16h/day is chosen over 20h not on cost but on MARGIN. The projection is 11
+  # days of one cycle; 210 h absorbs being wrong about it, 88 h does not. The
+  # failure mode is not a slow demo — it suspends every Free service in the
+  # workspace, including unrelated production ones.
+  #
+  # Window 08:00-23:59 UTC covers European working hours and the whole US
+  # working day (04:00-20:00 ET, 00:00-16:00 PT). It misses the Asia-Pacific
+  # morning; shifting it is a one-line change, and the cost is identical.
+  #
+  # */5 rather than */10 because the ping is FREE: this repo is public, so
+  # GitHub Actions minutes are unmetered, and instance-hours accrue from the
+  # service being awake rather than from how often it is pinged. Scheduled
+  # workflows can be delayed under load, and a 15-minute idle timeout leaves no
+  # room for a 10-minute interval to slip. If this repo ever goes private,
+  # re-check: Actions minutes are then metered at 2,000/month free.
+  schedule:
+    - cron: "*/5 8-23 * * *"
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ without hardcoded integrations.
 Both are properties of *this deployment*, not of the code, and both are more
 surprising to find by experiment than to be told.
 
-**1. First request after idle takes ~50 seconds.** Render spins a free service
-down after 15 minutes without traffic; the container is replaced, not paused.
-Measured cold start: **42 seconds**. The catalog itself now survives this — it
-lives in libSQL/Turso rather than on the container — so your listings and
-ownership bindings are still there when it wakes. Only the latency is yours to
-absorb.
+**1. First request after idle takes ~50 seconds — but only outside
+08:00–23:59 UTC.** A keep-alive holds the service warm inside that window, so
+there is no cold start there. Outside it, Render spins a free service down after
+15 minutes without traffic and the container is replaced, not paused; measured
+cold start **42 seconds**. You pay it once — the service then stays warm for 15
+minutes past your last request.
+
+The catalog survives either way: it lives in libSQL/Turso rather than on the
+container, so your listings and ownership bindings are there when it wakes.
 
 **2. THE TRUST LAYER IS INERT HERE. Every verification badge reads `"unknown"`,
 and `?verified_only=true` returns an empty list.** Not a bug and not

--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -249,6 +249,45 @@ the "merged" PR that never landed, arriving a third way.
 it — otherwise a stacked PR can reach `main` having only ever been tested against
 its parent branch.
 
+### 3.4e A limit that was never measured, treated as binding for a day and a half
+
+Render grants **750 free instance-hours per workspace per month**, and exhausting
+it suspends every free service in the workspace. That is real, and the
+consequence is severe, so it was treated as the binding constraint on whether the
+facilitator could be kept warm.
+
+**Actual usage: 19.37 hours, eleven days into the cycle. Projected ~53 h/month —
+2.6% of the limit.** Nine services, ~1.8 hours a day between them, because they
+are all asleep almost all of the time.
+
+What that cost:
+
+- The keep-alive was **disabled entirely** rather than reduced, on the strength
+  of the unmeasured figure.
+- A day and a half of decisions were framed as *"which services can we afford to
+  keep warm"* when the answer was *"all of them, easily"*.
+- Real work was proposed on it: counting services to establish a divisor, and
+  deleting two dormant services to improve that divisor — **for headroom that was
+  never scarce**, from services that were drawing approximately zero.
+
+**The tell was available the whole time and nobody read it.** Billing shows
+consumed hours for the current cycle. One page. The divisor arithmetic
+(`750 ÷ N`) was an *estimate of a quantity that is directly displayed*, and it
+was wrong because its core assumption — that services run continuously — is
+false for anything idle.
+
+Same family as the rest of this register, arriving from the direction of a
+*constraint* rather than a test: **a number that looked like a limit, was
+plausible, was never measured, and shaped decisions for as long as it went
+unchecked.** The corrective is identical to the one for fees — a figure that
+drives a decision carries its source, and "the documented maximum" is not a
+measurement of what you are using.
+
+**What survived the measurement:** the failure mode is still severe, and one
+always-on free service still does not fit (731 h is 97% of the pool by itself).
+So the answer moved from *"no keep-alive"* to *"16 h/day with 210 h of margin"* —
+not to *"leave it on"*.
+
 ### 3.5 Tests that passed for the wrong reason — three times
 
 1. **RA-12** — eight tests green against deliberately broken code; the control
@@ -321,55 +360,78 @@ argument fails with the code.
 
 ---
 
-## 4b. The keep-alive — arithmetic, and the number I cannot supply
+## 4b. The keep-alive — ENABLED 2026-08-11, against measured headroom
 
-The cold start is the most-hit annoyance. The workflow exists with its schedule
-removed; whether to restore it is arithmetic, and one input is not mine to read.
+**Billing settled it: 19.37 h consumed 11 days into the cycle across nine
+services, projecting to ~53 h/month — 7% of the 750-hour pool.** The divisor
+arithmetic that preceded this was chasing a constraint that does not exist; see
+§3.4e, which is the more useful half of this story.
 
-**What draws instance hours.** Render's free tier is **750 hours per WORKSPACE
-per month**, shared. **Free web services and private services draw hours.**
-**Static sites and managed Postgres draw none.** So the divisor is the count of
-free *web/private services*, not the count of things in the dashboard — which is
-why it may well be 4–5 rather than 8.
+### What it costs
 
-**Count it here:** Dashboard → the service list → count only rows typed **Web
-Service** or **Private Service** whose plan is **Free**. I cannot enumerate your
-account, and guessing the divisor is the one part of this that would be
-invention.
+| Window (daily) | This service | + others (~53 h) | Share of pool | Margin |
+| --- | --- | --- | --- | --- |
+| 8 h/day | 244 h | 297 h | 40% | 453 h |
+| 12 h/day | 365 h | 418 h | 56% | 332 h |
+| **16 h/day** | **487 h** | **540 h** | **72%** | **210 h** |
+| 20 h/day | 609 h | 662 h | 88% | 88 h |
+| 24/7 | 731 h | 784 h | **105%** | **over budget** |
 
-**Cost of keeping this one warm:**
+**Note the last row.** Even with ~700 hours spare, a single always-on free
+service does not fit — 24/7 is 731 h by itself, 97% of the pool before anything
+else runs. *"We have plenty spare"* and *"we can leave it on"* are different
+claims, and only the first is true.
 
-| Window | Hours/month | Share of the 750 pool |
+### The schedule
+
+```yaml
+schedule:
+  - cron: "*/5 8-23 * * *"     # 16 h/day, 08:00-23:59 UTC
+```
+
+**16 h rather than 20 h is a margin decision, not a cost one.** The projection is
+eleven days of one cycle. 210 h absorbs being wrong about it; 88 h does not. The
+failure mode is not a slow demo — it suspends every free service in the
+workspace, including unrelated production ones. Having just been wrong about this
+number by a factor of forty, leaving room to be wrong again is cheap.
+
+**`*/5` rather than `*/10`** because the ping is free: this repo is public, so
+Actions minutes are unmetered, and instance-hours accrue from the service being
+awake rather than from how often it is pinged. Scheduled workflows can be delayed
+under load, and a 15-minute idle timeout leaves no room for a 10-minute interval
+to slip.
+
+**The window** covers European working hours and the whole US working day
+(04:00–20:00 ET, 00:00–16:00 PT). It misses the Asia-Pacific morning; shifting it
+costs nothing and is a one-line change.
+
+### What a developer experiences
+
+| | Inside the window | Outside it |
 | --- | --- | --- |
-| 2 h/day | 60 | 8% |
-| 4 h/day | 120 | 16% |
-| 6 h/day | 180 | 24% |
-| 8 h/day | 240 | 32% |
-| 12 h/day | 360 | 48% |
-| 20 h/day | 600 | **80%** |
+| First request | **Normal, ~200-300 ms** | **~50 s** (42 s measured) |
+| Subsequent | Normal | Normal, and stays warm 15 min after each request |
+| Catalog | Present | **Present** — it is in Turso and survives regardless |
 
-**Headroom per service, by divisor:**
+Two details worth knowing:
 
-| Free web services | Hours each | If run continuously |
-| --- | --- | --- |
-| 3 | 250 | 8.3 h/day |
-| 4 | 188 | 6.2 h/day |
-| **5** | **150** | **5.0 h/day** |
-| 8 | 94 | 3.1 h/day |
+- **The keep-alive does not make the window's first request fast.** The ping
+  itself pays the cold start at 08:00; developers benefit from then on.
+- **Outside the window you pay it once**, not per request. After waking, the
+  service stays up for 15 minutes past your last call, so an active session runs
+  at normal speed after the first hit.
 
-**Proposal, if the divisor is 4 or 5:** a **4 h/day weekday window** — 120
-h/month, 16% of the pool, comfortably inside a 150–188 h share even if every
-other service ran flat out. Cron `*/10 8-11 * * 1-5` (a ten-minute ping through a
-four-hour window; the idle timeout is 15 minutes, so ten leaves margin).
+### Orphan to delete
 
-**Do not restore it if the divisor is 8 or more.** At 94 h each, a 120 h window
-is already over budget on its own, and the failure mode is not a slow demo — it
-is **every free service in the workspace suspended**, including unrelated
-production ones.
+**`vellar-db`** — a free Postgres, 24 days old, used by nothing: the facilitator
+is on Turso and the wallet repo uses a different database. Render deletes free
+Postgres at 30 days, so it goes on its own in about six days. **It draws no
+instance-hours**, so it never had any bearing on this decision — deleting it
+early just removes something that reads as load-bearing and is not.
 
-**Whatever is chosen, record the divisor and the arithmetic next to the cron**,
-because the number that makes it safe is invisible from the workflow file and
-will not be re-derived by whoever next edits it.
+**The two dormant web services (`backend`, failed deploy, 8 months; `capcut-bot`,
+7 months) do not need deleting for headroom either.** They were drawing
+approximately nothing, which the measurement confirms.
 
 ## 5. What is open, and who owns it
 

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -237,7 +237,7 @@ Five things, in the order you will meet them.
 
 | | What | What to do |
 | --- | --- | --- |
-| **1** | **~50s on the first request after 15 min idle.** The free tier replaces the container; measured cold start 42s | Set a generous client timeout, or send a warming `GET /health` before a real call. `/health` is exempt from rate limiting |
+| **1** | **~50s on the first request after 15 min idle — but only OUTSIDE 08:00–23:59 UTC.** A keep-alive holds it warm inside that window. Measured cold start 42s | Inside the window, nothing to do. Outside it, set a generous client timeout or send a warming `GET /health` first (exempt from rate limiting). Either way you pay it once — it stays warm 15 min past your last call |
 | **2** | **Roughly 1 settle in 3 fails** with `settle_exact_stellar_transaction_submission_failed` and an empty `transaction` | **Retry.** It fails before the chain sees anything, so nothing was spent and nothing double-pays. Observed at 3/11 and 3/9 across two sessions; cause not established — a testnet RPC lead, not a facilitator defect |
 | **3** | **Trust badges are inert.** `verification` and `acceptsVerification` are always `"unknown"` | Read `ownerVerified` instead — that one works. The badge source is deployed nowhere and is not switching on soon (README has the dependency chain) |
 | **4** | **`?verified_only=true` returns an empty list** | Do not use it. It filters on the inert field |


### PR DESCRIPTION
Billing settled it: **19.37 h consumed 11 days in, across nine services — ~53 h/month projected, 7% of the pool.** The divisor arithmetic was chasing a constraint that doesn't exist.

## Schedule

```yaml
schedule:
  - cron: "*/5 8-23 * * *"     # 16 h/day, 08:00–23:59 UTC
```

| Window | This service | + others | Share | Margin |
|---|---|---|---|---|
| 8 h/day | 244 h | 297 h | 40% | 453 h |
| 12 h/day | 365 h | 418 h | 56% | 332 h |
| **16 h/day** | **487 h** | **540 h** | **72%** | **210 h** |
| 20 h/day | 609 h | 662 h | 88% | 88 h |
| 24/7 | 731 h | 784 h | **105%** | **over budget** |

**Note the last row.** Even with ~700 h spare, **one always-on free service does not fit** — 731 h is 97% of the pool before anything else runs. *"Plenty spare"* and *"leave it on"* are different claims; only the first is true.

**16 h over 20 h is a margin decision, not a cost one.** The projection is eleven days of one cycle. 210 h absorbs being wrong; 88 h doesn't. Having just been wrong about this number by a factor of forty, room to be wrong again is cheap.

**`*/5` not `*/10`** — the ping is free (public repo, unmetered Actions), and instance-hours accrue from being *awake*, not from ping frequency. Scheduled workflows get delayed under load, and a 15-min idle timeout leaves no room for a 10-min interval to slip.

## Developer experience

| | Inside 08:00–23:59 UTC | Outside |
|---|---|---|
| First request | **~200–300 ms** | **~50 s** (42 s measured) |
| Subsequent | normal | normal — warm 15 min past your last call |
| Catalog | present | **present** — it's in Turso either way |

Two easy-to-miss details: the ping itself pays the 08:00 cold start, and outside the window you pay it **once per session**, not per request.

## Also

The workflow header still called itself the **emptiness** fix — true when the catalog died with the container, false since Turso. It's now purely a latency fix and says so.

## Register 3.4e — a limit that was never measured

750 h is real and the consequence severe, so it was treated as binding. **Actual usage: 2.6% of it.**

That cost: the keep-alive **disabled entirely** rather than reduced; a day and a half of decisions framed as *"which services can we afford to keep warm"* when the answer was *"all of them"*; and proposed work deleting two dormant services **for headroom that was never scarce, from services drawing approximately zero**.

The tell was one Billing page the whole time. The divisor was an **estimate of a quantity that is directly displayed**, and wrong because its core assumption — that services run continuously — is false for anything idle.

**`vellar-db`** recorded as an orphan to delete; draws no instance-hours, so it never bore on this.