### PR TITLE
fix: make pushing to a merged PR's branch impossible, not merely known

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Refuse to push to a branch whose PR is already merged or closed.
+#
+# WHY THIS IS A HOOK AND NOT A RULE. Content failed to land seven times in this
+# engagement. Three of those were the same act: pushing commits to a branch whose
+# PR had already been squash-merged and closed, so the commits belonged to no PR
+# and reached main never.
+#
+# The third time, the tooling to detect it existed, the lesson was written down
+# in docs/closing-state.md, and the push happened anyway — with a message
+# claiming the check had been done. Twice is a mistake; three times with the
+# lesson in front of you is a process that does not work. So this stops being
+# something to remember and becomes something the tool refuses.
+#
+# Install (once per clone — git does not track hooks by default):
+#
+#     git config core.hooksPath .githooks
+#
+# Bypass, when you genuinely mean it (e.g. reopening the PR yourself):
+#
+#     git push --no-verify
+#
+# Requires `gh`. If gh is missing or unauthenticated the hook WARNS and allows
+# the push: a hook that blocks work when a helper is unavailable gets disabled,
+# and a disabled hook protects nothing.
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+case "$branch" in
+  main|master|HEAD) exit 0 ;;
+esac
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "pre-push: gh not found — cannot check PR state, allowing push." >&2
+  exit 0
+fi
+
+state="$(gh pr view "$branch" --json state --jq .state 2>/dev/null)"
+
+case "$state" in
+  "")
+    # No PR for this branch yet. Normal for a first push.
+    exit 0
+    ;;
+  OPEN)
+    exit 0
+    ;;
+  MERGED|CLOSED)
+    cat >&2 <<EOF
+
+  ✗ pre-push REFUSED
+
+    Branch : $branch
+    Its PR : $state
+
+    Commits pushed to a $state PR's branch belong to no PR. GitHub does not
+    reopen or re-diff one, so they will never reach main — and nothing in the
+    PR UI or in verify-merged.mjs will tell you, because the merged diff is
+    genuinely on main. This has already happened three times here.
+
+    Do this instead:
+
+        git checkout -b <new-branch> origin/main
+        git cherry-pick $(git rev-parse --short HEAD)
+        git push -u origin <new-branch>
+        gh pr create --base main
+
+    Then confirm by CONTENT, not by status:
+
+        node scripts/verify-merged.mjs <pr>
+
+    If you really mean it:  git push --no-verify
+
+EOF
+    exit 1
+    ;;
+  *)
+    echo "pre-push: unexpected PR state '$state' for $branch — allowing push." >&2
+    exit 0
+    ;;
+esac

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ cp .env.example .env   # set SPONSOR_SECRET_KEY (funded testnet account)
 npm run dev            # http://localhost:4100
 ```
 
+One-time setup, if you will be pushing branches:
+
+```sh
+git config core.hooksPath .githooks   # refuses pushes to a merged PR's branch
+```
+
 Tests and typecheck:
 
 ```sh

--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -341,6 +341,45 @@ newer than the merge. Two things went wrong while adding it, both worth keeping:
   three it is now a note, not a failure. **A verifier that cries wolf gets
   ignored, which returns it to useless.**
 
+### 3.4g The same mistake three times, with the lesson written down in front of me
+
+Content failed to land **seven** times in this engagement. Three of them were the
+identical act: **pushing commits to a branch whose PR had already been
+squash-merged and closed.**
+
+The third occurrence is the one worth recording. By then:
+
+- the tool to detect it existed (`verify-merged.mjs`, with the post-merge-commit
+  check added an hour earlier),
+- §3.4f described the exact failure, written by me that afternoon,
+- and the push happened anyway — **with a message announcing that the PR state
+  had been verified first.** It was checked *after* the push. The claim was in
+  the output before the fact was true.
+
+**Twice is a mistake. Three times, holding the lesson, is a process that does not
+work.** Knowing about a failure mode is not a defence against it; the two
+occasions I caught it, I caught it by accident afterwards, not by remembering.
+
+So it stopped being something to remember. `.githooks/pre-push` refuses to push
+to a branch whose PR is `MERGED` or `CLOSED`, prints the recovery steps, and is
+bypassable with `--no-verify` for the case where you mean it. Install with
+`git config core.hooksPath .githooks`.
+
+Two deliberate choices in it, both from this register:
+
+- **It allows the push when `gh` is missing or unauthenticated**, warning
+  instead. A hook that blocks work when a helper is unavailable gets disabled,
+  and a disabled hook protects nothing.
+- **It self-tests**: exit 1 on a merged branch, 0 on an unmerged one, 0 on
+  `main`. Verified rather than assumed, because the last three things written to
+  catch silent failures each failed silently first.
+
+The through-line for the whole register: **every failure here was caught by
+accident, and every fix that held was the one that made the mistake impossible
+rather than memorable.** The mutation harness aborts on a bad anchor. The API
+returns the status so it cannot be read out of scope. The hook refuses the push.
+Notes did not work, three times.
+
 ### 3.5 Tests that passed for the wrong reason — three times
 
 1. **RA-12** — eight tests green against deliberately broken code; the control

