### PR TITLE
fix(catalog): statsSource reports provenance, not arithmetic (O-7)

### DIFF
--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -99,15 +99,15 @@ path after these changes is **~2m30s**.
 | **O-4** | "A plain classic keypair works fine" had no code; the only example was smart-account-only | closed — `buyer-classic.mjs`, proven live (settlement `6cf8091c…`) |
 | **O-5** | A second settle failure code (`settle_exact_stellar_transaction_failed`) was undocumented, and money-safety was asserted only for the other one | closed-by-doc, and **measured**: 6 failures in 13 attempts moved zero value |
 | **O-6** | `/health` omits `unverifiableEntries` entirely when zero; the doc implied it is always present | closed-by-doc — the code is right (`server.ts:126`, test asserts a healthy catalog adds no noise) |
-| **O-7** | **`statsSource` asserts a provenance it does not have** — a restored entry whose stored count is 0 is labelled `"observed"` | **open defect — Low severity, fix recommended below.** *Not* the persistence defect it first looks like |
+| **O-7** | **`statsSource` asserted a provenance it did not have** — a restored entry whose stored count is 0 was labelled `"observed"` | **closed-by-test.** Fixed with the `restored` flag (option A below); 4 tests in `catalog.statsintegrity.test.ts` |
 | **O-8** | Following the tutorial pollutes a shared catalog irreversibly | **open — product gap, recorded below** |
 | **O-9** | `curl -I` on a paid route returns 200 while `GET` returns 402 | closed-by-doc — debug with GET |
 | **O-10** | Documented gotcha "`pagination.total` ignores `verified_only`" was stale | closed-by-doc — verified fixed live (`items: 0, total: 0`); `list()` computes `total` from the filtered set |
 | **O-11** | **A gitignored `.env.recording` silently outranks the built-in defaults** — found while regression-testing O-3. With no shell vars the seller advertised the *dead* `GBDZH5KZ…`/`CBIN4HTP…` pair from a stale local file, not the in-code defaults. This is the exact hazard the hardcoding existed to prevent, re-entering through the env-file path | closed — boot log now prints the **provenance** of each value (`environment` / `examples/.env.recording` / `built-in default`) and the trustline preflight runs regardless. Deployment is unaffected: the file is gitignored and never shipped |
 
-#### O-7 — `statsSource` asserts a provenance it does not have — **defect, Low**
+#### O-7 — `statsSource` asserted a provenance it did not have — **closed-by-test**
 
-**The label lies.** An entry can take real, settled payments indefinitely, report
+**The label lied.** An entry could take real, settled payments indefinitely, report
 `settlements: 0`, and stamp that zero `statsSource: "observed"` — a positive
 claim that this process witnessed every settlement counted, made by a process
 that witnessed none of them. It is the same class as G-4, whose whole finding was
@@ -166,17 +166,36 @@ witnessed rather than unknown.
 | **A** | Track provenance on the entry: set a `restored` flag when an entry is loaded from storage, and derive `statsSource` from it so a restored entry can never report `"observed"` | One field on `StoredEntry`, one line in `toItem()`, one line in the load path | Low. `"persisted"` already exists in the wire contract and already means "part of this count came from disk"; a restored zero is exactly that case |
 | **B** | Make the label three-valued — `observed` / `persisted` / `restored-unknown` | Same code, plus a new enum member | Higher. Adds a value agents must learn, and the existing two already express it |
 
-**Recommended: A.** It makes the label mean what the docs already say it means,
-without adding vocabulary. The current derivation
-(`settlements === observed`) infers provenance from a coincidence of numbers;
+**A was chosen and applied.** It makes the label mean what the docs already say
+it means, without adding vocabulary. The old derivation
+(`settlements === observed`) inferred provenance from a coincidence of numbers;
 `restored` records it as a fact, which is the actual difference between the two
-states. B is only worth it if consumers need to distinguish "restored with a
-known non-zero count" from "restored with nothing" — no consumer does today.
+states. B was rejected as only worth it if consumers need to distinguish
+"restored with a known non-zero count" from "restored with nothing" — no consumer
+does today.
 
