### PR TITLE
docs: salvage the two facts #42 contributed, and close it as superseded

### DIFF
--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -459,6 +459,14 @@ services, projecting to ~53 h/month — 7% of the 750-hour pool.** The divisor
 arithmetic that preceded this was chasing a constraint that does not exist; see
 §3.4e, which is the more useful half of this story.
 
+**What draws hours, for whoever revisits this:** free **web** and **private
+services** consume instance-hours. **Static sites and managed Postgres consume
+none**, and paid services draw from their own plan rather than the free pool — so
+the number of things in the dashboard is not the number that matters. Hours are
+also consumed by *running time*, not by a service existing: anything idle spins
+down after 15 minutes and stops accruing, which is why the nine services here
+total ~1.8 h/day between them.
+
 ### What it costs
 
 | Window (daily) | This service | + others (~53 h) | Share of pool | Margin |
@@ -510,6 +518,11 @@ afternoons and a two-hour European lunch.
 **A is in force only because it was chosen before anyone asked where the traffic
 comes from.** If the first real evaluators are in Asia-Pacific, B or C is
 strictly better and the change is one line.
+
+**Record the measurement beside the cron whenever it changes.** Whether it is a
+Billing reading or a divisor, the number that makes a window safe is invisible
+from the workflow file, and nobody will re-derive it — they will either assume it
+is fine or leave it alone for fear that it is not.
 
 ### What a developer experiences
 


### PR DESCRIPTION
**#42 should be closed, not merged.** Its §4b and main's §4b are the same section written on **opposite sides of the measurement**:

| | §4b heading |
|---|---|
| `main` | *The keep-alive — **ENABLED**, against measured headroom* |
| #42 | *The keep-alive — arithmetic, and why the divisor **may be** the wrong model* |

Merging #42 replaces the measured version with the speculative one it was superseded by. The conflict is git reporting that both can't be true, not a formatting accident — and the only clean resolutions are "keep main's" (making #42 a no-op) or "keep #42's" (a regression).

Everything substantive in it already reached `main` by a better route:

| #42 said | On main as |
|---|---|
| divisor is a worst case, read Billing | §3.4e — **with the actual measurement** |
| dormant services draw ~0 | §3.4e and §4b |
| `vellar-db` orphan | present |
| 120 h → 87 h weekday correction | **obsolete** — the window is daily now |

## What this PR salvages

Two things from #42 that never landed anywhere:

1. **What draws hours** — free web/private services do; static sites and managed Postgres don't; paid services draw from their own plan. And hours accrue from **running time**, not from a service existing. That's the reference someone needs *before* they start counting dashboard rows.
2. **Record the measurement beside the cron** when it changes — the number that makes a window safe is invisible from the workflow file, and nobody re-derives it.

Merge this, then close #42 with a pointer here.