### PR TITLE
Close the cold-start gaps: bring-your-own asset, a seller that reads its config, and a classic buyer

### DIFF
--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -85,6 +85,124 @@ the risk still exists in a different place. **Open**: still true.
 | **D-3** | A hardcoded log line imitating a real defect | closed-by-test — `/whoami` makes advertised state queryable |
 | **D-4** | The 26M fee | **RETRACTED.** It never existed; it was a stale RPC reading. Survives as the methodological finding in §3 |
 
+### Cold-start findings — O-1…O-10 (2026-08-11 walkthrough)
+
+From a walkthrough run with no repo knowledge, starting from `using-it.md` and
+the hosted instance. Time to first successful payment was **19m41s**; the same
+path after these changes is **~2m30s**.
+
+| ID | Finding | Status |
+| --- | --- | --- |
+| **O-1** | The payment asset is unobtainable and undocumented — `X402TST`'s issuer secret no longer exists, so no one can hold it, and no doc said to bring your own | closed — `provision-testnet.mjs` + `using-it.md` § First: bring your own payment asset |
+| **O-2** | The only script that could produce an asset was dot-prefixed, named `tmp`, referenced nowhere, and **did not run**: no friendbot→RPC readiness wait, `prepareTransaction` called on classic `changeTrust`, no retry for RPC node lag | closed — shipped as `provision-testnet.mjs`, all three fixed, two clean runs (1m35s, 2m58s) |
+| **O-3** | `seller.mjs` silently ignored `PAYTO`/`ASSET` while **both** docs documented them as flags | closed — env honoured, with a boot preflight that checks the real condition and names the fix |
+| **O-4** | "A plain classic keypair works fine" had no code; the only example was smart-account-only | closed — `buyer-classic.mjs`, proven live (settlement `6cf8091c…`) |
+| **O-5** | A second settle failure code (`settle_exact_stellar_transaction_failed`) was undocumented, and money-safety was asserted only for the other one | closed-by-doc, and **measured**: 6 failures in 13 attempts moved zero value |
+| **O-6** | `/health` omits `unverifiableEntries` entirely when zero; the doc implied it is always present | closed-by-doc — the code is right (`server.ts:126`, test asserts a healthy catalog adds no noise) |
+| **O-7** | **`statsSource` asserts a provenance it does not have** — a restored entry whose stored count is 0 is labelled `"observed"` | **open defect — Low severity, fix recommended below.** *Not* the persistence defect it first looks like |
+| **O-8** | Following the tutorial pollutes a shared catalog irreversibly | **open — product gap, recorded below** |
+| **O-9** | `curl -I` on a paid route returns 200 while `GET` returns 402 | closed-by-doc — debug with GET |
+| **O-10** | Documented gotcha "`pagination.total` ignores `verified_only`" was stale | closed-by-doc — verified fixed live (`items: 0, total: 0`); `list()` computes `total` from the filtered set |
+| **O-11** | **A gitignored `.env.recording` silently outranks the built-in defaults** — found while regression-testing O-3. With no shell vars the seller advertised the *dead* `GBDZH5KZ…`/`CBIN4HTP…` pair from a stale local file, not the in-code defaults. This is the exact hazard the hardcoding existed to prevent, re-entering through the env-file path | closed — boot log now prints the **provenance** of each value (`environment` / `examples/.env.recording` / `built-in default`) and the trustline preflight runs regardless. Deployment is unaffected: the file is gitignored and never shipped |
+
+#### O-7 — `statsSource` asserts a provenance it does not have — **defect, Low**
+
+**The label lies.** An entry can take real, settled payments indefinitely, report
+`settlements: 0`, and stamp that zero `statsSource: "observed"` — a positive
+claim that this process witnessed every settlement counted, made by a process
+that witnessed none of them. It is the same class as G-4, whose whole finding was
+that `statsSource` "continued to read `observed`, asserting a provenance the data
+did not have". That was closed at the write path; this is the same assertion
+surviving at the read path.
+
+Low severity because it misreports trust metadata, not money: no payment is
+affected and no binding moves. It is a defect rather than a note because a
+consumer cannot detect it — `"observed"` is exactly what a healthy fresh entry
+reports, so there is no signal to distrust.
+
+**Checked before recording, because it looks like a persistence bug and is not.**
+
+A round-trip probe against a real libSQL store (`upsert` → 2 settlements →
+`flush` → `reopen` → load) returns:
+
+```
+BEFORE: settlements=2 observed=2 statsSource="observed"
+AFTER : settlements=2 observed=0 statsSource="persisted"   ← correct
+```
+
+Confirmed in production too: after a live restart, the walkthrough's own entry
+restored as `settlements=5, observed=0, statsSource="persisted"`. **The
+persistence path is correct and the documented meaning holds.**
+
+The real defect is narrower. `toItem()` derives the label as
+`settlements === observed ? "observed" : "persisted"`
+([`catalog.ts:1464`](../src/catalog.ts)). For a restored entry whose stored
+count is **0**, both sides are 0, so it reports `"observed"` — asserting "every
+settlement was witnessed by the running process" about an entry this process
+never witnessed. Vacuously true at zero, and misleading in exactly the case you
+meet it.
+
+How an entry reaches a stored count of 0 while plainly having settled: the G-4
+gate refuses to count a settlement whose `payTo` is not bound to the entry. That
+was observed live — two successful on-chain payments (merchant balance
+1.0 → 1.2) against a URL bound to a *different* `payTo` left `settlements`
+unchanged at 5. So an entry can take real, settled payments forever while its
+counter stays 0, and then claim `"observed"` for the zero.
+
+Consequence for the reader: `using-it.md` says "`observedSettlements` is the
+number to trust", and that number is 0 for a resource that has definitely
+settled. The live demo entry shows exactly this today.
+
+**Scope: the label, not the gate.** The G-4 refusal that produces these zeros is
+most likely *correct* — stats may only be moved by the bound owner, and that is
+the control G-4 exists to enforce. Nothing here proposes counting unbound
+settlements. The defect is that the read path describes the resulting zero as
+witnessed rather than unknown.
+
+**Two candidate fixes, and a recommendation.**
+
+| | Fix | Cost | Risk |
+| --- | --- | --- | --- |
+| **A** | Track provenance on the entry: set a `restored` flag when an entry is loaded from storage, and derive `statsSource` from it so a restored entry can never report `"observed"` | One field on `StoredEntry`, one line in `toItem()`, one line in the load path | Low. `"persisted"` already exists in the wire contract and already means "part of this count came from disk"; a restored zero is exactly that case |
+| **B** | Make the label three-valued — `observed` / `persisted` / `restored-unknown` | Same code, plus a new enum member | Higher. Adds a value agents must learn, and the existing two already express it |
+
+**Recommended: A.** It makes the label mean what the docs already say it means,
+without adding vocabulary. The current derivation
+(`settlements === observed`) infers provenance from a coincidence of numbers;
+`restored` records it as a fact, which is the actual difference between the two
+states. B is only worth it if consumers need to distinguish "restored with a
+known non-zero count" from "restored with nothing" — no consumer does today.
+
+Deliberately not applied in this change: it edits a wire field on the read path
+and belongs with its own test (`catalog.statsintegrity.test.ts` is the natural
+home — extend it with a restart case asserting a restored zero never reports
+`"observed"`). Sequencing it separately keeps this diff to onboarding.
+
+#### O-8 — catalog pollution is irreversible and self-service-proof
+
+The documented tutorial runs the seller on `localhost`. The first settlement
+catalogs that URL on whatever facilitator you point at — **including the shared
+hosted instance** — and a loopback URL can never pass ownership verification, so
+the entry is permanently `ownerVerified: false` and permanently counted in
+`/health`'s `unverifiableEntries`.
+
+There is no self-service removal, and no operator one either: the runbook
+explicitly warns against deleting ownership rows to clear entries
+(`operator-runbook.md`, "Do not delete the ownership rows to 'fix' this"). The
+only removal path is eviction past `MAX_ENTRIES`. Nothing in the docs warns that
+the tutorial writes to shared state, or that the write is one-way.
+
+Evidence: this walkthrough added `http://localhost:4031/quote` to the public
+hosted catalog. It is still there, and `unverifiableEntries` is now 1.
+
+The scale question is the real one: every developer who follows the guide
+against the hosted instance leaves one permanent junk entry, and agents calling
+`/discovery/resources` read them as real listings. Two candidate directions,
+neither applied: refuse to catalog structurally-unverifiable URLs (loopback,
+private range, `http`) at ingest rather than only flagging them afterwards; or
+document a supported operator eviction path. The first changes catalog-on-settle
+semantics, so it is a decision, not a cleanup.
+
 ---
 
 ## 2. G-14 — payTo whitespace hijack — **Medium** — closed-by-test, **not yet deployed**
@@ -419,6 +537,60 @@ compared verbatim and never keyed on; `payer` only enters a Set.
 A config comment reasoned about "1 XLM, ~20 settles/minute" long after the value
 was 5 XLM. Numbers that carry an argument are asserted in tests now, so the
 argument fails with the code.