-Deliberately not applied in this change: it edits a wire field on the read path
-and belongs with its own test (`catalog.statsintegrity.test.ts` is the natural
-home — extend it with a restart case asserting a restored zero never reports
-`"observed"`). Sequencing it separately keeps this diff to onboarding.
+**What shipped.** `StoredEntry.restored` is set on every load and carried through
+updates, and `toItem()` reads it instead of comparing counts. The field is
+**required, not optional**, for a reason found while writing the tests:
+`bindLoadedEntry` rebuilds the entry field by field rather than spreading it, so
+an optional flag was silently dropped there and loaded entries went straight back
+to reporting `"observed"`. The first implementation passed its own unit test and
+was still wrong at the seam. Required makes that omission a type error — and
+`exactOptionalPropertyTypes` is what surfaced it.
+
+**One deliberate imprecision, in the safe direction.** A restored entry that
+inherited 0 and then witnesses new settlements keeps reporting `"persisted"`,
+even though every settlement in that count really was observed. Under-claiming
+provenance is the correct error to make here, and `observedSettlements` still
+carries the exact witnessed number. Asserted directly in the tests so it reads as
+a decision rather than a bug.
+
+**Tests** — `catalog.statsintegrity.test.ts`, alongside G-4's, since this is the
+same assertion on the other path: a restored zero never reports `"observed"`; a
+restored entry stays `"persisted"` after new settlements and after re-upsert; an
+in-process entry still reports `"observed"`; and a crafted row claiming
+`restored: false` cannot forge observed provenance, because the load path decides
+it and not the payload.
 
 #### O-8 — catalog pollution is irreversible and self-service-proof
 

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -217,10 +217,13 @@ needs [runbook §1](./operator-runbook.md).
 ```
 
 - **`ownerVerified`** — yours to control, per above.
-- **`statsSource`** — `"observed"` means every settlement was witnessed by the
-  running process; `"persisted"` means part of the count was loaded from storage
-  and cannot be re-derived from the chain. `observedSettlements` is the number to
-  trust.
+- **`statsSource`** — where these numbers came from. `"observed"` means the entry
+  was created by the running process, so it witnessed the whole history.
+  `"persisted"` means the entry was loaded from storage: its baseline was
+  recorded by a previous process and cannot be re-derived from the chain.
+  A restored entry always reports `"persisted"`, **including when its stored
+  count is 0** — a zero it inherited is still a zero it did not witness.
+  `observedSettlements` is the number to trust either way.
 - **`verification` / `acceptsVerification`** — always `"unknown"` here. Not about
   you; see [§ What will bite you](#what-will-bite-you-on-the-hosted-instance).
 - Your entry appears **only after a real payment settles.** Verify-only traffic

--- a/src/catalog.statsintegrity.test.ts
+++ b/src/catalog.statsintegrity.test.ts
@@ -169,3 +169,125 @@ describe("G-4 — recordSettlement is gated at the catalog, not at the caller", 
     expect(stats(catalog)?.settlements).toBe(1);
   });
 });
+
+// ============================================================================
+// O-7 — `statsSource` asserted a provenance it did not have.
+//
+// G-4 above fixed the WRITE path: stats can no longer be moved by a payTo that
+// is not bound. The same assertion survived on the READ path. `statsSource` was
+// derived as `settlements === observed`, which answers "was the inherited
+// portion zero?" — not "did this process witness these numbers?". A restored
+// entry whose stored count is 0 satisfies `0 === 0` and was therefore labelled
+// "observed", claiming witness for an entry the process had never seen.
+//
+// That is the live case rather than a corner one, because G-4's own gate is what
+// produces the zeros: a resource can take real, settled payments indefinitely
+// and keep a stored count of 0 whenever the paying `payTo` is not bound to it.
+// Observed in production — two successful on-chain payments against a URL bound
+// to a different payTo left the counter unmoved, and the entry then reported
+// that 0 as "observed".
+// ============================================================================
+
+describe("O-7 — statsSource reports provenance, not arithmetic", () => {
+  it("a restored entry NEVER reports observed — including when its stored count is 0", async () => {
+    const { reopen } = await import("./store.testkit.js");
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const file = `file:${join(mkdtempSync(join(tmpdir(), "o7-")), "catalog.db")}`;
+
+    // Run 1: the entry is cataloged, but NO settlement is ever attributed to it
+    // — exactly what the G-4 gate leaves behind when the payer is unbound.
+    const before = await BazaarCatalog.create(reopen(file));
+    await before.upsertFromPayment(
+      { resourceUrl: VICTIM_URL, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      reqs(OWNER),
+    );
+    expect(stats(before)?.settlements, "precondition: nothing counted").toBe(0);
+    expect(stats(before)?.statsSource, "in-process, so genuinely observed").toBe("observed");
+    await before.flush();
+
+    // Run 2: same database, fresh process. The numbers are identical and their
+    // provenance is not — this process witnessed none of it.
+    const after = await BazaarCatalog.create(reopen(file));
+    const t = stats(after);
+    expect(t?.settlements, "the stored zero survives").toBe(0);
+    expect(t?.observedSettlements, "this process saw nothing").toBe(0);
+    expect(t?.statsSource, "O-7: a restored zero must not claim to be observed").toBe("persisted");
+  });
+
+  it("stays persisted after a restored entry witnesses new settlements", async () => {
+    const { reopen } = await import("./store.testkit.js");
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const file = `file:${join(mkdtempSync(join(tmpdir(), "o7b-")), "catalog.db")}`;
+
+    const before = await BazaarCatalog.create(reopen(file));
+    await before.upsertFromPayment(
+      { resourceUrl: VICTIM_URL, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      reqs(OWNER),
+    );
+    await before.flush();
+
+    const after = await BazaarCatalog.create(reopen(file));
+    expect(after.recordSettlement(VICTIM_URL, "CPAYER", OWNER)).toBe(true);
+    // Re-upserting must not launder the provenance either.
+    await after.upsertFromPayment(
+      { resourceUrl: VICTIM_URL, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      reqs(OWNER),
+    );
+
+    const t = stats(after);
+    expect(t?.settlements).toBe(1);
+    expect(t?.observedSettlements, "the new one WAS witnessed").toBe(1);
+    // Deliberately conservative: the arithmetic (1 === 1) would say "observed",
+    // but the baseline came from disk. Under-claiming is the safe direction, and
+    // observedSettlements still carries the exact witnessed count.
+    expect(t?.statsSource, "restored entries do not become observed").toBe("persisted");
+  });
+
+  it("an entry created in this process reports observed", async () => {
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(
+      { resourceUrl: VICTIM_URL, x402Version: 2, discoveryInfo: { input: { type: "http", method: "GET" } } } as never,
+      reqs(OWNER),
+    );
+    expect(catalog.recordSettlement(VICTIM_URL, "CPAYER", OWNER)).toBe(true);
+    expect(stats(catalog)?.statsSource).toBe("observed");
+  });
+
+  it("a crafted file cannot forge observed provenance", async () => {
+    const { reopen, seedRows } = await import("./store.testkit.js");
+    const { mkdtempSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const file = `file:${join(mkdtempSync(join(tmpdir(), "o7c-")), "catalog.db")}`;
+
+    // A payload asserting its own provenance, the way a tampered file would.
+    await seedRows(file, {
+      ownership: [{ key: VICTIM_URL, payTo: OWNER }],
+      entries: [
+        {
+          key: VICTIM_URL,
+          payload: {
+            resource: {
+              resource: VICTIM_URL,
+              type: "http",
+              x402Version: 2,
+              accepts: [reqs(OWNER)],
+              lastUpdated: new Date().toISOString(),
+            },
+            stats: { settlements: 999, payers: ["CPAYER"] },
+            restored: false,
+          },
+        },
+      ],
+    });
+
+    const catalog = await BazaarCatalog.create(reopen(file));
+    const t = stats(catalog);
+    expect(t?.observedSettlements, "never read from the file").toBe(0);
+    expect(t?.statsSource, "the load path decides provenance, not the payload").toBe("persisted");
+  });
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -437,6 +437,37 @@ interface StoredEntry {
   resource: DiscoveryResource;
   stats: SettlementStats;
   /**
+   * O-7 — did these stats come from a previous process?
+   *
+   * Set on every load and never cleared, because a restored entry's baseline was
+   * witnessed by nobody currently running, and no later settlement makes that
+   * untrue. `statsSource` is derived from THIS rather than from
+   * `settlements === observed`, which is the arithmetic it used to use.
+   *
+   * That arithmetic answered "was the inherited portion zero?", which is a
+   * different question and gives the wrong answer in the case you actually meet:
+   * a restored entry whose stored count is 0 satisfies `0 === 0` and was
+   * therefore labelled "observed" — asserting this process witnessed every
+   * settlement in the count, about an entry it had never seen. An entry reaches
+   * a stored 0 while plainly having settled whenever the G-4 gate refuses stats
+   * for an unbound payTo, so this is the live case, not a corner one.
+   *
+   * Deliberately conservative in one direction: a restored entry that inherited
+   * 0 and then witnesses new settlements keeps reporting "persisted", even
+   * though every settlement in that count was in fact observed. Under-claiming
+   * provenance is the safe error; `observedSettlements` still carries the exact
+   * number this process saw.
+   *
+   * It survives `flush()` as a field but is meaningless on disk: the load path
+   * sets it unconditionally, so a crafted CATALOG_FILE cannot forge "observed".
+   *
+   * REQUIRED, not optional, on purpose. `bindLoadedEntry` rebuilds the entry
+   * field by field rather than spreading it, and an optional flag there was
+   * silently dropped — a loaded entry went straight back to reporting
+   * "observed". Making it required turns that omission into a type error.
+   */
+  restored: boolean;
+  /**
    * Fix 0 Layer 1 (TOFU ownership binding). The set of payTo addresses bound to
    * this canonical resourceUrl. The first settlement to catalog a URL binds its
    * payTo here; only a settlement whose payTo is already in this set may append
@@ -1068,6 +1099,9 @@ export class BazaarCatalog {
       stats: existing?.stats ?? { settlements: 0, payers: [], observed: 0 },
       boundPayTo: existing ? existing.boundPayTo : [requirements.payTo],
       verifiedOwner: existing?.verifiedOwner ?? false,
+      // Carried, not recomputed: updating a restored entry does not make this
+      // process the witness of the baseline it inherited.
+      restored: existing?.restored ?? false,
     };
     if (isFirstCatalog) {
       // Ownership is recorded when the binding is ESTABLISHED (not at eviction),
@@ -1268,6 +1302,9 @@ export class BazaarCatalog {
         stats,
         boundPayTo: [],
         verifiedOwner: false,
+        // Set here and nowhere else on this path: anything reaching this loop
+        // came off disk, including a stored count of 0.
+        restored: true,
       };
       // Keyed by the CANONICAL form, for the same reason as ownership above: the
       // stored `resource.resource` is the merchant's advertised spelling, and
@@ -1325,6 +1362,9 @@ export class BazaarCatalog {
       resource: { ...stored.resource, accepts: kept },
       stats: stored.stats ?? { settlements: 0, payers: [], observed: 0 },
       boundPayTo: authoritative,
+      // Rebuilt field by field rather than spread, so provenance must be carried
+      // explicitly or a loaded entry silently reports itself as observed (O-7).
+      restored: stored.restored,
       // Never trust a stored verified flag — a crafted file could forge it (RA-9).
       // Layer 2 re-verifies from the resource on the bound owner's next
       // settlement, via `reverify` (G-1).
@@ -1458,11 +1498,15 @@ function toItem(entry: StoredEntry): TrustedDiscoveryResource {
       uniquePayers: entry.stats.payers.length,
       // Forged stats cannot be *rejected* — settlement history has no
       // independent source — so they are DISCLOSED instead. observedSettlements
-      // counts only what this process saw; statsSource says whether any part of
-      // `settlements` was inherited from disk and is therefore unverifiable.
+      // counts only what this process saw; statsSource says whether these
+      // numbers were inherited from a previous process and are therefore
+      // unverifiable.
+      //
+      // O-7: this was `settlements === observed`, which claimed "observed" for a
+      // restored entry whose stored count was 0 — a provenance assertion about
+      // an entry this process had never seen. Read the flag, not the arithmetic.
       observedSettlements: entry.stats.observed,
-      statsSource:
-        entry.stats.settlements === entry.stats.observed ? ("observed" as const) : ("persisted" as const),
+      statsSource: entry.restored ? ("persisted" as const) : ("observed" as const),
       ...(entry.stats.lastSettled ? { lastSettled: entry.stats.lastSettled } : {}),
     },
   };


### PR DESCRIPTION
Follow-up to #49, which closed the cold-start onboarding gaps. That walkthrough
surfaced one defect in `src/catalog.ts`; #49 recorded it and this fixes it.

## The defect

`statsSource` was derived as `settlements === observed`. That answers "was the
inherited portion zero?" — a different question from "did this process witness
these numbers?" — and it gives the wrong answer in the case you actually meet. A
restored entry whose stored count is 0 satisfies `0 === 0` and was labelled
`"observed"`, asserting witness for an entry the process had never seen.

**This is G-4 surviving on the read path.** G-4 was raised because `statsSource`
"continued to read observed, asserting a provenance the data did not have". It
was closed on the write side — stats can no longer be moved by an unbound
`payTo`. The same claim remained on the way out.

It is the live case rather than a corner one, because **G-4's own gate produces
the zeros**: a resource can take real, settled payments indefinitely and keep a
stored count of 0 whenever the paying `payTo` is not bound to it. Observed in
production during the walkthrough — two successful on-chain payments against a
URL bound to a different `payTo` left the counter unmoved at 5, and the entry
reported that count as `"observed"`.

## What this is not

**Not a persistence defect**, and that was checked before anything was written.
A round-trip against a real libSQL store returns `settlements=2 observed=0
statsSource="persisted"`, and a live restart restored an entry as
`settlements=5 observed=0 "persisted"`. Both correct.

**The gate is unchanged.** Refusing stats for an unbound `payTo` is most likely
correct behaviour and nothing here counts settlements it did not count before.
Only the label describing the resulting zero changes.

## The fix

`StoredEntry.restored` is set on load, carried through updates, and read by
`toItem()`. Chosen over a three-valued label (`observed` / `persisted` /
`restored-unknown`) because the existing two values already express it, and no
consumer needs to distinguish "restored with a known count" from "restored with
nothing".

The field is **required, not optional**, because of a seam found while testing:
`bindLoadedEntry` rebuilds the entry field by field rather than spreading it, so
an optional flag was silently dropped there and loaded entries went straight back
to reporting `"observed"`. The first implementation passed its own unit test and
was still wrong at the seam. Required turns that omission into a type error;
`exactOptionalPropertyTypes` is what surfaced it.

**One deliberate imprecision, in the safe direction.** A restored entry that
inherited 0 and then witnesses new settlements keeps reporting `"persisted"`,
even though every settlement in that count really was observed. Under-claiming
provenance is the right error to make, and `observedSettlements` still carries
the exact witnessed number. Asserted in the tests so it reads as a decision
rather than a bug.

## Wire-field impact

The value set is unchanged (`observed` / `persisted`); only which entries report
which. Entries loaded from storage now report `"persisted"` where some previously
reported `"observed"`. `using-it.md` is updated to describe provenance rather
than arithmetic.

## Tests

Four cases in `catalog.statsintegrity.test.ts`, deliberately next to G-4's
because it is the same assertion on the other path:

- a restored zero never reports `"observed"`;
- a restored entry stays `"persisted"` after new settlements **and** after
  re-upsert (updating must not launder provenance);
- an entry created in this process still reports `"observed"`;
- a crafted row claiming `restored: false` cannot forge provenance, because the
  load path decides it and not the payload.

**342 tests pass** (4 new), 3 skipped. Typecheck clean.