--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -293,12 +293,26 @@ not to *"leave it on"*.
 `verify-merged.mjs` reported **LANDED** for #45 while `src/rpcstatus.ts`, its
 tests and the upstream draft were absent from `main`.
 
-**The tool was not wrong.** `gh pr diff` returns what was *merged*, so it answered
-*"is what was merged on main?"* — truthfully. The question actually being asked
-was *"is everything I wrote on main?"*, and those diverged because **I pushed two
-commits to the branch seven minutes after the PR was squash-merged and closed.**
-GitHub does not reopen or re-diff a merged PR, so those commits belonged to no PR
-and landed nowhere.
+**The tool was not wrong, and that is the whole finding.** `gh pr diff` returns
+what was *merged*, so it answered *"is what was merged on main?"* — truthfully.
+The question actually being asked was *"is everything I wrote on main?"*.
+
+Those two questions have the same answer almost always, and diverge in exactly
+one situation: **commits landing on a closed PR's branch.** I pushed two, seven
+minutes after #45 was squash-merged. GitHub does not reopen or re-diff a merged
+PR, so they belonged to no PR and landed nowhere.
+
+**A correct answer to the wrong question is harder to catch than a wrong answer,
+because there is nothing to disbelieve.** A wrong answer contradicts something —
+a count, an expectation, another tool. A right answer to a question you did not
+ask agrees with everything, and the only signal is the gap between what you meant
+and what you typed, which nothing in the output can show you. `LANDED` was
+accurate, printed confidently, and useless for the thing being checked.
+
+The generalisation, which is worth more than the fix: **a verification tool
+should state the question it answers, not just the verdict.** `verify-merged.mjs`
+now prints what it checked when the branch still exists, so "what was merged" and
+"what is on the branch" cannot be silently conflated again.
 
 Two errors, both mine: pushing to a merged PR's branch without checking it was
 still open (my own commit message said *"pushed onto #45"* — assumed, not
@@ -311,11 +325,16 @@ hygiene rather than a squash quirk.
 **Fixed structurally.** The verifier now fails when the head branch has commits
 newer than the merge. Two things went wrong while adding it, both worth keeping:
 
-- **The new check silently did nothing at first**, because `headRefName` was not
-  in the fields requested from `gh` — so the branch lookup threw, the `catch`
-  swallowed it, and the check passed everything. *A check written to catch silent
-  passes, silently passing.* It now distinguishes "branch deleted" (healthy) from
-  "could not determine the branch" (reported as unverified).
+- **THE SHARPEST INSTANCE OF THIS ENTIRE PATTERN, and it belongs on the record as
+  such: a check written to catch silent passes, silently passed.** `headRefName`
+  was not among the fields requested from `gh`, so the branch lookup threw on
+  `origin/undefined`, the `catch` swallowed it as "branch deleted, healthy", and
+  every PR sailed through. The mechanism, the failure mode and the blind spot
+  were identical to the defect it existed to prevent — written by someone who had
+  spent two days cataloguing that exact shape, in the tool built to stop it, on
+  the same afternoon. It now distinguishes "branch deleted" (healthy) from "could
+  not determine the branch" (reported as unverified), because those are different
+  answers and a bare `catch` made them one.
 - **It then produced a false positive on #43**, whose one distinctive line in
   `docs/using-it.md` had been legitimately rewritten by #45. "None present" is
   only evidence when there were enough candidate lines to mean something; below

--- a/docs/upstream-issue-draft.md
+++ b/docs/upstream-issue-draft.md
@@ -1,4 +1,16 @@
-# Upstream issue — DRAFT, not filed
+# Upstream issue — FILED
+
+**Open: https://github.com/x402-foundation/x402/issues/3125** (2026-08-11)
+
+Filed with the workaround linked as a commit-pinned permalink rather than
+described, and the PR offered unconditionally in the body — four lines with a
+test is less work for a maintainer than a discussion.
+
+The text below is what was submitted.
+
+---
+
+## Original draft notes
 
 **Target:** `x402-foundation/x402` (the repo `@x402/stellar` points at).
 **Confirmed against:** `@x402/stellar@2.21.0` — the latest release, not just our

--- a/scripts/verify-merged.mjs
+++ b/scripts/verify-merged.mjs
@@ -63,6 +63,7 @@ function verify(pr) {
   const meta = gh(["pr", "view", String(pr), "--json", "state,mergedAt,baseRefName,headRefName,headRefOid,mergeCommit,title"]);
   const problems = [];
   const notes = [];
+  let branchTipSeen = false;
 
   if (meta.state !== "MERGED") problems.push(`state is ${meta.state}, not MERGED`);
 
@@ -102,6 +103,7 @@ function verify(pr) {
     }
     if (branchTip) {
       const tipMs = Date.parse(branchTip.split(" ")[0]);
+      branchTipSeen = true;
       if (Number.isFinite(tipMs) && tipMs > mergedAtMs + 60_000) {
         problems.push(
           `branch "${meta.headRefName}" has commits AFTER the merge (${branchTip.slice(0, 60)}…) — ` +
@@ -161,7 +163,7 @@ function verify(pr) {
   }
   if (filesChecked === 0) notes.push("no substantive additions to verify (deletions/renames only)");
 
-  return { pr, title: meta.title, problems, notes };
+  return { pr, title: meta.title, problems, notes, branchChecked: Boolean(branchTipSeen) };
 }
 
 const selftest = process.argv.includes("--selftest");
@@ -176,7 +178,14 @@ for (const pr of prs) {
   const r = verify(pr);
   const ok = r.problems.length === 0;
   if (!ok) failed++;
+  // State the QUESTION, not just the verdict. "Is what was merged on main?" and
+  // "is everything I wrote on main?" have the same answer almost always, and
+  // diverge exactly when commits land on a closed PR's branch — which is how a
+  // truthful LANDED once covered two-thirds of a PR being missing. A correct
+  // answer to the wrong question is harder to catch than a wrong one, because
+  // there is nothing to disbelieve.
   console.log(`\n  ${ok ? "LANDED" : "NOT LANDED"}  #${r.pr}  ${r.title.slice(0, 62)}`);
+  console.log(`            ? checked: the MERGED diff is on main${r.branchChecked ? ", and the branch has nothing newer" : " (branch gone — nothing newer to check)"}`);
   for (const n of r.notes) console.log(`            · ${n}`);
   for (const p of r.problems) console.log(`      FAIL  ${p}`);
 }


### PR DESCRIPTION
Recovers the orphaned commit and stops the cause.

## The cause is me, three times

Content failed to land **seven** times in this engagement. Three were the identical act: pushing to a branch whose PR was already squash-merged and closed.

The third is the one worth recording. By then the tool to detect it existed, §3.4f described the exact failure — **written by me that afternoon** — and the push happened anyway, **with a message announcing the PR state had been verified first.** It was checked *after* the push. The claim was in the output before the fact was true.

**Twice is a mistake. Three times, holding the lesson, is a process that doesn't work.**

## So it's a hook now

`.githooks/pre-push` refuses to push to a `MERGED`/`CLOSED` PR's branch, prints the cherry-pick recovery, and honours `--no-verify`.

```
merged branch   -> exit 1
unmerged branch -> exit 0
main            -> exit 0
```

Two choices carried from this register:

- **It allows the push when `gh` is missing or unauthenticated**, warning instead. A hook that blocks work when a helper is unavailable gets disabled, and a disabled hook protects nothing.
- **It is self-tested rather than assumed** — the last three things written to catch silent failures each failed silently first.

Install: `git config core.hooksPath .githooks` (documented in the README).

## Also recovered in this commit

**The verifier now states the question it answered**, not just the verdict:

```
? checked: the MERGED diff is on main, and the branch has nothing newer
```

Because *"is what was merged on main"* and *"is everything I wrote on main"* diverge exactly when commits land on a closed PR's branch — and **a correct answer to the wrong question is harder to catch than a wrong one, since there's nothing to disbelieve.**

§3.4f also names the `headRefName` omission as the sharpest instance of the whole pattern: **a check written to catch silent passes, silently passing.**

## The through-line

Every failure in this register was caught by accident, and every fix that held made the mistake *impossible* rather than *memorable*. The mutation harness aborts on a bad anchor. The capture API returns the status so it can't be read out of scope. The hook refuses the push. Notes didn't work, three times.