+
+### 3.9 A guard was replaced, and the hazard came back through a file that outranks the code
+
+`PAYTO` and `ASSET` were hardcoded constants in `seller.mjs` that ignored the
+environment. The reason was real and written next to them: a stale value makes
+the seller advertise a merchant with no trustline, and that settle fails on-chain
+in a way indistinguishable from a spend control refusing it. The cost was that
+both docs documented `PAYTO=… ASSET=…` flags the code silently discarded, so
+every newcomer had to edit source (O-3).
+
+The fix replaced the proxy with the real check — honour the environment, and
+refuse to boot unless the pair can actually be paid. **The replacement was
+correct and the hazard still came back**, through a path neither the constants
+nor the preflight covered:
+
+    [seller] payTo GBDZH5KZ… (from examples/.env.recording)
+
+`seller.mjs` calls `process.loadEnvFile(".env.recording")` before reading its
+config. That file is gitignored, so it is invisible in review, absent from CI,
+and present on exactly the machines where someone is working. The moment the
+constants became `process.env.PAYTO || default`, a stale local dotfile started
+outranking the reviewed default — and it advertised the **dead** `GBDZH5KZ…` /
+`CBIN4HTP…` pair that commit `62e6e05` had already retired. Caught only because
+the regression check ran the deployed configuration (no shell vars) rather than
+the developer one.
+
+Three things generalise:
+
+1. **Removing a guard means finding every input it was covering, not just the one
+   it was written for.** The constants were blocking the environment; the env
+   *file* was a second input nobody enumerated, because it does not look like an
+   input — it looks like local convenience.
+2. **A gitignored file that feeds config outranks code while being invisible to
+   review.** Anything with that shape (`.env*`, local overrides, machine state)
+   is unreviewable by construction, so it must be *reported at runtime* — the
+   only place it is visible.
+3. **Setting a value is not enough; say where it came from.** The fix is one
+   line per value:
+
+       [seller] payTo GBFK… (from environment)
+       [seller] asset CBJL… (from examples/.env.recording)
+
+   The preflight already proved the pair was *payable* — it passed, because the
+   dead pair still holds a trustline. Validity was never the question. **Which
+   value is in effect, and who supplied it**, was. A check that answers "is this
+   good?" does not answer "is this the one you meant?", and only the second
+   catches a stale override.
+
+This is D-3's lesson arriving from the other direction. There, a log line
+disagreed with the advertised state and imitated a defect; the fix made
+advertised state queryable via `/whoami`. Here the advertised state was correct
+and *unexplained* — right value, unknown origin. Both are the same requirement:
+a service must be able to say what it is doing **and** why, or the next person
+debugs the wrong layer.
 
 ---
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -14,10 +14,22 @@ roles, two scripts, both in `examples/`.
 - Node ≥ 20, `npm install` in both the repo root and `examples/`
 - A funded testnet **sponsor** account (facilitator fee payer) — fund any new
   keypair at [friendbot](https://friendbot.stellar.org)
-- A **merchant** account (`payTo`), holding a trustline to the payment asset
-- A **payer**: any x402-capable Stellar signer. The examples use a Vellar
-  smart account with an ed25519 session key (the "agent with a budget"
-  pattern); a plain classic keypair works too.
+- A **payment asset**, a **merchant** account holding a trustline to it, and a
+  funded **payer**. One command produces all three:
+
+  ```sh
+  cd examples && node provision-testnet.mjs
+  ```
+
+  There is no built-in test token and no faucet — the facilitator settles in
+  whatever SEP-41 asset you name, so you bring your own. The demo seller's
+  `X402TST` **cannot be acquired by anyone**: its issuer secret no longer
+  exists. See [`using-it.md` § First: bring your own payment
+  asset](./using-it.md#first-bring-your-own-payment-asset).
+
+- A **payer signer**: a plain classic keypair (`buyer-classic.mjs`) or a Vellar
+  smart account with an ed25519 session key (`buyer.mjs`, the "agent with a
+  budget" pattern). Both are proven against this facilitator.
 
 ## 1. Start the facilitator
 
@@ -68,6 +80,11 @@ cd examples
 FACILITATOR_URL=http://localhost:4100 PAYTO=G... ASSET=C... PRICE_ATOMIC=1000000 node seller.mjs
 ```
 
+`PAYTO` and `ASSET` are the values printed by `provision-testnet.mjs`. The
+seller refuses to boot unless `PAYTO` is funded and holds a trustline to
+`ASSET` — without it, payments verify and then fail at settlement with an error
+that reads like a spend control refusing them.
+
 An unpaid `GET /quote` returns `402` with a `PAYMENT-REQUIRED` header that
 carries both the payment requirements and the (server-enriched) discovery
 extension.
@@ -88,10 +105,26 @@ The buyer flow, condensed:
 
 ```sh
 cd examples
-RESOURCE_URL=http://localhost:4031/quote \
+
+# Classic keypair — the smaller path, no extra dependencies.
+RESOURCE_URL=http://127.0.0.1:4031/quote \
+PAYER_SECRET=S... SIM_SOURCE_ACCOUNT=G... \
+node buyer-classic.mjs
+
+# Or a Vellar smart account, for an on-chain enforced budget.
+RESOURCE_URL=http://127.0.0.1:4031/quote \
 WALLET_CONTRACT_ID=C... AGENT_SECRET=S... SIM_SOURCE_ACCOUNT=G... \
 node buyer.mjs
 ```
+
+`SIM_SOURCE_ACCOUNT` must be a **different** account from the payer. The
+facilitator rebuilds the transaction with itself as the source, so yours is used
+only to simulate — but simulating from the payer yields source-account
+credentials, which the scheme rejects
+(`invalid_exact_stellar_payload_unsupported_credential_type`).
+
+Expect to retry: roughly one settle in three fails on testnet with an empty
+`transaction`. Nothing is spent when that happens.
 
 ## 4. Discover it
 
@@ -137,6 +170,13 @@ as MCP tools — see the README for client config.
 
 - **Catalog-on-settle.** A resource enters the catalog only after a real
   payment settles for it. Verify-only traffic doesn't catalog (spam guard).
+- **Catalog writes are one-way.** The entry is keyed by URL and there is no
+  self-service removal. That is harmless here, because this page runs its own
+  facilitator against a local database you can delete. It is **not** harmless if
+  you point `FACILITATOR_URL` at the shared hosted instance while your seller is
+  still on `localhost`: that leaves a permanently unverifiable public entry. See
+  [`using-it.md` § Your first settlement writes to a shared
+  catalog](./using-it.md#your-first-settlement-writes-to-a-shared-catalog-permanently).
 - **Smart-account fees.** If your payer is policy-governed, the verify-time
   simulation runs the policy and the fee estimate lands well above a plain
   transfer. This facilitator's ceiling accommodates it by default; other

--- a/docs/handover-docs-site.md
+++ b/docs/handover-docs-site.md
@@ -1,0 +1,131 @@
+# Handover — docs.vellar.xyz
+
+What the hosted documentation site is missing, found by walking the x402 loop
+cold on 2026-08-11 (no repo knowledge, starting from the site and the hosted
+facilitator). Separate repo, separate session — this is the work list.
+
+The site is a **client-SDK site**; the facilitator is a footnote. Pages audited:
+`/docs/introduction`, `/docs/quickstart`, `/docs/x402`, `/docs/facilitator`.
+
+**The pattern:** the site documents the two things that explain themselves (cold
+starts, rate limits) and omits the ones that silently cost hours. Every fact
+below is verified live — sources are in `docs/using-it.md` and
+`docs/closing-state.md` § Cold-start findings (O-1…O-11) in the facilitator repo.
+
+---
+
+## P0 — blockers. Someone hits these and stops.
+
+### 1. No testnet asset, and no way to get one
+
+Nothing on the site says how to obtain a SEP-41 token. `/docs/quickstart`
+references `nativeTokenId` as a bare variable and never explains where it comes
+from. `/docs/x402` omits asset acquisition entirely.
+
+**Write:** the facilitator settles in whatever SEP-41 asset the resource names.
+There is no canonical asset, no built-in test token, and **no faucet** — you
+bring your own. Point at `examples/provision-testnet.mjs` (creates an issuer, a
+SAC, a trustlined merchant, and a funded payer in ~2 minutes).
+
+**Also state plainly:** the demo seller's `X402TST` (`CDYCX4PE…`) **cannot be
+acquired by anyone.** Its issuer keypair was generated in-process by a throwaway
+script and the secret no longer exists. Readers who find the contract id in
+`/discovery/resources` will otherwise burn time trying to get a balance that
+cannot exist.
+
+### 2. The ~1-in-3 settle failure is documented nowhere on the site
+
+The single most damaging omission. The failure is loud, has an alarming name
+(`settle_exact_stellar_transaction_submission_failed`), and reads as "this
+product is broken" rather than "retry".
+
+**Write:** roughly one settle in three fails on testnet with an empty
+`transaction` field, under **two** reason codes —
+`settle_exact_stellar_transaction_submission_failed` and
+`settle_exact_stellar_transaction_failed`. Both mean the transaction was never
+submitted: **nothing was spent, nothing double-pays.** Retry with a freshly
+signed payload (signatures expire in ledgers, not wall-clock).
+
+Measured: 13 attempts, 6 failures, merchant balance afterwards exactly
+successes × price. The rate is not stable — earlier sessions saw 3/11 and 3/9.
+Treat retry as mandatory, not as a rare path.
+
+### 3. No end-to-end path exists on the site
+
+`/docs/quickstart` defers to `/docs/x402`, which is client-only and defers
+merchant topics to `/docs/facilitator`, which doesn't cover them. **The loop
+closes on nothing.** A reader cannot get from "I have a wallet" to "I paid for a
+resource" using the site alone.
+
+**Write:** one page that runs the whole loop — provision an asset, start a
+seller, pay it, see it in discovery. Or link to `docs/guide.md` and
+`docs/using-it.md` in the facilitator repo, which the site currently never
+references.
+
+---
+
+## P1 — silent failures. Things work, wrongly.
+
+### 4. Echoing `required.extensions` into the payment payload
+
+Not mentioned anywhere. Skip it and **the payment succeeds and nothing is
+listed** — a silent failure with no error and no signal.
+
+**Write:** echo `required.extensions` into the payment payload; that echo is
+what tells the facilitator to catalog the resource.
+
+### 5. `ownerVerified`'s five requirements
+
+`/docs/facilitator` names the field but not the conditions, so a reader cannot
+act on it. Copy the five-row table from `docs/using-it.md`: https-only and
+publicly resolvable; unauthenticated GET returns 402; a `PAYMENT-REQUIRED`
+header ≤ 64 KiB; `accepts[].payTo` includes your address; answers within 3s with
+no redirect. Add the trailing-slash canonicalisation note.
+
+### 6. `verified_only` is inert
+
+Not mentioned. Agents will filter on it and get an empty list.
+
+**Write:** do not use `?verified_only=true`; it filters on `verification`, which
+is always `"unknown"` because the attestation service is deployed nowhere. Read
+`ownerVerified` instead — that one works.
+
+### 7. Simulation source must differ from the payer
+
+Not mentioned, and it is a hard failure with an opaque code. The facilitator
+**rebuilds the transaction with itself as the source**, so the caller's source
+is simulate-only — but if the payer *is* that source, Soroban emits
+source-account credentials and the scheme rejects them with
+`invalid_exact_stellar_payload_unsupported_credential_type`.
+
+**Write:** always simulate from a funded account that is not the payer.
+
+---
+
+## P2 — accuracy and debugging
+
+| # | Item | What to write |
+| --- | --- | --- |
+| 8 | **Classic keypairs are supported and now have code** | `/docs/x402` implies smart accounts throughout. A plain `G…` keypair works — proven, settlement `6cf8091c…`. Point at `examples/buyer-classic.mjs`. The only difference is the auth-entry signature shape: a vec of `{ public_key, signature }` maps vs. the smart account's `SignerKey`/`Signature`. |
+| 9 | **Debug with GET, not HEAD** | `curl -I` on a paid route returns **200**; `GET` returns 402. A reader probing with HEAD concludes the paid route isn't wired up. |
+| 10 | **Merchants need a trustline** | A merchant without a trustline to the payment asset verifies fine and then fails at settlement, with an on-chain error that reads exactly like a spend control refusing it. |
+| 11 | **`/health` omits `unverifiableEntries` when zero** | The key is absent, not `0`. Check for presence, not value. |
+| 12 | **Cataloging is settle-only** | A resource enters discovery only after a real payment settles. Verify-only traffic catalogs nothing. |
+| 13 | **Link out to the facilitator repo** | The site never points at `examples/` or the repo docs — the only materials that actually run. |
+
+---
+
+## Facts to copy verbatim
+
+Verified live on 2026-08-11 against `https://vellar-facilitator.onrender.com`:
+
+- Rate limit **60 req/min per IP**; `/verify` and `/settle` bodies capped at
+  **32 KiB**. `/health` is exempt from rate limiting.
+- Cold start ~42–50s, but a keep-alive holds the instance warm
+  **00:00–07:59 and 12:00–19:59 UTC**. Inside that window there is no cold start.
+- Spend controls are **log-only on testnet** — you cannot test your handling of
+  `503 settlement_refused` there.
+- `stellar:testnet` only. Testnet assets are not money.
+- Trust badges `verification` / `acceptsVerification` are always `"unknown"`.
+- Time to first successful payment, cold, following the docs: **19m41s** before
+  this work, **~2m30s** after.

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -19,6 +19,44 @@ point anything real at it.
 
 ---
 
+## First: bring your own payment asset
+
+Both roles need this, and it is the step most likely to stop you before you
+start.
+
+The facilitator settles in a **SEP-41 token, and it does not care which one.**
+There is no canonical asset, no built-in test token, and no faucet. You bring a
+token you control.
+
+**You cannot use the demo seller's token.** The `X402TST` asset (`CDYCX4PE…`)
+advertised by `vellar-seller-demo` was minted by an issuer keypair generated
+in-process by a throwaway script; that secret no longer exists anywhere. Nobody
+can mint more of it — not you, not us. Reading the contract id out of
+`/discovery/resources` will not help, because the problem is not knowing the id,
+it is that no one can obtain a balance. **A payment to that demo resource cannot
+be built by anyone except its original wallet.** Point your buyer at your own
+seller instead.
+
+Making your own takes about two minutes on testnet:
+
+```sh
+cd examples && npm install
+node provision-testnet.mjs
+```
+
+That creates an issuer, deploys a Stellar Asset Contract for a fresh token,
+funds a merchant account **with a trustline** (your `payTo`), funds a classic
+payer **with a balance** (your buyer), and prints a paste-ready env block. Add
+`AGENT_PUBLIC=G…` if you also want a Vellar smart account as the payer.
+
+Doing it by hand needs, in order: an issuer account, a SAC for the asset
+(`createStellarAssetContract`), a `changeTrust` on every classic recipient, and
+a `mint` to the payer. Two traps the script already handles — friendbot
+returning 200 before the RPC can see the account, and `prepareTransaction`
+rejecting classic operations such as `changeTrust`.
+
+---
+
 ## Merchants
 
 ### What you change
@@ -47,6 +85,20 @@ that reports exactly what it is advertising. That last part is worth stealing: i
 exists because a hardcoded `localhost` in a log line once hid a broken deployment
 for weeks.
 
+Run it against your own merchant and asset — both are read from the environment:
+
+```sh
+cd examples
+PAYTO=G... ASSET=C... PRICE_ATOMIC=1000000 node seller.mjs
+```
+
+It refuses to boot if that pair cannot be paid: `PAYTO` must be a funded account
+holding a **trustline to `ASSET`**. Without the trustline every payment verifies
+and then fails at settlement, with an on-chain error that reads exactly like a
+spend control refusing it — so the check happens once, at boot, and names the
+fix. `SKIP_TRUSTLINE_CHECK=1` bypasses it; an unreachable RPC warns rather than
+blocks.
+
 ### What your 402 must declare
 
 Your unpaid response needs payment requirements. For discovery, add the bazaar
@@ -73,8 +125,14 @@ const routes = {
 };
 ```
 
+`SEP41_CONTRACT_ID` is **your** token's contract id — the `ASSET` value printed
+by `provision-testnet.mjs`, or the SAC of any asset you control. There is no
+default to fall back on; see [§ First: bring your own payment
+asset](#first-bring-your-own-payment-asset).
+
 **Your account needs a trustline to the payment asset**, or settlement fails
-on-chain after everything else has succeeded.
+on-chain after everything else has succeeded. `seller.mjs` checks this at boot
+so you find out before a buyer does.
 
 ### Getting ownership verification right
 
@@ -114,6 +172,10 @@ curl -s https://vellar-facilitator.onrender.com/health
 # → "unverifiableEntries": 1   when any entry's URL can never be verified
 #   (http, private address, or a route template — a structural problem, not a
 #    transient one)
+#
+# The field is ABSENT, not 0, when nothing is wrong — a healthy catalog does not
+# carry the key at all. Do not read "no such field" as "the endpoint does not
+# report this"; check for its presence, not its value.
 
 curl -s 'https://vellar-facilitator.onrender.com/discovery/resources' \
   | python3 -c 'import sys,json; [print(i["resource"], i["trust"]["ownerVerified"]) for i in json.load(sys.stdin)["items"]]'
@@ -175,12 +237,28 @@ needs [runbook §1](./operator-runbook.md).
 | The **payment asset**, and a trustline to it | **XLM for fees** — the facilitator's sponsor pays them |
 | A Stellar signer: a plain classic keypair **or** a smart account | An account on this facilitator. No signup, no key, no allowlist |
 
-**A smart account is optional.** The examples use a Vellar smart account with an
-ed25519 session key — the "agent with a budget" pattern, where an on-chain policy
-contract constrains what the key may spend. A classic keypair works fine. The
-reason the examples use one: policy-governed accounts run their policy inside
-`__check_auth`, which pushes the simulated fee to ~130k stroops, and facilitators
-defaulting to a 50k ceiling reject them. This one defaults to 500,000.
+**A smart account is optional, and both paths have working code.**
+
+| Payer | Example | Use it when |
+| --- | --- | --- |
+| **Classic keypair** | `examples/buyer-classic.mjs` | You just want to pay. No extra dependencies. |
+| **Vellar smart account** | `examples/buyer.mjs` | You want an agent whose budget is enforced on-chain by a policy contract. |
+
+The classic example is the smaller one and is proven against this facilitator
+(settlement `6cf8091c…`). The smart-account example exists because of the "agent
+with a budget" pattern: policy-governed accounts run their policy inside
+`__check_auth`, which pushes the simulated fee to ~130k stroops, and
+facilitators defaulting to a 50k ceiling reject them. This one defaults to
+500,000.
+
+**Whichever you use, simulate from a different account than the payer.** Both
+examples take a `SIM_SOURCE_ACCOUNT`: any funded account, never charged, never
+signs. It exists because the facilitator **rebuilds the transaction with itself
+as the source** before submitting, so your source is only ever used to simulate
+— but if the payer *is* that source, Soroban authorizes the transfer with
+source-account credentials, and the scheme accepts only address credentials
+(`invalid_exact_stellar_payload_unsupported_credential_type`). Simulating from a
+separate account is what produces an auth entry you can sign detached.
 
 ### Discovering resources
 
@@ -217,9 +295,22 @@ filter on `verified_only`; it is inert here and returns nothing.
 5. Retry with PAYMENT-SIGNATURE: base64(payload) → 200 + content
 ```
 
-**Copy from `examples/buyer.mjs`** — it is the exact signing code proven against
-this facilitator, including the smart-account auth-entry shape, which is the part
-worth not reinventing.
+**Copy from `examples/buyer-classic.mjs`** (classic keypair) or
+`examples/buyer.mjs` (smart account). Both are the exact signing code proven
+against this facilitator; the auth-entry shape is the part worth not
+reinventing.
+
+```sh
+cd examples
+RESOURCE_URL=https://your-seller/quote \
+PAYER_SECRET=S... SIM_SOURCE_ACCOUNT=G... \
+node buyer-classic.mjs
+```
+
+The two differ only in step 3. A classic account signs its auth entry with a vec
+of `{ public_key, signature }` maps; a smart account signs with its own
+contract-defined `SignerKey`/`Signature` shape. Everything else — the transfer,
+the extension echo, the retry — is identical.
 
 Two things that will cost you time otherwise:
 
@@ -233,15 +324,65 @@ Two things that will cost you time otherwise:
 
 ## What will bite you on the hosted instance
 
-Five things, in the order you will meet them.
+Six things, in the order you will meet them.
 
 | | What | What to do |
 | --- | --- | --- |
 | **1** | **~50s on the first request after 15 min idle — but only OUTSIDE the warm window.** A keep-alive holds it warm **00:00–07:59 and 12:00–19:59 UTC** (covering the working day in Asia-Pacific, Europe and US East). Measured cold start 42s | Inside the window, nothing to do. Outside it, set a generous client timeout or send a warming `GET /health` first (exempt from rate limiting). Either way you pay it once — it stays warm 15 min past your last call |
-| **2** | **Roughly 1 settle in 3 fails** with `settle_exact_stellar_transaction_submission_failed` and an empty `transaction` | **Retry.** It fails before the chain sees anything, so nothing was spent and nothing double-pays. Observed at 3/11 and 3/9 across two sessions; cause not established — a testnet RPC lead, not a facilitator defect |
+| **2** | **Roughly 1 settle in 3 fails**, with an empty `transaction` and one of two reasons: `settle_exact_stellar_transaction_submission_failed` or `settle_exact_stellar_transaction_failed` | **Retry — and no, you did not pay twice.** See below |
 | **3** | **Trust badges are inert.** `verification` and `acceptsVerification` are always `"unknown"` | Read `ownerVerified` instead — that one works. The badge source is deployed nowhere and is not switching on soon (README has the dependency chain) |
 | **4** | **`?verified_only=true` returns an empty list** | Do not use it. It filters on the inert field |
-| **5** | **`pagination.total` ignores `verified_only`** | You will see `items: []` alongside `total: 1`. Trust `items.length` |
+| **5** | **`curl -I` on a paid route returns 200, not 402** | Debug with `GET`, not `HEAD` — a HEAD request does not carry the payment challenge, so the route looks unpaid when it is working correctly |
+| **6** | **Your first settlement writes to a shared catalog, and the write is one-way** | Know this before you settle, not after — see below |
+
+### Your first settlement writes to a shared catalog, permanently
+
+**Read this before you settle against the hosted instance, because it cannot be
+undone afterwards.**
+
+The catalog is global to the facilitator, and a resource is added the first time
+a payment settles for it. Point a buyer at a seller running on
+`http://localhost:4031/quote` — which is exactly what the walkthrough tells you
+to do — and that URL is now a **public entry on a shared instance**, visible to
+every agent calling `/discovery/resources`.
+
+It is permanent in practice:
+
+- A loopback URL can never pass ownership verification (https-only, no
+  loopback), so the entry is `ownerVerified: false` **forever**, and counted in
+  `/health`'s `unverifiableEntries`.
+- There is no self-service removal, and no supported operator one — the runbook
+  explicitly warns against deleting ownership rows to clear entries.
+- The only removal path is eviction once the catalog passes `MAX_ENTRIES`.
+
+Nothing breaks, and your payments are unaffected. The cost is borne by everyone
+reading the catalog: agents see a localhost URL they cannot call, listed
+alongside real resources.
+
+**If you would rather not leave one:** run your own facilitator for the
+walkthrough (`docs/guide.md`, one command and a local database), and point at the
+hosted instance only once your seller has a public https URL. If you do settle
+from localhost, that is accepted and expected here — just do it knowing it is a
+one-way write to shared state.
+
+### About that settle failure
+
+Both reasons above mean the same thing in practice: **the transaction was never
+submitted, so nothing was spent and nothing double-pays.** Retry the whole
+flow — sign a fresh payload, because signatures expire in ledgers.
+
+That is measured, not assumed. Across 13 settlement attempts in one session, 6
+failed; the merchant's on-chain balance afterwards was exactly the number of
+*successes* × the price, with no partial or duplicate transfers from any failed
+attempt. If you want to check it yourself, read the merchant's trustline balance
+on Horizon before and after — an empty `transaction` field means there is no
+on-chain event to reconcile.
+
+The rate is not stable. The doc's "1 in 3" came from earlier sessions (3/11 and
+3/9); the 6/13 above was a worse day. Treat retry as mandatory, not as a rare
+path. Cause not established — it looks like a testnet RPC lead rather than a
+facilitator defect, which is also why the two reason codes are not meaningfully
+different to a caller.
 
 Also worth knowing: **60 requests/min per IP**, **32 KiB request bodies**, and
 spend-control refusals arrive as `503 settlement_refused` with a machine-readable

--- a/examples/.env.recording.example
+++ b/examples/.env.recording.example
@@ -1,21 +1,32 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Recording env for the Vellar demo walkthrough (testnet only).
-# Copy to `.env.recording`, paste the SECRETS from
-# vela-wallet/scripts/x402-spike/.wallet-verified-only.json, then:
-#   set -a; source examples/.env.recording; set +a
-# The filled `.env.recording` is gitignored. Keep secrets off camera.
 #
-# Public IDs below are the REAL values from the flagship provenance proof
-# (the run that produced settlement tx 8bde387b…). They are public on-chain.
+# ▸ STARTING FROM SCRATCH? Do not fill this in by hand. Run:
+#       cd examples && node provision-testnet.mjs
+#   It creates an asset, a merchant with a trustline, and a funded payer, then
+#   prints a complete env block to paste here. Add AGENT_PUBLIC=G… to also get a
+#   smart account.
+#
+# The values below are the flagship provenance proof (settlement tx 8bde387b…).
+# They are PUBLIC and they are kept for the record — but see the warnings: the
+# asset cannot be acquired and the wallet is retired, so this file is a
+# reference, not a working starting point.
+#
+# Copy to `.env.recording`, then:  set -a; source examples/.env.recording; set +a
+# The filled `.env.recording` is gitignored. Keep secrets off camera.
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Live facilitator (pre-filled)
 FACILITATOR_URL=https://vellar-facilitator.onrender.com
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
 
-# Asset = the bound test token from the proven run (NOT USDC — this wallet's
-# budget is bound to this token). This is also the recipient contract the
-# verified-only policy gates on.
+# Asset = the bound test token from the proven run (NOT USDC).
+#
+# ⚠ YOU CANNOT ACQUIRE THIS TOKEN. Its issuer keypair was generated in-process
+# during provisioning and the secret no longer exists — nobody can mint more or
+# send you any. It is here because the demo seller still advertises it. To pay
+# anything, provision your own asset (see the top of this file) and point your
+# seller at that instead.
 ASSET=CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR
 
 # ── Seller (the paid API) ────────────────────────────────────────────────────
@@ -31,7 +42,15 @@ WALLET_CONTRACT_ID=CDPUL7TZKJOUEYJSIGNVXINSB3ZSYTQP6Z6N6DCSV3UBHTFE5KE232EF
 # deleted. Do NOT try to paste agent2Secret here; it no longer exists and the
 # wallet is admin-only + empty. For a new recording, provision a fresh wallet.
 AGENT_SECRET=S...PASTE_your_agent_secret  # SECRET — a signer on a wallet YOU provision
-SIM_SOURCE_ACCOUNT=G...ANY_FUNDED_TESTNET # any funded classic account, simulate-only
+
+# ── Buyer (the agent) — CLASSIC KEYPAIR, the simpler path ────────────────────
+# Used by buyer-classic.mjs. No smart account, no passkey-kit.
+PAYER_SECRET=S...PASTE_your_payer_secret  # SECRET — holds ASSET + a trustline
+
+# Simulate-only: never charged, never signs. MUST be a DIFFERENT account from
+# the payer — simulating from the payer produces source-account credentials,
+# which the facilitator rejects (unsupported_credential_type).
+SIM_SOURCE_ACCOUNT=G...ANY_FUNDED_TESTNET
 
 # ── Provenance revoke (off-camera, between the verified/revoked takes) ────────
 REGISTRY_CONTRACT_ID=CBZVS2ETJKCIMRRWUHTZFVMWDACJNYUZ54JIXUJCHXNBFNXELKTSWHGP

--- a/examples/buyer-classic.mjs
+++ b/examples/buyer-classic.mjs
@@ -1,0 +1,170 @@
+// BUYER (classic keypair) — pay for an x402 resource with a plain Stellar
+// account. No smart account, no passkey-kit, no policy contract.
+//
+// This is the minimal payer. If you want an agent with an on-chain budget, use
+// `buyer.mjs` instead — that one signs with a Vellar smart account's session
+// key and the spend limit is enforced by the wallet contract.
+//
+// Flow: GET → 402 → build the SEP-41 transfer → sign the auth entry with your
+// account key → echo the discovery extension → retry with PAYMENT-SIGNATURE.
+//
+// Run (testnet):
+//   RESOURCE_URL=http://127.0.0.1:4031/quote \
+//   PAYER_SECRET=S...          (your account; holds the asset + a trustline) \
+//   SIM_SOURCE_ACCOUNT=G...    (a DIFFERENT funded account — see below) \
+//   node buyer-classic.mjs
+//
+// WHY A SEPARATE SIMULATION SOURCE
+// --------------------------------
+// The facilitator rebuilds the transaction with ITSELF as the source account
+// before submitting, so the source you build with is only ever used to
+// simulate — it is never charged and never signs anything. But it must not be
+// the payer: when the payer is also the transaction source, Soroban authorizes
+// the transfer with SOURCE-ACCOUNT credentials, and the facilitator's scheme
+// only accepts ADDRESS credentials
+// (`invalid_exact_stellar_payload_unsupported_credential_type`). Simulating
+// from a different account is what makes the auth entry an address entry that
+// you can sign detached.
+
+import {
+  Address,
+  Keypair,
+  xdr,
+  hash,
+  nativeToScVal,
+  buildAuthorizationEntryPreimage,
+  rpc,
+} from "@stellar/stellar-sdk";
+import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+try {
+  process.loadEnvFile(join(dirname(fileURLToPath(import.meta.url)), ".env.recording"));
+} catch {}
+
+const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+const PASSPHRASE = "Test SDF Network ; September 2015";
+const RESOURCE_URL = process.env.RESOURCE_URL || "http://127.0.0.1:4031/quote";
+const payerSecret = process.env.PAYER_SECRET;
+const simSource = process.env.SIM_SOURCE_ACCOUNT;
+
+if (!payerSecret || !simSource) {
+  console.error("PAYER_SECRET and SIM_SOURCE_ACCOUNT are required (run provision-testnet.mjs to get both)");
+  process.exit(1);
+}
+
+const payer = Keypair.fromSecret(payerSecret);
+const server = new rpc.Server(RPC_URL);
+
+if (payer.publicKey() === simSource) {
+  console.error(
+    `SIM_SOURCE_ACCOUNT must be a DIFFERENT account from the payer.\n` +
+      `  payer and sim source are both ${simSource}\n` +
+      `  Simulating from the payer produces source-account credentials, which the\n` +
+      `  facilitator rejects with invalid_exact_stellar_payload_unsupported_credential_type.`,
+  );
+  process.exit(1);
+}
+
+// 1. Unpaid request → 402 with payment requirements + discovery extension.
+const unpaid = await fetch(RESOURCE_URL);
+if (unpaid.status !== 402) {
+  console.error(`expected 402, got ${unpaid.status} — is the seller running?`);
+  process.exit(2);
+}
+const required = JSON.parse(Buffer.from(unpaid.headers.get("PAYMENT-REQUIRED"), "base64").toString("utf8"));
+const req = required.accepts.find((a) => a.network === "stellar:testnet" && a.scheme === "exact");
+if (!req) {
+  console.error("no stellar:testnet exact requirement in the 402");
+  process.exit(2);
+}
+console.error(`[buyer] 402: ${req.amount} atomic of ${req.asset} -> ${req.payTo}`);
+if (required.extensions?.bazaar) console.error("[buyer] discovery extension present — will echo");
+
+// 2. Build the SEP-41 transfer, `from` = your classic account.
+const tx = await AssembledTransaction.build({
+  contractId: req.asset,
+  method: "transfer",
+  args: [
+    nativeToScVal(payer.publicKey(), { type: "address" }),
+    nativeToScVal(req.payTo, { type: "address" }),
+    nativeToScVal(BigInt(req.amount), { type: "i128" }),
+  ],
+  networkPassphrase: PASSPHRASE,
+  rpcUrl: RPC_URL,
+  publicKey: simSource, // simulate-only; the facilitator re-sources the tx
+  parseResultXdr: (r) => r,
+});
+
+// 3. Sign the payer's auth entry.
+//
+// Signatures expire in LEDGERS (~5s each), not wall-clock — current + 12 gives
+// about a minute. Never cache a signed payload.
+//
+// For a classic account, Soroban expects the signature as a vec of
+// { public_key, signature } maps — one per signer that contributed. A single
+// master-key account means exactly one entry. (A smart account instead expects
+// its own contract-defined shape; that is the difference between this file and
+// buyer.mjs.) Map keys must be in sorted order: public_key before signature.
+const expirationLedger = (await server.getLatestLedger()).sequence + 12;
+const auth = tx.built.operations[0].auth ?? [];
+let signed = 0;
+for (const entry of auth) {
+  if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
+  const creds = entry.credentials().address();
+  if (Address.fromScAddress(creds.address()).toString() !== payer.publicKey()) continue;
+
+  creds.signatureExpirationLedger(expirationLedger);
+  const preimage = buildAuthorizationEntryPreimage(entry, expirationLedger, PASSPHRASE);
+  const signature = payer.sign(hash(preimage.toXDR()));
+
+  creds.signature(
+    xdr.ScVal.scvVec([
+      xdr.ScVal.scvMap([
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol("public_key"),
+          val: xdr.ScVal.scvBytes(payer.rawPublicKey()),
+        }),
+        new xdr.ScMapEntry({
+          key: xdr.ScVal.scvSymbol("signature"),
+          val: xdr.ScVal.scvBytes(signature),
+        }),
+      ]),
+    ]),
+  );
+  signed++;
+}
+if (signed === 0) {
+  console.error(
+    "no address auth entry for the payer to sign.\n" +
+      "  If SIM_SOURCE_ACCOUNT is the payer, simulation produced source-account\n" +
+      "  credentials instead — use a different account.",
+  );
+  process.exit(2);
+}
+tx.built.operations[0].auth = auth;
+
+// 4. Payment payload — echoing the discovery extension is what catalogs the
+//    resource. Skip it and the payment still succeeds, but nothing is listed.
+const paymentPayload = {
+  x402Version: 2,
+  resource: required.resource,
+  accepted: req,
+  payload: { transaction: tx.built.toXDR() },
+  ...(required.extensions ? { extensions: required.extensions } : {}),
+};
+
+// 5. Retry with the payment attached.
+const paid = await fetch(RESOURCE_URL, {
+  headers: { "PAYMENT-SIGNATURE": Buffer.from(JSON.stringify(paymentPayload)).toString("base64") },
+});
+const body = await paid.json();
+console.error(`[buyer] HTTP ${paid.status}`);
+if (paid.status !== 200) {
+  console.error(`[buyer] not unlocked: ${JSON.stringify(body)}`);
+  process.exit(2);
+}
+console.log(JSON.stringify(body, null, 2));
+console.error(`[buyer] ✅ paid + unlocked, settlement tx: ${body.settlement?.transaction}`);
+console.error("[buyer] the resource should now be cataloged: try GET {facilitator}/discovery/resources");

