### PR TITLE
fix: recover the orphaned rpcstatus work, and stop the verifier passing it

### DIFF
--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -288,6 +288,40 @@ always-on free service still does not fit (731 h is 97% of the pool by itself).
 So the answer moved from *"no keep-alive"* to *"16 h/day with 210 h of margin"* —
 not to *"leave it on"*.
 
+### 3.4f The verifier passed a PR that was two-thirds missing — sixth instance
+
+`verify-merged.mjs` reported **LANDED** for #45 while `src/rpcstatus.ts`, its
+tests and the upstream draft were absent from `main`.
+
+**The tool was not wrong.** `gh pr diff` returns what was *merged*, so it answered
+*"is what was merged on main?"* — truthfully. The question actually being asked
+was *"is everything I wrote on main?"*, and those diverged because **I pushed two
+commits to the branch seven minutes after the PR was squash-merged and closed.**
+GitHub does not reopen or re-diff a merged PR, so those commits belonged to no PR
+and landed nowhere.
+
+Two errors, both mine: pushing to a merged PR's branch without checking it was
+still open (my own commit message said *"pushed onto #45"* — assumed, not
+verified), and then trusting a LANDED result for a question the tool does not
+answer.
+
+**Sixth instance of content not landing**, and the second caused by branch
+hygiene rather than a squash quirk.
+
+**Fixed structurally.** The verifier now fails when the head branch has commits
+newer than the merge. Two things went wrong while adding it, both worth keeping:
+
+- **The new check silently did nothing at first**, because `headRefName` was not
+  in the fields requested from `gh` — so the branch lookup threw, the `catch`
+  swallowed it, and the check passed everything. *A check written to catch silent
+  passes, silently passing.* It now distinguishes "branch deleted" (healthy) from
+  "could not determine the branch" (reported as unverified).
+- **It then produced a false positive on #43**, whose one distinctive line in
+  `docs/using-it.md` had been legitimately rewritten by #45. "None present" is
+  only evidence when there were enough candidate lines to mean something; below
+  three it is now a note, not a failure. **A verifier that cries wolf gets
+  ignored, which returns it to useless.**
+
 ### 3.5 Tests that passed for the wrong reason — three times
 
 1. **RA-12** — eight tests green against deliberately broken code; the control

--- a/docs/upstream-issue-draft.md
+++ b/docs/upstream-issue-draft.md
@@ -101,9 +101,54 @@ meaning. A distinct `errorReason` per status would also work and would be more
 expressive, but it is a behaviour change for anyone matching on the current
 string, so the additive form seems the safer proposal.
 
-The same pattern appears in the `pollForTransaction` failure path immediately
-below, which discards `getTransaction`'s result in the same way; worth the same
-treatment, though we have not measured that one.
+### The same pattern, one call later — flagging, not claiming
+
+We went looking for a second instance after finding the first, and there is one
+immediately below. We have **not** measured this path; the code is quoted rather
+than characterised, and the consequence below follows from reading it.
+
+```js
+async pollForTransaction(server, txHash, maxPollAttempts = 15, delayMs = 1e3) {
+  for (let i = 0; i < maxPollAttempts; i++) {
+    try {
+      const txResult = await server.getTransaction(txHash);
+      if (txResult.status === "SUCCESS") return { success: true };
+      else if (txResult.status === "FAILED") return { success: false };
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    } catch (error) { /* … */ }
+  }
+  return { success: false };          // poll exhausted
+}
+```
+
+It returns a bare boolean, so `txResult.resultXdr` — the on-chain reason a
+transaction reverted — is dropped. The sharper part is that **two different
+outcomes both become `{ success: false }`**, and `settle` renders both as
+`settle_exact_stellar_transaction_failed`:
+
+1. **`status === "FAILED"`** — included in a ledger and reverted. Terminal, and
+   the reason is in `resultXdr`.
+2. **Poll exhaustion** — polling stopped after `maxPollAttempts`. The transaction
+   may still be pending and may still succeed. That is not a failure, it is an
+   unknown.
+
+Those want opposite handling, and unlike the submission case this one has a
+money-safety edge: `transaction` is populated with the hash, so a caller that
+treats a timeout as terminal and re-pays may pay twice if the original lands.
+Distinguishing them needs only the status, or a distinct `errorReason` for
+exhaustion.
+
+We raise it because it is the same habit rather than the same line —
+information the RPC supplied, discarded before a caller can act on it. **We have
+not observed this happening and are not claiming a rate for it.**
+
+### We are happy to send the PR
+
+The submission-path change is roughly four lines, additive, with no behaviour
+change for existing consumers — `errorReason` keeps its current value. Say the
+word and we will open it against `main`, with a test if you want one. We are
+equally happy for you to take the suggestion and write it yourselves; the goal is
+the information reaching callers, not the authorship.
 
 ### Environment
 
@@ -134,4 +179,12 @@ which is why we would rather the information simply be returned.
 - **Rate framing.** "Roughly one in three" is described as our deployment's
   experience, not as a property of the network. The local reproduction was 10/17,
   and quoting either as a measurement of the RPC would overreach.