--- a/examples/provision-testnet.mjs
+++ b/examples/provision-testnet.mjs
@@ -1,0 +1,310 @@
+// Provision everything you need to run the x402 loop on Stellar testnet.
+//
+// WHY THIS EXISTS
+// ---------------
+// The facilitator settles payments in a SEP-41 token. It does not care which
+// one — but you must hold some, and you cannot hold the token used by this
+// project's demo seller (X402TST / CDYCX4PE…): its issuer keypair is generated
+// in-process by a throwaway script and its secret no longer exists anywhere.
+// Nobody can mint it. So you bring your own token, and this script makes one.
+//
+// WHAT IT CREATES (testnet only)
+//   • an issuer account + a Stellar Asset Contract (SAC) for a new token
+//   • a merchant account with a trustline  ← your `payTo`
+//   • a classic payer account with a trustline and a balance  ← your buyer
+//   • optionally, a Vellar smart account with your ed25519 agent key as signer
+//     (only when AGENT_PUBLIC is set; needs passkey-kit-sdk)
+//
+// It prints a paste-ready env block at the end.
+//
+// USAGE
+//   cd examples && npm install
+//   node provision-testnet.mjs                       # classic payer only
+//   AGENT_PUBLIC=G... node provision-testnet.mjs      # also a smart account
+//
+//   ASSET_CODE=MYTOKEN   override the token code (default X402DEV, ≤12 alnum)
+//
+// TESTNET ONLY. It prints secret keys to stdout, because you need the payer's
+// secret to run a buyer. Never point this at pubnet and never reuse these keys.
+
+import {
+  Asset,
+  Keypair,
+  Networks,
+  Operation,
+  StrKey,
+  TransactionBuilder,
+  nativeToScVal,
+  scValToNative,
+  rpc,
+} from "@stellar/stellar-sdk";
+
+const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+const HORIZON = process.env.HORIZON_URL || "https://horizon-testnet.stellar.org";
+const PASSPHRASE = Networks.TESTNET;
+const ASSET_CODE = process.env.ASSET_CODE || "X402DEV";
+
+// The Vellar smart-account (passkey-kit) wallet contract already installed on
+// testnet. Only used by the optional AGENT_PUBLIC branch.
+//
+// This is the one value here that can rot without anything failing loudly: it
+// pins a wasm someone else uploaded, so if that install is archived or you want
+// a different wallet build, `Client.deploy` fails with a wasm-not-found error
+// that does not name this constant. Override with WALLET_WASM_HASH.
+// Last verified working: 2026-08-11 (wallet CDKIAPI3…, settlement e8581537…).
+const WALLET_WASM_HASH =
+  process.env.WALLET_WASM_HASH || "fdefad64b96837147e1c333e51f537b696eab925e9f147e63d597c04e3c903f0";
+
+const PAYER_MINT_ATOMIC = 1_000_000_000n; // 100 tokens @ 7 decimals
+const MERCHANT_SEED_UNITS = "1"; // so the merchant's trustline is visibly live
+
+if (!/^[A-Za-z0-9]{1,12}$/.test(ASSET_CODE)) {
+  console.error(`ASSET_CODE must be 1-12 alphanumeric characters, got "${ASSET_CODE}"`);
+  process.exit(1);
+}
+const agentPublic = process.env.AGENT_PUBLIC;
+if (agentPublic && !StrKey.isValidEd25519PublicKey(agentPublic)) {
+  console.error("AGENT_PUBLIC must be a valid G… ed25519 public key");
+  process.exit(1);
+}
+
+const server = new rpc.Server(RPC_URL);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Retry helper. soroban-testnet.stellar.org is load-balanced across nodes whose
+ * ledger states drift, so a read that succeeds on one node can 404 on the next
+ * call. Everything that touches the network goes through this.
+ */
+async function retry(label, fn, attempts = 6) {
+  for (let a = 1; ; a++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (a >= attempts) throw new Error(`${label}: gave up after ${attempts} attempts — ${err.message}`);
+      console.log(`  [retry ${a}/${attempts - 1}] ${label}: ${String(err.message ?? err).slice(0, 100)}`);
+      await sleep(3000 * a);
+    }
+  }
+}
+
+/**
+ * Fund an account and WAIT until the RPC can actually see it.
+ *
+ * Friendbot returning 200 does not mean the account is visible to Soroban RPC —
+ * and because the RPC is load-balanced, one successful read does not mean the
+ * next one hits a node that has caught up. We require three consecutive reads.
+ */
+async function fundAndWait(pub) {
+  const res = await fetch(`https://friendbot.stellar.org?addr=${pub}`);
+  // 400 usually means "already funded", which is fine; anything else is not.
+  if (!res.ok && res.status !== 400) {
+    throw new Error(`friendbot ${pub.slice(0, 6)}…: HTTP ${res.status}`);
+  }
+  let streak = 0;
+  for (let i = 0; i < 60; i++) {
+    try {
+      await server.getAccount(pub);
+      if (++streak >= 3) return;
+    } catch {
+      streak = 0;
+    }
+    await sleep(2000);
+  }
+  throw new Error(`${pub.slice(0, 6)}…: funded but never became visible to the RPC`);
+}
+
+/**
+ * Build, sign and submit. Only Soroban operations may be passed through
+ * `prepareTransaction` — it rejects classic operations such as changeTrust and
+ * payment outright with "unsupported operation type", so we skip it for those.
+ */
+async function submit(label, kp, ops) {
+  return retry(label, async () => {
+    const acct = await server.getAccount(kp.publicKey());
+    let tx = new TransactionBuilder(acct, { fee: "1000000", networkPassphrase: PASSPHRASE });
+    for (const op of ops) tx = tx.addOperation(op);
+    tx = tx.setTimeout(120).build();
+
+    const needsSoroban = tx.operations.some(
+      (o) =>
+        o.type === "invokeHostFunction" ||
+        o.type === "extendFootprintTtl" ||
+        o.type === "restoreFootprint",
+    );
+    if (needsSoroban) tx = await server.prepareTransaction(tx);
+
+    tx.sign(kp);
+    const sent = await server.sendTransaction(tx);
+    if (sent.status === "ERROR") {
+      throw new Error(`send rejected: ${JSON.stringify(sent.errorResult ?? sent.status)}`);
+    }
+    for (let i = 0; i < 45; i++) {
+      await sleep(1500);
+      const got = await server.getTransaction(sent.hash);
+      if (got.status === "SUCCESS") return sent.hash;
+      if (got.status === "FAILED") throw new Error(`tx FAILED (${sent.hash})`);
+    }
+    throw new Error(`timed out awaiting ${sent.hash}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+const issuer = Keypair.random();
+const merchant = Keypair.random();
+const payer = Keypair.random();
+const deployer = Keypair.random();
+// A funded account used ONLY to simulate. It must be distinct from the payer:
+// when the payer is also the transaction source, Soroban authorizes with
+// source-account credentials, and the facilitator's scheme accepts only address
+// credentials. Its secret is never needed, so it is never printed.
+const simSource = Keypair.random();
+
+const asset = new Asset(ASSET_CODE, issuer.publicKey());
+const sacId = asset.contractId(PASSPHRASE);
+
+console.log(`\nProvisioning ${ASSET_CODE} on testnet — this takes 2-4 minutes.\n`);
+
+console.log("[1/7] funding accounts (friendbot, then waiting for RPC visibility)…");
+await Promise.all([issuer, merchant, payer, deployer, simSource].map((k) => fundAndWait(k.publicKey())));
+console.log("  ok — 5 accounts funded and visible");
+
+console.log(`[2/7] deploying the SAC for ${ASSET_CODE}:${issuer.publicKey().slice(0, 6)}…`);
+const sacHash = await submit("sac-deploy", deployer, [Operation.createStellarAssetContract({ asset })]);
+console.log(`  ok — ${sacId}`);
+
+console.log("[3/7] waiting for the contract instance to be readable…");
+await retry("sac-live", async () => {
+  const acct = await server.getAccount(deployer.publicKey());
+  const probe = new TransactionBuilder(acct, { fee: "1000000", networkPassphrase: PASSPHRASE })
+    .addOperation(Operation.invokeContractFunction({ contract: sacId, function: "decimals", args: [] }))
+    .setTimeout(60)
+    .build();
+  const sim = await server.simulateTransaction(probe);
+  if (!rpc.Api.isSimulationSuccess(sim)) throw new Error("contract instance not live yet");
+  return scValToNative(sim.result.retval);
+});
+console.log("  ok — decimals: 7");
+
+console.log("[4/7] adding trustlines (merchant + payer)…");
+await submit("merchant-trustline", merchant, [Operation.changeTrust({ asset })]);
+await submit("payer-trustline", payer, [Operation.changeTrust({ asset })]);
+console.log("  ok — both trustlines live");
+
+console.log("[5/7] funding the payer with tokens…");
+const mintHash = await submit("mint-to-payer", issuer, [
+  Operation.invokeContractFunction({
+    contract: sacId,
+    function: "mint",
+    args: [nativeToScVal(payer.publicKey(), { type: "address" }), nativeToScVal(PAYER_MINT_ATOMIC, { type: "i128" })],
+  }),
+]);
+await submit("seed-merchant", issuer, [
+  Operation.payment({ destination: merchant.publicKey(), asset, amount: MERCHANT_SEED_UNITS }),
+]);
+console.log(`  ok — payer holds ${PAYER_MINT_ATOMIC} atomic (100 ${ASSET_CODE})`);
+
+let walletId;
+if (agentPublic) {
+  console.log("[6/7] deploying a Vellar smart account with your agent key…");
+  const { Client } = await import("passkey-kit-sdk");
+  const { basicNodeSigner } = await import("@stellar/stellar-sdk/contract");
+  const deployTx = await retry("wallet-deploy", () =>
+    Client.deploy(
+      {
+        signer: {
+          tag: "Ed25519",
+          values: [
+            Buffer.from(StrKey.decodeEd25519PublicKey(agentPublic)),
+            [undefined],
+            [undefined],
+            { tag: "Persistent", values: undefined },
+          ],
+        },
+      },
+      {
+        rpcUrl: RPC_URL,
+        networkPassphrase: PASSPHRASE,
+        wasmHash: WALLET_WASM_HASH,
+        publicKey: deployer.publicKey(),
+        ...basicNodeSigner(deployer, PASSPHRASE),
+        timeoutInSeconds: 120,
+      },
+    ),
+  );
+  const { result: walletClient } = await deployTx.signAndSend();
+  walletId = walletClient.options.contractId;
+  await submit("mint-to-wallet", issuer, [
+    Operation.invokeContractFunction({
+      contract: sacId,
+      function: "mint",
+      args: [nativeToScVal(walletId, { type: "address" }), nativeToScVal(PAYER_MINT_ATOMIC, { type: "i128" })],
+    }),
+  ]);
+  console.log(`  ok — ${walletId} (funded)`);
+} else {
+  console.log("[6/7] skipping the smart account (set AGENT_PUBLIC to create one)");
+}
+
+console.log("[7/7] verifying on-chain state…");
+for (const [label, kp] of [
+  ["merchant", merchant],
+  ["payer", payer],
+]) {
+  const acct = await (await fetch(`${HORIZON}/accounts/${kp.publicKey()}`)).json();
+  const line = (acct.balances ?? []).find(
+    (b) => b.asset_code === ASSET_CODE && b.asset_issuer === issuer.publicKey(),
+  );
+  if (!line) throw new Error(`${label} trustline missing after provisioning`);
+  console.log(`  ok — ${label} balance: ${line.balance}`);
+}
+
+console.log(`
+════════════════════════════════════════════════════════════════════════════
+  Done. Paste this into examples/.env.recording (testnet keys — do not reuse)
+════════════════════════════════════════════════════════════════════════════
+
+FACILITATOR_URL=https://vellar-facilitator.onrender.com
+STELLAR_RPC_URL=${RPC_URL}
+
+# The token you just created. This is YOUR asset — you can mint more.
+ASSET=${sacId}
+ASSET_CODE_ISSUER=${ASSET_CODE}:${issuer.publicKey()}
+ISSUER_SECRET=${issuer.secret()}
+
+# Seller (the paid API)
+PAYTO=${merchant.publicKey()}
+MERCHANT_SECRET=${merchant.secret()}
+PRICE_ATOMIC=1000000
+SELLER_PORT=4031
+
+# Buyer — classic keypair (works with buyer-classic.mjs)
+PAYER_SECRET=${payer.secret()}
+# Simulate-only, never charged, never signs. MUST differ from the payer.
+SIM_SOURCE_ACCOUNT=${simSource.publicKey()}
+${
+  walletId
+    ? `
+# Buyer — smart account (works with buyer.mjs); pair with your AGENT_SECRET
+WALLET_CONTRACT_ID=${walletId}
+AGENT_PUBLIC=${agentPublic}`
+    : `
+# No smart account was created. Re-run with AGENT_PUBLIC=G… if you want one.`
+}
+
+Next:
+  1. Start the seller:
+       PAYTO=${merchant.publicKey()} \\
+       ASSET=${sacId} \\
+       node seller.mjs
+  2. Pay it (classic keypair — the values above are already in .env.recording):
+       RESOURCE_URL=http://127.0.0.1:4031/quote \\
+       PAYER_SECRET=${payer.secret()} \\
+       SIM_SOURCE_ACCOUNT=${simSource.publicKey()} \\
+       node buyer-classic.mjs
+
+  Roughly 1 settle in 3 fails on testnet with an empty transaction — retry it.
+  Nothing is spent when that happens.
+════════════════════════════════════════════════════════════════════════════
+`);

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -17,29 +17,67 @@ import { HTTPFacilitatorClient } from "@x402/core/http";
 import { x402ResourceServer, x402HTTPResourceServer } from "@x402/core/server";
 import { ExactStellarScheme } from "@x402/stellar/exact/server";
 import { bazaarResourceServerExtension, declareDiscoveryExtension } from "@x402/extensions/bazaar";
+import {
+  Networks,
+  Operation,
+  StrKey,
+  TransactionBuilder,
+  nativeToScVal,
+  scValToNative,
+  rpc,
+} from "@stellar/stellar-sdk";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 // Auto-load examples/.env.recording so you never have to `source` it. Existing
 // shell env vars still win (loadEnvFile does not override). No-op if absent.
+// Captured BEFORE the env file loads, so the boot log can say where PAYTO and
+// ASSET actually came from. `.env.recording` is a gitignored dotfile that
+// silently outranks the built-in defaults, and a stale one advertising a dead
+// merchant is precisely the failure these constants were once hardcoded to
+// prevent. It cannot be silent now: provenance is printed, and the trustline is
+// checked, on every boot.
+const shellPayTo = process.env.PAYTO;
+const shellAsset = process.env.ASSET;
+
 try {
   process.loadEnvFile(join(dirname(fileURLToPath(import.meta.url)), ".env.recording"));
 } catch {}
 
 const FACILITATOR_URL = process.env.FACILITATOR_URL || "https://vellar-facilitator.onrender.com";
-// Demo merchant. Hard-defaulted so a stale shell `PAYTO` cannot make the seller
-// serve a merchant with no trustline — the failure that motivated hardcoding.
+// Demo merchant + asset. These are DEFAULTS, overridable by `PAYTO` / `ASSET`
+// so you can run this seller against your own merchant without editing source
+// (`node provision-testnet.mjs` creates a matched set).
+//
+// They used to be hardcoded constants that silently ignored the environment.
+// The reason was real: a stale shell `PAYTO` makes the seller advertise a
+// merchant with no trustline, and that settle fails on-chain in a way that is
+// indistinguishable from a spend control refusing unless you go and read
+// Horizon. Ignoring the environment defended against that by making the seller
+// unusable for anyone else — while both docs still documented the flags. The
+// guard now lives in `preflightMerchant()` below, which checks the actual
+// condition (does this payTo hold a trustline to this asset?) instead of
+// proxying it, and refuses to boot with a message that names the fix.
 //
 // UPDATED 2026-08-10: the previous pair (CBIN4HTP… / GBDZH5KZ…) are DEAD — the
-// old issuer was burned during provisioning. A settle against them fails
-// on-chain, which is indistinguishable from a control refusing unless you check
-// Horizon. If you change these, redeploy vellar-seller-demo and re-run the live
-// ownership gate (docs/operator-runbook.md §4): the gate verifies the payTo the
-// challenge NAMES, so a stale 402 reads as a mismatch that looks like a
-// control failure.
-const PAYTO = "GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH";
-const ASSET = "CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR"; // X402TST bound token
+// old issuer was burned during provisioning. If you change these defaults,
+// redeploy vellar-seller-demo and re-run the live ownership gate
+// (docs/operator-runbook.md §4): the gate verifies the payTo the challenge
+// NAMES, so a stale 402 reads as a mismatch that looks like a control failure.
+const PAYTO = process.env.PAYTO || "GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH";
+const ASSET = process.env.ASSET || "CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR";
 const PRICE_ATOMIC = process.env.PRICE_ATOMIC || "1000000";
+
+// Used only by the boot-time merchant preflight below — never on the payment
+// path, which goes through the facilitator.
+const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+const PASSPHRASE = Networks.TESTNET;
+
+/** Where a value came from — shell, the env file, or the built-in default. */
+const sourceOf = (shellValue, name) =>
+  shellValue ? "environment" : process.env[name] ? "examples/.env.recording" : "built-in default";
+const PAYTO_SOURCE = sourceOf(shellPayTo, "PAYTO");
+const ASSET_SOURCE = sourceOf(shellAsset, "ASSET");
 
 /**
  * The address this merchant advertises as its own — the single source of truth
@@ -168,6 +206,115 @@ async function initializeWithRetry() {
   );
   throw lastError;
 }
+
+/**
+ * Refuse to boot a seller that cannot possibly be paid.
+ *
+ * A merchant with no trustline to the payment asset fails at SETTLEMENT — after
+ * verification has already passed — with an on-chain error that reads exactly
+ * like a spend control refusing the payment. You cannot tell the two apart
+ * without going and reading Horizon, which is why this used to be "defended"
+ * by ignoring `PAYTO`/`ASSET` entirely.
+ *
+ * Checked here instead, once, at boot:
+ *   1. both values are well-formed strkeys (a typo is caught before any I/O);
+ *   2. `PAYTO` is a real, funded account;
+ *   3. `PAYTO` holds a trustline to `ASSET` — a SAC `balance()` on an account
+ *      without one fails with Error(Contract, #13) rather than returning 0.
+ *
+ * A DEFINITIVE negative is fatal. An INCONCLUSIVE result (RPC unreachable) is a
+ * warning: a testnet RPC blip must not take a working seller offline, and the
+ * failure it guards against is loud on the settle path anyway.
+ *
+ * `SKIP_TRUSTLINE_CHECK=1` bypasses it for offline or fixture-driven runs.
+ */
+async function preflightMerchant() {
+  console.error(`[seller] payTo ${PAYTO} (from ${PAYTO_SOURCE})`);
+  console.error(`[seller] asset ${ASSET} (from ${ASSET_SOURCE})`);
+  if (!StrKey.isValidEd25519PublicKey(PAYTO)) {
+    console.error(
+      `\n[seller] FATAL: PAYTO is not a valid Stellar account address.\n` +
+        `  got: ${PAYTO}\n` +
+        `  PAYTO must be a G… ed25519 public key — the merchant that receives payment.\n`,
+    );
+    process.exit(1);
+  }
+  if (!StrKey.isValidContract(ASSET)) {
+    console.error(
+      `\n[seller] FATAL: ASSET is not a valid contract address.\n` +
+        `  got: ${ASSET}\n` +
+        `  ASSET must be a C… SEP-41 contract id (for a classic asset, its SAC).\n`,
+    );
+    process.exit(1);
+  }
+  if (process.env.SKIP_TRUSTLINE_CHECK === "1") {
+    console.error("[seller] preflight SKIPPED (SKIP_TRUSTLINE_CHECK=1) — settlement may fail on-chain");
+    return;
+  }
+
+  const server = new rpc.Server(RPC_URL);
+  const inconclusive = (why) =>
+    console.error(
+      `[seller] preflight INCONCLUSIVE (${String(why).slice(0, 120)}) — ` +
+        `could not confirm ${PAYTO.slice(0, 8)}… holds a trustline to ${ASSET.slice(0, 8)}…; starting anyway`,
+    );
+
+  let account;
+  try {
+    account = await server.getAccount(PAYTO);
+  } catch (err) {
+    const msg = String(err?.message ?? err);
+    if (!/not found/i.test(msg)) return inconclusive(msg);
+    console.error(
+      `\n[seller] FATAL: PAYTO ${PAYTO} does not exist on this network.\n\n` +
+        `  Fund it, then start again:\n` +
+        `    curl "https://friendbot.stellar.org?addr=${PAYTO}"\n\n` +
+        `  Or provision a complete matched set (asset, merchant, trustline, payer):\n` +
+        `    node provision-testnet.mjs\n`,
+    );
+    process.exit(1);
+  }
+
+  let sim;
+  try {
+    const probe = new TransactionBuilder(account, { fee: "1000000", networkPassphrase: PASSPHRASE })
+      .addOperation(
+        Operation.invokeContractFunction({
+          contract: ASSET,
+          function: "balance",
+          args: [nativeToScVal(PAYTO, { type: "address" })],
+        }),
+      )
+      .setTimeout(60)
+      .build();
+    sim = await server.simulateTransaction(probe);
+  } catch (err) {
+    return inconclusive(err?.message ?? err);
+  }
+
+  if (!rpc.Api.isSimulationSuccess(sim)) {
+    console.error(
+      `\n[seller] FATAL: PAYTO ${PAYTO}\n` +
+        `        has no trustline to ASSET ${ASSET}.\n\n` +
+        `  Every payment would verify and then FAIL at settlement, with an on-chain\n` +
+        `  error that looks like a spend control refusing it. Add the trustline first.\n\n` +
+        `  With the Stellar CLI (you need the merchant's secret key):\n` +
+        `    stellar tx new change-trust --source <MERCHANT_SECRET> \\\n` +
+        `      --line <CODE>:<ISSUER> --network testnet\n\n` +
+        `  Or provision a complete matched set (asset, merchant, trustline, payer):\n` +
+        `    node provision-testnet.mjs\n\n` +
+        `  If you believe this is wrong, SKIP_TRUSTLINE_CHECK=1 bypasses this check.\n`,
+    );
+    process.exit(1);
+  }
+
+  console.error(
+    `[seller] preflight ok — ${PAYTO.slice(0, 8)}… holds a trustline to ${ASSET.slice(0, 8)}…` +
+      ` (balance ${scValToNative(sim.result.retval)} atomic)`,
+  );
+}
+
+await preflightMerchant();
 await initializeWithRetry();
 
 function adapter(req) {


### PR DESCRIPTION
Walked the x402 loop cold — no repo knowledge, starting from `docs/using-it.md`
and the hosted instance. **Time to first successful payment: 19m41s**, of which
13 minutes were spent before the seller ever started. The same path is now
**~2m30s**.

None of the three blockers were in the facilitator. It verified, settled
on-chain, cataloged, and re-listed on retry, and its self-reported failure rate
was honest. Everything that cost time was scaffolding: an asset you could not
get, a hidden broken script, and a documented command that lied.

> **Follow-up:** this PR *records* the one real code defect the walkthrough found
> (O-7, `statsSource` asserting a provenance it does not have). The fix for it is
> in **#50** — it is not part of this change, which touches no `src/`.

## The three

**1. The payment asset was unobtainable, and undocumented.** `using-it.md` wrote
`asset: SEP41_CONTRACT_ID` and never said what it was. Worse, the demo's
`X402TST` **cannot be acquired by anyone** — its issuer keypair was generated
in-process by a throwaway script and the secret is gone. Reading the id out of
`/discovery/resources` does not help; nobody can obtain a balance.

`examples/provision-testnet.mjs` ships as supported, with three defects fixed:
friendbot 200 ≠ visible to the RPC (needs *three* consecutive reads — the RPC is
load-balanced across drifting nodes); `prepareTransaction` rejecting classic
`changeTrust` outright, which broke every trustline; and no retry for node lag.
The old script needed six attempts and three hand-patches to pass once. This one
ran clean three times.

**2. `seller.mjs` ignored `PAYTO` and `ASSET`** while both docs documented them.
The hardcoding had a real reason — a stale value advertises a merchant with no
trustline, and that settle fails on-chain looking exactly like a spend control
refusing it. So the guard is *replaced*, not removed: the environment is
honoured, and a boot preflight checks the real condition and names the fix.

**3. "A plain classic keypair works fine" had no code.** It does now, and it is
proven — 4 settlements across two asset sets. The facilitator rebuilds the
transaction with itself as the source, so your source is simulate-only, but it
must not *be* the payer or Soroban emits source-account credentials the scheme
refuses.

## Worth a reviewer's attention

Replacing the guard in (2) was correct and **the hazard came back anyway**,
through a path neither the constants nor the preflight covered. `seller.mjs`
loads a gitignored `.env.recording`, so the moment the constants became
`process.env.PAYTO || default`, a stale local dotfile outranked the reviewed
default — and it carried the *dead* pair retired in `62e6e05`. Caught only by
regression-testing the deployed configuration rather than the developer one.
Deployment was never affected; the file is never shipped.

The preflight did not catch it, because the dead pair still holds a trustline.
"Is this pair payable?" and "is this the pair you meant?" are different
questions. Every boot now prints provenance. Recorded as evidence lesson **3.9**.

## Recorded here, fixed elsewhere

**O-7 — `statsSource` asserts a provenance it does not have.** Checked before
writing, because it looks like a persistence defect and is not: a round-trip
probe returns `statsSource="persisted"` correctly, and a live restart restored
an entry as `settlements=5 observed=0 "persisted"`. The bug is on the read
path — `toItem()` infers the label from `settlements === observed`, so a
*restored* entry whose stored count is 0 is labelled `"observed"`. That is the
same assertion G-4 was raised for, surviving where G-4 fixed only the write
side. **Fixed in #50.**

**O-8 — catalog pollution is irreversible**, with no self-service removal.
Accepted; the mitigation is a warning placed *before* the walkthrough, so a
developer knows they are writing to shared state one-way before they do it.

## Verification

- **338 tests pass**, 3 skipped — unchanged. No `src/` changes in this PR.
- Clean-room run of the shipped scripts with zero edits: provision → seller →
  paid, first attempt. Seller up in 4s, payment in 15s.
- Both buyers proven end-to-end, including the smart-account branch of the
  provisioning script (wallet `CDKIAPI3…`, settlement `e8581537…`).
- Settle reliability sampled honestly: 13 attempts, 6 failures. Merchant balance
  afterwards was exactly successes × price — **no failed attempt moved money**,
  under either reason code.

`docs/handover-docs-site.md` is included but targets a **separate repo**
(docs.vellar.xyz); it is a work list to pick up later, not part of this change.