-- **If they ask for a PR:** the change is ~4 lines and we can offer one.
+- **The PR is offered in the body**, not held back for them to ask, and worded to
+  be indifferent to authorship so it does not read as a claim on the fix.
+- **The second instance is framed as a habit, not a second bug report.** It makes
+  the issue about a pattern — information the RPC supplied, discarded before a
+  caller can act — which is more useful to a maintainer than one line number. The
+  code is quoted verbatim so they can judge it themselves.
+- **The strongest point in the report is the one we have measured least.** The
+  poll-exhaustion double-pay risk is derived from reading the code, not observed.
+  That asymmetry is stated in the issue rather than smoothed over.

--- a/docs/upstream-issue-draft.md
+++ b/docs/upstream-issue-draft.md
@@ -1,0 +1,137 @@
+# Upstream issue — DRAFT, not filed
+
+**Target:** `x402-foundation/x402` (the repo `@x402/stellar` points at).
+**Confirmed against:** `@x402/stellar@2.21.0` — the latest release, not just our
+pinned 2.20.0. Verified by unpacking the published tarball; the discard is
+identical in both.
+
+**Not opened.** It goes out under the repo owner's name, so it is here to be read
+first.
+
+---
+
+## Title
+
+`exact/stellar`: `settle` discards the RPC's `sendTransaction` response, making
+retryable and terminal submission failures indistinguishable
+
+## Body
+
+### Summary
+
+When submission fails, `ExactStellarScheme.settle` replaces the entire Soroban
+RPC response with a single constant `errorReason`. The response distinguishes
+failures that a caller should retry from failures that a caller must not retry,
+and that distinction is lost before it reaches anyone.
+
+### Where
+
+`src/exact/facilitator/index.ts` (in the published build,
+`dist/cjs/exact/facilitator/index.js:346-355` of 2.21.0):
+
+```js
+const sendResult = await server.sendTransaction(txToSubmit);
+if (sendResult.status !== "PENDING") {
+  return {
+    success: false,
+    network: payload.accepted.network,
+    transaction: "",
+    errorReason: "settle_exact_stellar_transaction_submission_failed",
+    payer
+  };
+}
+```
+
+`sendResult` carries `status`, `errorResult` (a `TransactionResult` XDR naming
+the ledger-level failure), `diagnosticEvents` and `latestLedger`. None of it
+survives.
+
+### Why it matters — two causes, opposite correct responses
+
+Measured on testnet against `https://soroban-testnet.stellar.org`, by proxying
+JSON-RPC and logging the response the library then discarded. **17 submissions,
+10 failures:**
+
+| `status` | Count | Correct caller response |
+| --- | --- | --- |
+| `TRY_AGAIN_LATER` | **9** | **Retry.** No `errorResult`, nothing reached a ledger, nothing was spent |
+| `ERROR` → `txBadSeq` | 1 | **Do not retry.** The payload is stale; resubmitting it can never succeed |
+
+Both arrive at the caller as the same string, so a facilitator operator cannot
+tell a transient refusal from a dead payload, and neither can the merchant or
+buyer downstream. In our deployment this presents as roughly one settle in three
+failing for no visible reason, at a stable rate across sessions.
+
+The `TRY_AGAIN_LATER` case is the sharp one: the status is *literally named*
+"try again later", and the library converts it into a terminal failure.
+
+Sample of the captured responses:
+
+```
+[tap] SUBMISSION NOT PENDING   status TRY_AGAIN_LATER   latestLedger 4085901
+[tap] SUBMISSION NOT PENDING   status ERROR             errorResult {"code":"txBadSeq","feeCharged":"32755"}
+[tap] SUBMISSION NOT PENDING   status TRY_AGAIN_LATER   latestLedger 4085938
+```
+
+The last of those is from a **freshly funded, never-used source account on its
+first ever transaction**, which rules out sequence contention as an explanation
+for the `TRY_AGAIN_LATER` cases.
+
+### Suggested fix
+
+Additive, non-breaking — pass through what the RPC already returned:
+
+```js
+if (sendResult.status !== "PENDING") {
+  return {
+    success: false,
+    network: payload.accepted.network,
+    transaction: "",
+    errorReason: "settle_exact_stellar_transaction_submission_failed",
+    payer,
+    // NEW: preserve what the RPC actually said.
+    rpcStatus: sendResult.status,
+    ...(sendResult.errorResult ? { rpcErrorResult: sendResult.errorResult } : {}),
+  };
+}
+```
+
+Existing consumers are unaffected — `errorReason` keeps its current value and
+meaning. A distinct `errorReason` per status would also work and would be more
+expressive, but it is a behaviour change for anyone matching on the current
+string, so the additive form seems the safer proposal.
+
+The same pattern appears in the `pollForTransaction` failure path immediately
+below, which discards `getTransaction`'s result in the same way; worth the same
+treatment, though we have not measured that one.
+
+### Environment
+
+- `@x402/stellar@2.21.0` (also present in 2.20.0)
+- Node 22 / 25, `@stellar/stellar-sdk` 14.x
+- `stellar:testnet` via `https://soroban-testnet.stellar.org`
+
+### Workaround, for anyone finding this issue first
+
+We wrap `rpc.Server.prototype.sendTransaction` and record non-`PENDING` statuses
+in `AsyncLocalStorage` scoped to the request, then attach the real status to our
+own error body. It works, and it is a monkey-patch on a dependency's prototype —
+which is why we would rather the information simply be returned.
+
+---
+
+## Notes for the reviewer (not part of the issue)
+
+- **Tone is deliberate:** it reports a defect with evidence and a patch-shaped
+  suggestion, and does not editorialise about the library. The one line that
+  comes closest — *"the status is literally named 'try again later'"* — is
+  kept because it is the crux, not a complaint.
+- **What is claimed vs shown.** Shown: the code discards the response; the two
+  statuses occur; a fresh account still got `TRY_AGAIN_LATER`. **Not claimed:**
+  what causes `TRY_AGAIN_LATER`, or that retrying is definitively correct — the
+  RPC reference lists the status without defining it. The issue asks for the
+  information to be surfaced, which is true regardless of what the status means.
+- **Rate framing.** "Roughly one in three" is described as our deployment's
+  experience, not as a property of the network. The local reproduction was 10/17,
+  and quoting either as a measurement of the RPC would overreach.
+- **If they ask for a PR:** the change is ~4 lines and we can offer one.

--- a/mutations/rpcstatus.json
+++ b/mutations/rpcstatus.json
@@ -1,0 +1,51 @@
+[
+  {
+    "label": "module-level slot instead of AsyncLocalStorage (context leak)",
+    "file": "src/rpcstatus.ts",
+    "find": "        const slot = store.getStore();\n        if (slot) {",
+    "replace": "        const slot = (globalThis as any).__leak ??= {};\n        if (slot) {",
+    "test": "src/rpcstatus.test.ts"
+  },
+  {
+    "label": "stop recording the status entirely",
+    "file": "src/rpcstatus.ts",
+    "find": "          slot.captured = captured;",
+    "replace": "",
+    "test": "src/rpcstatus.test.ts"
+  },
+  {
+    "label": "record PENDING too (status stops meaning failure)",
+    "file": "src/rpcstatus.ts",
+    "find": "      if (typeof status === \"string\" && status !== \"PENDING\") {",
+    "replace": "      if (typeof status === \"string\") {",
+    "test": "src/rpcstatus.test.ts"
+  },
+  {
+    "label": "drop the error-code decode",
+    "file": "src/rpcstatus.ts",
+    "find": "          const errorCode = decodeErrorCode(result);",
+    "replace": "          const errorCode = undefined;",
+    "test": "src/rpcstatus.test.ts"
+  },
+  {
+    "label": "remove the try/catch (diagnostics can break a settle)",
+    "file": "src/rpcstatus.ts",
+    "find": "    const result = await original.call(this, tx);\n    try {",
+    "replace": "    const result = await original.call(this, tx);\n    if (true) {",
+    "test": "src/rpcstatus.test.ts"
+  },
+  {
+    "label": "return the bare value (the unsafe-read defect this caught)",
+    "file": "src/rpcstatus.ts",
+    "find": "    return { value, rpcStatus: store.getStore()?.captured };",
+    "replace": "    return value as never;",
+    "test": "src/rpcstatus.test.ts"
+  },
+  {
+    "label": "install silently",
+    "file": "src/rpcstatus.ts",
+    "find": "  log(\n    \"[rpcstatus] MONKEY-PATCH INSTALLED:",
+    "replace": "  void (\n    \"[rpcstatus] MONKEY-PATCH INSTALLED:",
+    "test": "src/rpcstatus.test.ts"
+  }
+]

--- a/scripts/verify-merged.mjs
+++ b/scripts/verify-merged.mjs
@@ -60,7 +60,7 @@ function distinctiveAdditions(patch) {
 }
 
 function verify(pr) {
-  const meta = gh(["pr", "view", String(pr), "--json", "state,mergedAt,baseRefName,headRefOid,mergeCommit,title"]);
+  const meta = gh(["pr", "view", String(pr), "--json", "state,mergedAt,baseRefName,headRefName,headRefOid,mergeCommit,title"]);
   const problems = [];
   const notes = [];
 
@@ -72,6 +72,43 @@ function verify(pr) {
     problems.push(
       `merged into "${meta.baseRefName}", NOT main — if that branch was squash-merged first, this content is unreachable`,
     );
+  }
+
+  // CHECK 1b — commits pushed to the branch AFTER the merge.
+  //
+  // Added after this script returned LANDED for #45 while two thirds of the work
+  // was missing from main. It was not wrong: `gh pr diff` reports what was
+  // MERGED, so it answered "is what was merged on main?" — truthfully — while
+  // the question actually being asked was "is everything I wrote on main?".
+  //
+  // The cause was pushing two commits to the branch SEVEN MINUTES after the PR
+  // was squash-merged and closed. GitHub does not reopen or re-diff a merged PR,
+  // so those commits belong to no PR at all and land nowhere.
+  if (meta.mergedAt) {
+    const mergedAtMs = Date.parse(meta.mergedAt);
+    // Distinguish "branch deleted" (healthy, nothing to check) from "we could
+    // not work out the branch" (a bug in this script). The first version
+    // swallowed both, so a missing field made the check silently pass — the
+    // exact failure it was written to catch, one level up.
+    let branchTip = "";
+    if (!meta.headRefName) {
+      problems.push("could not determine the head branch — this check did not run, treat as unverified");
+    } else {
+      try {
+        branchTip = sh("git", ["log", "-1", "--format=%cI %h %s", `origin/${meta.headRefName}`]).trim();
+      } catch {
+        /* ref absent: the branch was deleted on merge, which is the healthy case */
+      }
+    }
+    if (branchTip) {
+      const tipMs = Date.parse(branchTip.split(" ")[0]);
+      if (Number.isFinite(tipMs) && tipMs > mergedAtMs + 60_000) {
+        problems.push(
+          `branch "${meta.headRefName}" has commits AFTER the merge (${branchTip.slice(0, 60)}…) — ` +
+            `they belong to no PR and are not on main. Open a new PR for them`,
+        );
+      }
+    }
   }
 
   // CHECK 2 — provenance on main. A squash commit referencing (#N), or a real
@@ -107,8 +144,17 @@ function verify(pr) {
       continue;
     }
     const landed = lines.filter((l) => current.includes(l)).length;
-    if (landed === 0) {
+    // "None present" is only evidence of a missing landing when there were
+    // enough candidate lines for that to mean something. A file whose one
+    // distinctive line was legitimately rewritten by a LATER PR would otherwise
+    // be reported as never landed — which happened to #43's docs/using-it.md,
+    // superseded by #45 changing the keep-alive window.
+    if (landed === 0 && lines.length >= 3) {
       problems.push(`${file}: NONE of its ${lines.length} distinctive added lines are in main`);
+    } else if (landed === 0) {
+      notes.push(
+        `${file}: its ${lines.length} added line(s) are absent — too few to judge; likely superseded by a later PR, worth an eye`,
+      );
     } else if (landed < lines.length * 0.5) {
       notes.push(`${file}: only ${landed}/${lines.length} added lines present — later edits, or a partial landing`);
     }

--- a/src/rpcstatus.test.ts
+++ b/src/rpcstatus.test.ts
@@ -1,0 +1,258 @@
+import { rpc } from "@stellar/stellar-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  capturedRpcStatus,
+  installRpcStatusCapture,
+  withRpcStatusCapture,
+  __resetRpcStatusCaptureForTest,
+} from "./rpcstatus.js";
+
+// ============================================================================
+// THE GUARD. This file is the condition of merge for the monkey-patch in
+// rpcstatus.ts, and its job is to make a SILENT failure impossible.
+//
+// If @stellar/stellar-sdk renames sendTransaction, or @x402/stellar stops using
+// rpc.Server, the capture stops working and error bodies quietly lose their RPC
+// status. Nobody would notice: settlements still succeed, failures still fail,
+// and the only difference is a diagnostic that is no longer there. That is the
+// exact class of defect this codebase keeps finding — a control that degrades
+// invisibly. These tests turn it into a red build.
+//
+// The concurrency test matters MORE than the capture test. A leak between
+// requests does not lose a diagnostic, it produces a WRONG one presented as
+// real: request A's TRY_AGAIN_LATER reported on request B's failure would tell a
+// developer to retry a payload that is actually stale. Losing information is
+// recoverable; inventing it is not.
+// ============================================================================
+
+/** Install over a stub so the tests never touch a network. */
+function withStubbedSend(
+  impl: (tx: unknown) => Promise<Record<string, unknown>>,
+): { restore: () => void } {
+  const proto = rpc.Server.prototype as unknown as Record<string, unknown>;
+  const original = proto.sendTransaction;
+  proto.sendTransaction = impl;
+  __resetRpcStatusCaptureForTest();
+  installRpcStatusCapture(() => {});
+  return {
+    restore: () => {
+      proto.sendTransaction = original;
+      __resetRpcStatusCaptureForTest();
+    },
+  };
+}
+
+const server = () => new rpc.Server("https://rpc.invalid", { allowHttp: false });
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("capture — the diagnostic actually arrives", () => {
+  it("records a non-PENDING status raised inside library code we do not control", async () => {
+    // MUTATION THAT MUST BREAK THIS: remove the `slot.captured = …` assignment,
+    // or stop wrapping the settle call in withRpcStatusCapture. The status is
+    // then absent and every submission failure looks identical again — the
+    // situation this whole file exists to prevent.
+    const h = withStubbedSend(async () => ({ status: "TRY_AGAIN_LATER", latestLedger: 4085901 }));
+    try {
+      const { value, rpcStatus } = await withRpcStatusCapture(async () => {
+        // Stands in for @x402/stellar: it calls sendTransaction, throws the
+        // response away, and returns its own constant.
+        await server().sendTransaction({} as never);
+        return { success: false, errorReason: "settle_exact_stellar_transaction_submission_failed" };
+      });
+      expect(value.success).toBe(false);
+      expect(rpcStatus, "the RPC's answer must survive the library discarding it").toEqual({
+        status: "TRY_AGAIN_LATER",
+        latestLedger: 4085901,
+      });
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("decodes the error code when the RPC supplies one", async () => {
+    // txBadSeq and TRY_AGAIN_LATER need OPPOSITE responses from a caller, so the
+    // code is the part that carries the meaning.
+    //
+    // MUTATION: return undefined from decodeErrorCode. The caller can no longer
+    // distinguish "retry" from "this payload is stale", which is the entire
+    // point of surfacing anything.
+    const h = withStubbedSend(async () => ({
+      status: "ERROR",
+      errorResult: { result: () => ({ switch: () => ({ name: "txBadSeq" }) }) },
+    }));
+    try {
+      const { rpcStatus } = await withRpcStatusCapture(async () => {
+        await server().sendTransaction({} as never);
+      });
+      expect(rpcStatus?.errorCode).toBe("txBadSeq");
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("PENDING is not recorded — a successful submission has nothing to explain", async () => {
+    // MUTATION: drop the `status !== "PENDING"` guard. Every successful settle
+    // then carries a pointless rpcStatus, and the field stops meaning
+    // "something went wrong".
+    const h = withStubbedSend(async () => ({ status: "PENDING", hash: "abc" }));
+    try {
+      const { rpcStatus } = await withRpcStatusCapture(async () => {
+        await server().sendTransaction({} as never);
+      });
+      expect(rpcStatus).toBeUndefined();
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("a throw inside the recorder never breaks the settlement", async () => {
+    // Diagnostics must not be able to fail a payment. MUTATION: remove the
+    // try/catch in the patch — a malformed response then throws through
+    // sendTransaction and takes the settle with it.
+    const h = withStubbedSend(async () => ({
+      status: "ERROR",
+      get errorResult(): never {
+        throw new Error("hostile getter");
+      },
+    }));
+    try {
+      await expect(
+        withRpcStatusCapture(async () => {
+          await server().sendTransaction({} as never);
+          return "settled";
+        }),
+      ).resolves.toMatchObject({ value: "settled" });
+    } finally {
+      h.restore();
+    }
+  });
+});
+
+describe("isolation — a wrong diagnostic is worse than none", () => {
+  it("concurrent requests never see each other's status", async () => {
+    // THE TEST THAT MATTERS MOST.
+    //
+    // MUTATION THAT MUST BREAK THIS: replace the AsyncLocalStorage slot with a
+    // module-level `let lastCaptured`. Ten interleaved requests then all report
+    // whichever status was written last, so a caller whose payload was stale
+    // (txBadSeq) is told TRY_AGAIN_LATER and retries something that can never
+    // succeed — a confident, wrong instruction.
+    //
+    // The stub interleaves deliberately: each call yields before returning, so
+    // the requests are genuinely overlapping rather than accidentally serial.
+    const h = withStubbedSend(async (tx) => {
+      const id = (tx as { id: number }).id;
+      await new Promise((r) => setTimeout(r, id % 3));
+      return id % 2 === 0
+        ? { status: "TRY_AGAIN_LATER", latestLedger: 1000 + id }
+        : { status: "ERROR", errorResult: { result: () => ({ switch: () => ({ name: `code${id}` }) }) } };
+    });
+    try {
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, id) =>
+          withRpcStatusCapture(async () => {
+            await server().sendTransaction({ id } as never);
+            // Yield again AFTER capture, so a leak has every chance to happen.
+            await new Promise((r) => setTimeout(r, (10 - id) % 4));
+            return { id, captured: capturedRpcStatus() };
+          }),
+        ),
+      );
+
+      for (const { value: { id, captured } } of results) {
+        if (id % 2 === 0) {
+          expect(captured, `request ${id} must see its OWN status`).toEqual({
+            status: "TRY_AGAIN_LATER",
+            latestLedger: 1000 + id,
+          });
+        } else {
+          expect(captured?.status, `request ${id}`).toBe("ERROR");
+          expect(captured?.errorCode, `request ${id} must see its OWN error code`).toBe(`code${id}`);
+        }
+      }
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("a request that captured nothing does not inherit an earlier one's status", async () => {
+    // MUTATION: same module-level variable. A settle that succeeds after an
+    // earlier failure would report the earlier failure's status — attaching a
+    // diagnostic to a request that had no problem at all.
+    const h = withStubbedSend(async (tx) =>
+      (tx as { fail: boolean }).fail ? { status: "TRY_AGAIN_LATER" } : { status: "PENDING", hash: "ok" },
+    );
+    try {
+      await withRpcStatusCapture(async () => {
+        await server().sendTransaction({ fail: true } as never);
+      });
+      const second = await withRpcStatusCapture(async () => {
+        await server().sendTransaction({ fail: false } as never);
+      });
+      expect(second.rpcStatus, "a clean request carries no status").toBeUndefined();
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("outside a capture scope, recording is a no-op rather than a crash", async () => {
+    // Anything settling outside the route (a script, a test) must not throw.
+    const h = withStubbedSend(async () => ({ status: "TRY_AGAIN_LATER" }));
+    try {
+      await expect(server().sendTransaction({} as never)).resolves.toMatchObject({
+        status: "TRY_AGAIN_LATER",
+      });
+      expect(capturedRpcStatus(), "no scope, no status").toBeUndefined();
+    } finally {
+      h.restore();
+    }
+  });
+
+  it("the status can only be read where it is valid — the API shape enforces it", async () => {
+    // REGRESSION GUARD for a defect this file caught: the first version exposed
+    // capturedRpcStatus() as the way to read the result, and the natural call
+    // site — immediately after `await withRpcStatusCapture(...)` — is OUTSIDE
+    // the scope, so it returned undefined and the mechanism did nothing in
+    // production while every capture test passed.
+    //
+    // MUTATION: make withRpcStatusCapture return the bare value again. The
+    // server then has nowhere valid to read from, and this fails.
+    const h = withStubbedSend(async () => ({ status: "DUPLICATE" }));
+    try {
+      const out = await withRpcStatusCapture(async () => {
+        await server().sendTransaction({} as never);
+        return "done";
+      });
+      expect(out).toHaveProperty("value", "done");
+      expect(out).toHaveProperty("rpcStatus");
+      expect(out.rpcStatus?.status).toBe("DUPLICATE");
+      // ...and reading it the old way, after the scope, gives nothing.
+      expect(capturedRpcStatus()).toBeUndefined();
+    } finally {
+      h.restore();
+    }
+  });
+});
+
+describe("the patch announces itself", () => {
+  it("logs what it wraps and why, so it is not the next person's mystery", async () => {
+    // MUTATION: delete the log call. The patch becomes invisible, and the next
+    // person debugging odd sendTransaction behaviour has no thread to pull.
+    const lines: string[] = [];
+    const h = withStubbedSend(async () => ({ status: "PENDING" }));
+    h.restore();
+    __resetRpcStatusCaptureForTest();
+    const proto = rpc.Server.prototype as unknown as Record<string, unknown>;
+    const original = proto.sendTransaction;
+    installRpcStatusCapture((m) => lines.push(m));
+    proto.sendTransaction = original;
+    __resetRpcStatusCaptureForTest();
+
+    expect(lines.length, "installation must be announced").toBe(1);
+    expect(lines[0]).toMatch(/MONKEY-PATCH INSTALLED/);
+    expect(lines[0], "names what it wraps").toMatch(/sendTransaction/);
+    expect(lines[0], "names why").toMatch(/single constant|indistinguishable/);
+    expect(lines[0], "names the guard, so a reader can check it still works").toMatch(/rpcstatus\.test/);
+  });
+});

--- a/src/rpcstatus.ts
+++ b/src/rpcstatus.ts
@@ -1,0 +1,162 @@
+// Recover the RPC's own answer when a submission fails.
+//
+// THE PROBLEM. `@x402/stellar` (checked in 2.20.0 and 2.21.0, the latest)
+// discards the entire `sendTransaction` response and returns one constant:
+//
+//     const sendResult = await server.sendTransaction(txToSubmit);
+//     if (sendResult.status !== "PENDING") {
+//       return { success: false, transaction: "",
+//                errorReason: "settle_exact_stellar_transaction_submission_failed", payer };
+//     }
+//
+// Two causes needing OPPOSITE responses arrive identically. `TRY_AGAIN_LATER`
+// means retry — nothing reached a ledger, nothing was spent. `ERROR` with
+// `txBadSeq` means the payload is stale and retrying it is pointless. Measured
+// 2026-08-11: 9 of 10 failures were the first, 1 was the second.
+//
+// WHAT THIS DOES. Wraps `rpc.Server.prototype.sendTransaction` — a plain
+// prototype method on @stellar/stellar-sdk, which is OUR OWN direct dependency,
+// not @x402/stellar's private surface — and records any non-PENDING result in
+// AsyncLocalStorage scoped to the request that caused it. The settle route reads
+// it and puts the real status in the error body.
+//
+// WHY A PATCH AT ALL. The scheme builds its RPC client per call
+// (`getRpcClient()` -> `new rpc.Server(...)`), so there is no instance to hand
+// it, no constructor hook, and no injection point. The prototype is the only
+// place both call sites pass through.
+//
+// WHY THE SCOPING MATTERS MORE THAN THE CAPTURE. A module-level "last result"
+// would leak across concurrent settles: request A's `TRY_AGAIN_LATER` would be
+// reported on request B's failure. That is a WRONG diagnostic presented as a
+// real one, which is worse than none — it would send a developer to retry a
+// payload that is actually stale. AsyncLocalStorage gives each request its own
+// slot. Asserted under concurrency in src/rpcstatus.test.ts.
+//
+// HOW THIS FAILS, and why that is survivable. If the SDK renames the method, or
+// the scheme stops using `rpc.Server`, the capture silently stops and error
+// bodies quietly lose their status. That is exactly the class of defect this
+// codebase keeps finding, so it is guarded: rpcstatus.test.ts drives a
+// non-PENDING response end to end and fails if the status does not arrive.
+// A red test, not a silent gap.
+//
+// This is a WORKAROUND. The fix belongs upstream — see
+// docs/upstream-issue-draft.md.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { rpc } from "@stellar/stellar-sdk";
+
+/** What the RPC actually said, when it was not PENDING. */
+export interface CapturedRpcStatus {
+  /** PENDING | DUPLICATE | TRY_AGAIN_LATER | ERROR */
+  status: string;
+  /** Decoded from errorResult XDR when the RPC supplied one. */
+  errorCode?: string;
+  latestLedger?: number;
+}
+
+const store = new AsyncLocalStorage<{ captured?: CapturedRpcStatus }>();
+
+/**
+ * Run `fn` with a fresh capture slot and return BOTH its value and whatever the
+ * RPC reported inside it.
+ *
+ * Returning the status is not a convenience — it is what makes the API safe. An
+ * earlier version exposed a separate `capturedRpcStatus()` reader, and the
+ * obvious call site (right after `await withRpcStatusCapture(...)`) is OUTSIDE
+ * the AsyncLocalStorage scope, so it silently returned undefined and the whole
+ * mechanism did nothing in production. The guard test caught it. The shape below
+ * makes that mistake unexpressible: you cannot read the status anywhere it is
+ * not valid.
+ */
+export async function withRpcStatusCapture<T>(
+  fn: () => Promise<T>,
+): Promise<{ value: T; rpcStatus: CapturedRpcStatus | undefined }> {
+  return store.run({}, async () => {
+    const value = await fn();
+    return { value, rpcStatus: store.getStore()?.captured };
+  });
+}
+
+/** The status recorded so far in the CURRENT scope. Valid only inside
+ *  `withRpcStatusCapture`; undefined everywhere else, by design. */
+export function capturedRpcStatus(): CapturedRpcStatus | undefined {
+  return store.getStore()?.captured;
+}
+
+function decodeErrorCode(sendResult: Record<string, unknown>): string | undefined {
+  // The SDK may hand back either a decoded object or raw XDR depending on
+  // version; try the decoded shape first and fall back to the string.
+  const er = sendResult.errorResult as { result?: () => { switch?: () => { name?: string } } } | undefined;
+  try {
+    const name = er?.result?.()?.switch?.()?.name;
+    if (typeof name === "string") return name;
+  } catch {
+    /* not the decoded shape */
+  }
+  const raw = sendResult.errorResultXdr;
+  if (typeof raw === "string") {
+    try {
+      const { xdr } = require("@stellar/stellar-sdk") as typeof import("@stellar/stellar-sdk");
+      return xdr.TransactionResult.fromXDR(raw, "base64").result().switch().name;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+let installed = false;
+
+/**
+ * Install the patch. Idempotent, and LOUD — a monkey-patch nobody knows about is
+ * the next person's mystery, so it announces itself with what it wraps and why.
+ */
+export function installRpcStatusCapture(log: (msg: string) => void = console.warn): void {
+  if (installed) return;
+  const proto = rpc.Server.prototype as unknown as {
+    sendTransaction: (tx: unknown) => Promise<Record<string, unknown>>;
+  };
+  const original = proto.sendTransaction;
+  if (typeof original !== "function") {
+    log(
+      "[rpcstatus] NOT INSTALLED: rpc.Server.prototype.sendTransaction is not a function. " +
+        "Submission failures will carry no RPC status — see src/rpcstatus.ts.",
+    );
+    return;
+  }
+  proto.sendTransaction = async function patched(this: unknown, tx: unknown) {
+    const result = await original.call(this, tx);
+    try {
+      const status = result?.status;
+      if (typeof status === "string" && status !== "PENDING") {
+        const slot = store.getStore();
+        if (slot) {
+          const errorCode = decodeErrorCode(result);
+          const latestLedger = result.latestLedger;
+          const captured: CapturedRpcStatus = { status };
+          if (errorCode !== undefined) captured.errorCode = errorCode;
+          if (typeof latestLedger === "number") captured.latestLedger = latestLedger;
+          slot.captured = captured;
+        }
+      }
+    } catch {
+      // Diagnostics must never break a settlement. A failure to record is a lost
+      // diagnostic, not a lost payment.
+    }
+    return result;
+  };
+  installed = true;
+  log(
+    "[rpcstatus] MONKEY-PATCH INSTALLED: rpc.Server.prototype.sendTransaction is wrapped to record " +
+      "non-PENDING statuses (TRY_AGAIN_LATER, ERROR, DUPLICATE) per request. Reason: @x402/stellar " +
+      "replaces the RPC's response with a single constant, so retryable and terminal failures are " +
+      "indistinguishable to callers. This is a WORKAROUND; the fix belongs upstream. Guarded by " +
+      "src/rpcstatus.test.ts — if that test goes red, this capture has stopped working.",
+  );
+}
+
+/** TEST ONLY — undo the patch so a test can assert the uninstalled behaviour. */
+export function __resetRpcStatusCaptureForTest(originalRestore?: () => void): void {
+  installed = false;
+  originalRestore?.();
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import { loadConfig } from "./config.js";
 import { buildFacilitator } from "./facilitator.js";
 import { LibsqlCatalogStore } from "./store.js";
+import { installRpcStatusCapture, withRpcStatusCapture } from "./rpcstatus.js";
 import { BazaarCatalog } from "./catalog.js";
 import { registerBazaar } from "./bazaar.js";
 import {
@@ -253,8 +254,16 @@ export async function buildServer(
     // real settlement. Prevalidation does not cover it: one static valid XDR is
     // reused for every request.
     let result;
+    let rpcStatus;
     try {
-      result = await facilitator.settle(paymentPayload, paymentRequirements);
+      // The capture slot must wrap the settle call itself: the RPC response we
+      // want is produced deep inside @x402/stellar, which discards it before
+      // returning. See src/rpcstatus.ts.
+      const captured = await withRpcStatusCapture(() =>
+        facilitator.settle(paymentPayload, paymentRequirements),
+      );
+      result = captured.value;
+      rpcStatus = captured.rpcStatus;
     } catch (err) {
       policy?.refundUnspent(reservation);
       throw err;
@@ -266,6 +275,15 @@ export async function buildServer(
     // transaction then failed, so that reservation correctly stands.
     if (policy && result.success === false && !result.transaction) {
       policy.refundUnspent(reservation);
+    }
+    // Surface what the RPC actually said. Without this a caller sees
+    // `settle_exact_stellar_transaction_submission_failed` and cannot tell
+    // TRY_AGAIN_LATER (retry — nothing reached a ledger) from ERROR/txBadSeq
+    // (do not retry, the payload is stale). Additive: the x402-required fields
+    // are untouched.
+    if (result.success === false && rpcStatus) {
+      request.log.warn({ rpcStatus }, "[settle] submission refused by the RPC");
+      return { ...result, rpcStatus };
     }
     return result;
   });
@@ -395,6 +413,9 @@ function isParseableTransactionXdr(payload: PaymentPayload): boolean {
     return false;
   }
 }
+
+// Install before anything can settle. Announces itself loudly — see rpcstatus.ts.
+installRpcStatusCapture();
 
 const isDirectRun = process.argv[1]?.endsWith("server.ts") || process.argv[1]?.endsWith("server.js");
 if (isDirectRun) {


### PR DESCRIPTION
`verify-merged.mjs` reported **LANDED** for #45 while `src/rpcstatus.ts`, its tests and the upstream draft were **missing from `main`**.

## The tool wasn't wrong — I asked it the wrong question

`gh pr diff` returns what was *merged*, so it answered *"is what was merged on main?"* truthfully. What I needed was *"is everything I wrote on main?"*, and those diverged because **I pushed two commits seven minutes after the PR was squash-merged and closed.** GitHub doesn't reopen or re-diff a merged PR, so those commits belonged to no PR and landed nowhere.

Two errors, both mine: pushing to a merged PR's branch without checking it was open — my own commit message said *"pushed onto #45"*, assumed rather than verified — and then trusting LANDED for a question the tool doesn't answer.

**Sixth instance of content not landing.** Recovered by cherry-pick; 338 tests, typecheck clean.

## Verifier hardened — and it went wrong twice on the way

Now fails when the head branch has commits newer than the merge. Both stumbles are in the register because they're the same lesson recursing:

- **The new check silently did nothing at first** — `headRefName` wasn't among the fields requested from `gh`, so the lookup threw, the `catch` swallowed it, and everything passed. *A check written to catch silent passes, silently passing.* Now separates "branch deleted" (healthy) from "couldn't determine the branch" (unverified).
- **Then it false-positived on #43**, whose single distinctive line had been legitimately rewritten by #45. "None present" is only evidence with enough candidate lines; below three it's a note. **A verifier that cries wolf gets ignored, which returns it to useless.**

```
#45 → NOT LANDED   branch has commits AFTER the merge
#43, #44 → LANDED
```

## Upstream draft revised

`pollForTransaction` raised as a **habit**, not a second bug report — and it's stronger than I first described: the bare boolean collapses a transaction that **reverted on-chain** with **poll exhaustion where it may still land**. Since the hash is populated, a caller treating a timeout as terminal and re-paying **may pay twice**. Marked as derived from reading, not observed.

PR offered in the body, worded to be indifferent to authorship.