### PR TITLE
fix(demo): point the seller at USDC and a merchant with a live trustline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ node_modules/
 !.env.recording.example
 *.log
 
+# Local libSQL catalog. docs/guide.md tells you to `mkdir -p data` and point
+# CATALOG_DB_URL at file:./data/catalog.db to run a facilitator locally, so
+# following the guide leaves an untracked database here. It holds resource
+# listings and ownership bindings — operational state, never source.
+data/
+
 # Scratch and provisioning scripts — never commit.
 #
 # These are the files that HANDLE key material even when they do not contain it:

--- a/README.md
+++ b/README.md
@@ -237,9 +237,16 @@ locally and walking the loop with both example scripts.
 
 - **`seller.mjs`** — an Express API with one paid route that declares the
   bazaar discovery extension (price, input schema, output example).
+- **`buyer-classic.mjs`** — a plain Stellar keypair pays it, built entirely on
+  the **official** x402 client (`@x402/stellar/exact/client` +
+  `@x402/core/client`). ~12 lines of payment logic: no hand-assembled
+  transaction, no hand-signed auth entry, no second funded account, and the
+  discovery extension is echoed for you.
 - **`buyer.mjs`** — an agent pays it from a Vellar smart account with an
   ed25519 session key (V1 credentials), echoing the discovery extension so
-  the facilitator catalogs the resource on settlement.
+  the facilitator catalogs the resource on settlement. Hand-rolled by
+  necessity: the official client cannot sign for a smart account
+  ([`docs/upstream-issue-smart-accounts.md`](./docs/upstream-issue-smart-accounts.md)).
 
 See [`docs/guide.md`](./docs/guide.md) for the walkthrough.
 

--- a/docs/diagnosis-demo-listing.md
+++ b/docs/diagnosis-demo-listing.md
@@ -87,10 +87,45 @@ once, and the badge flips to `true` on that settlement.
 
 ## What changed here
 
-Only one thing, and it is not the fix: `render.yaml` now sets `PAYTO` and
-`ASSET` explicitly on the `vellar-seller-demo` service. They were unset, so the
-deployed public service silently inherited `examples/seller.mjs`'s built-in
-defaults — an edit to a source default would have changed what a public service
-advertises, with nothing in the deployment file to show it. The pinned values
-are the ones already in effect, so this is a no-op today; it is a prerequisite
-for changing those defaults without breaking the deployment.
+`render.yaml` now sets `PAYTO` and `ASSET` explicitly on `vellar-seller-demo`.
+They were unset, so the deployed public service silently inherited
+`examples/seller.mjs`'s built-in defaults — an edit to a source default would
+have changed what a public service advertises, with nothing in the deployment
+file to show it.
+
+The values are the fix:
+
+- **`ASSET`** is now canonical testnet USDC
+  (`CBIELTK6…`), obtainable by anyone from the DEX with no faucet
+  (`USE_USDC=1 node provision-testnet.mjs`). The resource becomes payable by
+  strangers for the first time, which is what makes the badge reachable at all.
+- **`PAYTO`** is a new merchant account holding a live USDC trustline. The
+  secret was generated straight to disk and never printed; it is **not** needed
+  at runtime — `seller.mjs` only ever uses the public address.
+
+The old binding to `GBJX3E4G…` resolves itself. Because it was never verified,
+the first settlement naming the new address **displaces** it automatically. No
+operator step, no runbook §1.
+
+## What is still outstanding
+
+This repo's part is done. Two actions remain and neither can happen here:
+
+1. **Deploy.** Render picks up `render.yaml` on push. Until it redeploys, the
+   live demo still advertises the dead asset.
+2. **Settle once against the hosted facilitator.** That is what creates the
+   displacement, triggers re-verification, and flips the badge. Provision a
+   payer with `USE_USDC=1`, point `buyer-classic.mjs` at
+   `https://vellar-seller-demo.onrender.com/quote`, and pay once. Retry if it
+   fails — roughly one settle in three does, and nothing is spent when it does.
+
+Afterwards, confirm with:
+
+```sh
+curl -s https://vellar-facilitator.onrender.com/discovery/resources \
+  | python3 -c 'import sys,json; [print(i["resource"], i["trust"]["ownerVerified"]) for i in json.load(sys.stdin)["items"]]'
+```
+
+The demo entry should read `True`. The three `localhost` entries will not — they
+are unreachable by design and cannot be removed; the boot guard added alongside
+this stops a fourth.

--- a/docs/diagnosis-demo-listing.md
+++ b/docs/diagnosis-demo-listing.md
@@ -1,0 +1,96 @@
+# Diagnosis — why the demo listing is permanently unverified
+
+**2026-08-12. Diagnosis and one safe change; the fix itself is blocked on a
+question only the operator can answer.**
+
+The flagship catalog entry — `vellar-seller-demo` — reads
+`ownerVerified: false` on the hosted instance. It is the first thing anyone
+evaluating this project looks at, and it makes the ownership-verification
+feature look broken.
+
+**It is not broken. The entry is correct and would verify if it were ever
+re-checked.**
+
+---
+
+## What was checked
+
+| Check | Result |
+| --- | --- |
+| `GET https://vellar-seller-demo.onrender.com/quote` | `402` |
+| `GET …/quote/` (trailing slash, as stored) | `402` |
+| `PAYMENT-REQUIRED` header present and decodable | yes |
+| Challenge `resource.url` | `https://vellar-seller-demo.onrender.com/quote` |
+| Challenge `accepts[].payTo` | `GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH` |
+| Catalog's bound `payTo` | `GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH` |
+
+The bound address and the advertised address are **identical**, the URL is
+public https, and it answers 402 with a valid header. Every precondition for
+ownership verification is met.
+
+The trailing slash was the initial suspicion and is a red herring: the canonical
+key strips it, and both spellings return 402 anyway.
+
+## The actual cause
+
+The trust block gives it away:
+
+```json
+{ "settlements": 0, "observedSettlements": 0, "statsSource": "persisted",
+  "ownerVerified": false }
+```
+
+`statsSource: "persisted"` means the entry was restored from durable storage
+during the libSQL/Turso migration, carrying its stored `ownerVerified: false`
+with it. And a failed verification **re-runs only on the resource's next
+settlement** (after a 15-minute cooldown).
+
+The resource advertises `CDYCX4PE…` — the dead **X402TST** asset, whose issuer
+secret no longer exists. Nobody can obtain a balance, so nobody can pay it, so
+there is never a next settlement.
+
+```
+  badge is false
+    ← re-check only fires on the next settlement
+        ← no settlement is possible
+            ← the advertised asset cannot be obtained by anyone
+```
+
+Each link is blocked by the one below. Nothing here is a defect in the
+verification logic; the retry trigger is simply unreachable for an unpayable
+resource.
+
+## The fix
+
+Make one payment possible, then make it. The advertised asset has to change to
+something obtainable — the natural choice is canonical testnet USDC
+(`CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA`, which resolves to
+`USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5`, 7 decimals,
+`auth_required: false` so trustlines are permissionless).
+
+**Which path depends on one unanswered question: is the secret for
+`GBJX3E4G…` still held?** The account exists and is funded (9999.99 XLM, 13.0
+X402TST), but the key's whereabouts is not recorded anywhere in this repo.
+
+| | If the secret is held | If it is lost |
+| --- | --- | --- |
+| Merchant | Keep `GBJX3E4G…` | Use a merchant you control |
+| Trustline | Add one to USDC on that account | Provision the new merchant with one |
+| Binding | Untouched — `payTo` is unchanged | Transfers by **displacement** on first settlement |
+| Operator involvement | none | none |
+
+The displacement path works here specifically because this binding was **never
+verified**. Runbook §1 is only required to move an already-verified binding.
+
+Then: redeploy the demo with the new `ASSET` (and `PAYTO`, if changed), pay it
+once, and the badge flips to `true` on that settlement.
+
+## What changed here
+
+Only one thing, and it is not the fix: `render.yaml` now sets `PAYTO` and
+`ASSET` explicitly on the `vellar-seller-demo` service. They were unset, so the
+deployed public service silently inherited `examples/seller.mjs`'s built-in
+defaults — an edit to a source default would have changed what a public service
+advertises, with nothing in the deployment file to show it. The pinned values
+are the ones already in effect, so this is a no-op today; it is a prerequisite
+for changing those defaults without breaking the deployment.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -21,11 +21,12 @@ roles, two scripts, both in `examples/`.
   cd examples && node provision-testnet.mjs
   ```
 
-  There is no built-in test token and no faucet — the facilitator settles in
-  whatever SEP-41 asset you name, so you bring your own. The demo seller's
-  `X402TST` **cannot be acquired by anyone**: its issuer secret no longer
-  exists. See [`using-it.md` § First: bring your own payment
-  asset](./using-it.md#first-bring-your-own-payment-asset).
+  The facilitator settles in whatever SEP-41 asset you name and ships none of
+  its own. Minting one is right for this walkthrough; canonical testnet USDC
+  (`CBIELTK6…`) is right when strangers need to transact in something they both
+  already hold. The demo seller's `X402TST` **cannot be acquired by anyone**:
+  its issuer secret no longer exists. See [`using-it.md` § First: bring your own
+  payment asset](./using-it.md#first-bring-your-own-payment-asset).
 
 - A **payer signer**: a plain classic keypair (`buyer-classic.mjs`) or a Vellar
   smart account with an ed25519 session key (`buyer.mjs`, the "agent with a
@@ -96,22 +97,18 @@ extension.
 The buyer flow, condensed:
 
 1. `GET` the resource → decode the `PAYMENT-REQUIRED` header.
-2. Build the SEP-41 `transfer(from = your account, to = payTo, amount)`.
-3. Sign the payer's auth entry (the examples sign with an ed25519 session
-   key as V1 address credentials — the pattern proven against this
-   facilitator; see `buyer.mjs` for the exact signing code).
-4. **Echo `required.extensions` into the payment payload** — this is what
+2. `client.createPaymentPayload(required)` — the official scheme builds the
+   SEP-41 `transfer(from = you, to = payTo, amount)`, signs your auth entry,
+   sets ledger-based expiry, and **echoes `required.extensions`**, which is what
    lets the facilitator catalog the resource for discovery.
-5. Retry with `PAYMENT-SIGNATURE: base64(paymentPayload)` → `200` + the
+3. Retry with `PAYMENT-SIGNATURE: base64(paymentPayload)` → `200` + the
    content + the on-chain settlement hash.
 
 ```sh
 cd examples
 
-# Classic keypair — the smaller path, no extra dependencies.
-RESOURCE_URL=http://127.0.0.1:4031/quote \
-PAYER_SECRET=S... SIM_SOURCE_ACCOUNT=G... \
-node buyer-classic.mjs
+# Classic keypair — the smaller path, built on the official x402 client.
+RESOURCE_URL=http://127.0.0.1:4031/quote PAYER_SECRET=S... node buyer-classic.mjs
 
 # Or a Vellar smart account, for an on-chain enforced budget.
 RESOURCE_URL=http://127.0.0.1:4031/quote \
@@ -125,11 +122,15 @@ node buyer.mjs
 asset](./using-it.md#first-bring-your-own-payment-asset) and
 [`walkthrough-wallet-spec.md`](./walkthrough-wallet-spec.md).
 
-`SIM_SOURCE_ACCOUNT` must be a **different** account from the payer. The
-facilitator rebuilds the transaction with itself as the source, so yours is used
-only to simulate — but simulating from the payer yields source-account
-credentials, which the scheme rejects
-(`invalid_exact_stellar_payload_unsupported_credential_type`).
+**Only `buyer.mjs` needs `SIM_SOURCE_ACCOUNT`**, and it must be a **different**
+account from the payer: the facilitator rebuilds the transaction with itself as
+the source, so yours is used only to simulate — but simulating from the payer
+yields source-account credentials, which the scheme rejects
+(`invalid_exact_stellar_payload_unsupported_credential_type`). `buyer-classic.mjs`
+does not need it, because the official client simulates from the SDK's null
+account. That is also the only reason `buyer.mjs` is hand-rolled at all — the
+official client cannot sign for a smart account; see
+[`upstream-issue-smart-accounts.md`](./upstream-issue-smart-accounts.md).
 
 Expect to retry: roughly one settle in three fails on testnet with an empty
 `transaction`. Nothing is spent when that happens.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -19,6 +19,8 @@ roles, two scripts, both in `examples/`.
 
   ```sh
   cd examples && node provision-testnet.mjs
+  # or, to use canonical testnet USDC instead of minting a throwaway token:
+  cd examples && USE_USDC=1 node provision-testnet.mjs
   ```
 
   The facilitator settles in whatever SEP-41 asset you name and ships none of

--- a/docs/upstream-issue-smart-accounts.md
+++ b/docs/upstream-issue-smart-accounts.md
@@ -1,0 +1,183 @@
+# Upstream issue — DRAFT, NOT FILED
+
+**Target:** `x402-foundation/x402` (the repo `@x402/stellar` points at).
+**Confirmed against:** `@x402/stellar@2.22.0` — the latest published release,
+verified by unpacking the tarball, not just our pinned 2.20.0. The signing block
+is byte-identical in both.
+**Status:** reproduced live on testnet against a real deployed smart account,
+not inferred from reading the source. Stack trace under
+[Reproduction](#reproduction).
+
+**Not opened.** It goes out under the repo owner's name, so it is here to be read
+first — same handling as
+[`upstream-issue-draft.md`](./upstream-issue-draft.md) (filed as
+[#3125](https://github.com/x402-foundation/x402/issues/3125)).
+
+**Why this one matters more than #3125.** #3125 makes a failure mode legible.
+This one makes an entire payer class impossible. Soroban smart accounts —
+policy-governed agents, passkey wallets — are the case x402 on Stellar is most
+often pitched for, and the official client cannot sign for any of them.
+
+---
+
+## Title
+
+`exact/stellar`: the client scheme cannot pay from a Soroban smart account —
+`signAuthEntries` forces an ed25519 signature shape
+
+## Body
+
+### Summary
+
+`ExactStellarScheme` (client) signs the payer's auth entry through
+`AssembledTransaction.signAuthEntries`, which narrows any signer's result to a
+naked signature buffer. A naked buffer routes `authorizeEntry` down its ed25519
+branch, which treats the auth entry's own address as an ed25519 public key. For a
+custom account contract that address is a `C…` contract id, so the call throws
+before a payment can be produced.
+
+The SDK has a documented escape hatch for exactly this case —
+`authorizeEntry`'s signer may return `{ signatureScVal }`, described in its own
+JSDoc as being "for custom account contracts (smart wallets, passkey/WebAuthn
+signers, etc.) whose `__check_auth` expects a signature structure" of its own.
+`signAuthEntries` does not expose it, and the x402 client scheme does not pass
+the `authorizeEntry` override that would.
+
+Net effect: `@x402/stellar` advertises Stellar payer support, but only classic
+`G…` keypairs can actually pay.
+
+### Where
+
+`src/exact/client/scheme.ts` (published build,
+`dist/cjs/exact/client/index.js:194-198` of 2.22.0):
+
+```js
+await tx.signAuthEntries({
+  address: sourcePublicKey,
+  signAuthEntry: this.signer.signAuthEntry,
+  expiration: maxLedger
+});
+```
+
+`signAuthEntries` accepts a fourth option, `authorizeEntry`, and it is not passed.
+
+### The chain
+
+Against `@stellar/stellar-sdk@16.2.0`:
+
+1. `AssembledTransaction.signAuthEntries`
+   (`lib/cjs/contract/assembled_transaction.js:615`) wraps the caller's
+   `signAuthEntry` and returns **a naked buffer** at line 670:
+
+   ```js
+   return buffer.Buffer.from(signedAuthEntry, "base64");
+   ```
+
+2. `authorizeEntry` (`lib/cjs/base/auth.js`) checks for `signatureScVal` first.
+   A naked buffer misses it and falls to the ed25519 branch, which derives the
+   signer's public key from the entry's own credentials address (line 52) and
+   verifies against it (line 58):
+
+   ```js
+   publicKey = address.Address.fromScAddress(addrAuth.address()).toString();
+   ...
+   if (!keypair.Keypair.fromPublicKey(publicKey).verify(payload, signature)) {
+   ```
+
+3. For a smart account that address is a `C…` contract id:
+
+   ```
+   Keypair.fromPublicKey("C…") → Error: invalid version byte. expected 48, got 16
+   ```
+
+The type layer suggests this should work — `isClientStellarSigner` accepts
+`{ address, signAuthEntry }` with `signTransaction` optional, which is exactly the
+shape a smart-account signer has. The runtime path does not.
+
+### Reproduction
+
+Run live on testnet against a **real deployed smart account** funded with the
+payment asset (2026-08-12). Not a constructed mock: the only unusual property of
+the signer is that its `address` is a `C…` contract id, which is what a smart
+account is.
+
+```js
+import { ExactStellarScheme } from "@x402/stellar/exact/client";
+
+const signer = {
+  address: "CBOTN25T3HPF6UKAYX5EO7BE3HGGLPNMV4GEWV75PRL6I7NFDHQSQD3Q", // smart account
+  signAuthEntry: async () => ({ signedAuthEntry: Buffer.alloc(64).toString("base64") }),
+};
+
+const scheme = new ExactStellarScheme(signer, { url: "https://soroban-testnet.stellar.org" });
+await scheme.createPaymentPayload(2, {
+  scheme: "exact",
+  network: "stellar:testnet",
+  amount: "1000000",
+  asset: "CACDPE626YV7HGDGAMFETFJK2P5SOEYFYIN5IC5I2HBDTLG42R7KX6UB",
+  payTo: "GC6NI7Z2UNXIGC5ULVQ7P6K765GRC6EF7NT2FAZ2EU3WU46EFTNHWAQO",
+  maxTimeoutSeconds: 120,
+  extra: { areFeesSponsored: true },
+});
+```
+
+Result:
+
+```
+Error: invalid version byte. expected 48, got 16
+    at decodeCheck (@stellar/stellar-sdk/lib/esm/base/strkey.js:349:11)
+    at StrKey.decodeEd25519PublicKey (@stellar/stellar-sdk/lib/esm/base/strkey.js:58:12)
+    at Keypair.fromPublicKey (@stellar/stellar-sdk/lib/esm/base/keypair.js:83:36)
+    at authorizeEntry (@stellar/stellar-sdk/lib/esm/base/auth.js:56:18)
+    at async AssembledTransaction.signAuthEntries (…/contract/assembled_transaction.js:658:24)
+    at async ExactStellarScheme.createPaymentPayload (@x402/stellar/dist/esm/chunk-SOJRTSRS.mjs:77:5)
+```
+
+**Note where it does not fail.** Simulation succeeded — the account is funded and
+the transfer assembles cleanly. Execution reaches `authorizeEntry` and dies
+purely on signature shaping, so this is not a funding, trustline or
+configuration problem.
+
+Executed against `@x402/stellar@2.20.0` with `@stellar/stellar-sdk@16.2.0`. The
+signing block in `2.22.0` is byte-identical, verified by unpacking the published
+tarball, so the same failure applies to the latest release.
+
+### Proposed fix
+
+Thread an optional `authorizeEntry` through the client scheme and forward it.
+`signAuthEntries` already accepts the parameter, so this is a pass-through — no
+`@stellar/stellar-sdk` change required:
+
+```js
+constructor(signer, rpcConfig, options = {}) {
+  this.authorizeEntry = options.authorizeEntry;   // optional
+  …
+}
+
+await tx.signAuthEntries({
+  address: sourcePublicKey,
+  signAuthEntry: this.signer.signAuthEntry,
+  expiration: maxLedger,
+  ...(this.authorizeEntry ? { authorizeEntry: this.authorizeEntry } : {}),
+});
+```
+
+A caller with a smart account then supplies an `authorizeEntry` that returns
+`{ signatureScVal }` in whatever shape its `__check_auth` expects. Classic
+keypairs are unaffected — the default path is unchanged when the option is
+omitted.
+
+An alternative that avoids a constructor argument is to let
+`ClientStellarSigner.signAuthEntry` optionally return `{ signatureScVal }` and
+have the scheme detect it, but that requires `signAuthEntries` in the SDK to stop
+narrowing to a buffer, which is the larger change across two repos.
+
+### Reference implementation
+
+`examples/buyer.mjs` in
+[Vellar-Wallet/vellar-facilitator](https://github.com/Vellar-Wallet/vellar-facilitator)
+is a working smart-account payer against a live facilitator, written against the
+raw SDK precisely because the client scheme cannot express it. It signs a
+policy-governed Vellar smart account with an ed25519 session key; the settlement
+hashes are in `docs/decisions.md`. Its sibling `examples/buyer-classic.mjs` is
+~12 lines on the official client, which is the gap this issue is about.

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -25,8 +25,33 @@ Both roles need this, and it is the step most likely to stop you before you
 start.
 
 The facilitator settles in a **SEP-41 token, and it does not care which one.**
-There is no canonical asset, no built-in test token, and no faucet. You bring a
-token you control.
+It ships no token of its own and runs no faucet, so you need to decide which
+token you are transacting in before anything else works.
+
+Two options, and the first is newer advice than the rest of this page:
+
+**Canonical testnet USDC.** `@x402/stellar` ships its address, so it is the
+closest thing to a default the ecosystem has:
+
+```
+CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
+  → USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5, 7 decimals
+```
+
+Verified live: the contract exists on testnet and the asset sets
+`auth_required: false`, so **anyone can open a trustline without the issuer's
+permission**. Use it when you want two parties who have never met to transact —
+agent-to-agent payment needs an asset both sides already accept, and a token you
+minted yourself is one nobody else holds.
+
+What is *not* verified here: how you obtain a **balance**. Trustlines are
+permissionless; the tokens still have to come from a faucet or another holder.
+Confirm that before committing to this path.
+
+**A token you mint yourself.** Fully self-contained, no faucet, no external
+dependency — and correspondingly useless to anyone but you. Right for walking
+the loop and for testing your own integration end to end. That is what
+`provision-testnet.mjs` below produces.
 
 **You cannot use the demo seller's token.** The `X402TST` asset (`CDYCX4PE…`)
 advertised by `vellar-seller-demo` was minted by an issuer keypair generated
@@ -112,12 +137,18 @@ cd examples
 PAYTO=G... ASSET=C... PRICE_ATOMIC=1000000 node seller.mjs
 ```
 
-It refuses to boot if that pair cannot be paid: `PAYTO` must be a funded account
-holding a **trustline to `ASSET`**. Without the trustline every payment verifies
+It refuses to boot in two cases. First, if that pair cannot be paid: `PAYTO` must
+be a funded account holding a **trustline to `ASSET`**. Without the trustline every payment verifies
 and then fails at settlement, with an on-chain error that reads exactly like a
 spend control refusing it — so the check happens once, at boot, and names the
 fix. `SKIP_TRUSTLINE_CHECK=1` bypasses it; an unreachable RPC warns rather than
 blocks.
+
+Second, if booting would pollute shared state: an **unverifiable resource URL
+pointed at a non-local facilitator** is refused, because the first settlement
+would write a permanent public entry nobody can remove. See [§ Your first
+settlement writes to a shared
+catalog](#your-first-settlement-writes-to-a-shared-catalog-permanently).
 
 ### What your 402 must declare
 
@@ -260,28 +291,39 @@ needs [runbook §1](./operator-runbook.md).
 | The **payment asset**, and a trustline to it | **XLM for fees** — the facilitator's sponsor pays them |
 | A Stellar signer: a plain classic keypair **or** a smart account | An account on this facilitator. No signup, no key, no allowlist |
 
-**A smart account is optional, and both paths have working code.**
+**A smart account is optional, and both paths have working code — but they are
+not equally easy, and the difference is upstream, not here.**
 
-| Payer | Example | Use it when |
-| --- | --- | --- |
-| **Classic keypair** | `examples/buyer-classic.mjs` | You just want to pay. No extra dependencies. |
-| **Vellar smart account** | `examples/buyer.mjs` | You want an agent whose budget is enforced on-chain by a policy contract. |
+| Payer | Example | Built on | Use it when |
+| --- | --- | --- | --- |
+| **Classic keypair** | `examples/buyer-classic.mjs` | The **official** x402 client | You just want to pay. ~12 lines. |
+| **Vellar smart account** | `examples/buyer.mjs` | Hand-rolled, of necessity | You want an agent whose budget is enforced on-chain by a policy contract. |
 
-The classic example is the smaller one and is proven against this facilitator
-(settlement `6cf8091c…`). The smart-account example exists because of the "agent
-with a budget" pattern: policy-governed accounts run their policy inside
-`__check_auth`, which pushes the simulated fee to ~130k stroops, and
-facilitators defaulting to a 50k ceiling reject them. This one defaults to
-500,000.
+The classic path is the one to copy. It is proven against this facilitator
+(settlement `9512a079…`) and it delegates everything to
+`@x402/stellar/exact/client` plus `@x402/core/client` — no custom SDK, no
+hand-assembled transaction, no hand-signed auth entry.
 
-**Whichever you use, simulate from a different account than the payer.** Both
-examples take a `SIM_SOURCE_ACCOUNT`: any funded account, never charged, never
-signs. It exists because the facilitator **rebuilds the transaction with itself
-as the source** before submitting, so your source is only ever used to simulate
-— but if the payer *is* that source, Soroban authorizes the transfer with
-source-account credentials, and the scheme accepts only address credentials
-(`invalid_exact_stellar_payload_unsupported_credential_type`). Simulating from a
-separate account is what produces an auth entry you can sign detached.
+The smart-account example exists for the "agent with a budget" pattern:
+policy-governed accounts run their policy inside `__check_auth`, which pushes the
+simulated fee to ~130k stroops, and facilitators defaulting to a 50k ceiling
+reject them. This one defaults to 500,000.
+
+It is hand-rolled because **the official client cannot express a smart-account
+signature today.** `AssembledTransaction.signAuthEntries` narrows your signer's
+result to a naked buffer, which routes to the ed25519 branch of `authorizeEntry`
+and throws on a C-address. The SDK's `{ signatureScVal }` escape hatch — added
+for exactly this case — is not reachable through the x402 client scheme. Details
+and the proposed fix: [`upstream-issue-smart-accounts.md`](./upstream-issue-smart-accounts.md).
+
+**You do not need a second funded account.** Earlier revisions of this page told
+you to pass a `SIM_SOURCE_ACCOUNT` different from the payer, because simulating
+from the payer yields source-account credentials that the scheme rejects
+(`invalid_exact_stellar_payload_unsupported_credential_type`). That was a
+consequence of building the transaction by hand. The official client simulates
+from the SDK's null account, so the payer is never the transaction source and the
+failure cannot arise. `buyer-classic.mjs` ignores the variable if you still have
+it set. `buyer.mjs` still needs one.
 
 ### Discovering resources
 
@@ -310,38 +352,45 @@ filter on `verified_only`; it is inert here and returns nothing.
 
 ### Paying
 
-```
-1. GET the resource                    → 402 + PAYMENT-REQUIRED header
-2. Build the SEP-41 transfer            (from you, to payTo, amount)
-3. Sign your auth entry
-4. Echo required.extensions into the payload   ← this is what catalogs it
-5. Retry with PAYMENT-SIGNATURE: base64(payload) → 200 + content
+With a classic keypair, the whole thing is three steps and the middle one is a
+single call:
+
+```js
+const signer = createEd25519Signer(PAYER_SECRET, "stellar:testnet");
+const client = new x402Client().register("stellar:testnet", new ExactStellarScheme(signer, { url: RPC_URL }));
+const http = new x402HTTPClient(client);
+
+const unpaid = await fetch(RESOURCE_URL);                                  // 402
+const required = http.getPaymentRequiredResponse(n => unpaid.headers.get(n));
+const payload = await client.createPaymentPayload(required);               // builds + signs
+const paid = await fetch(RESOURCE_URL, { headers: http.encodePaymentSignatureHeader(payload) });
 ```
 
+`createPaymentPayload` assembles the SEP-41 transfer, signs your auth entry, sets
+expiry from the seller's `maxTimeoutSeconds`, **and echoes the seller's
+`extensions` into the payload** — the last of which is what makes the facilitator
+catalog the resource. You do not register a client-side extension to get that;
+the merge is unconditional.
+
 **Copy from `examples/buyer-classic.mjs`** (classic keypair) or
-`examples/buyer.mjs` (smart account). Both are the exact signing code proven
-against this facilitator; the auth-entry shape is the part worth not
-reinventing.
+`examples/buyer.mjs` (smart account).
 
 ```sh
 cd examples
-RESOURCE_URL=https://your-seller/quote \
-PAYER_SECRET=S... SIM_SOURCE_ACCOUNT=G... \
-node buyer-classic.mjs
+RESOURCE_URL=https://your-seller/quote PAYER_SECRET=S... node buyer-classic.mjs
 ```
 
-The two differ only in step 3. A classic account signs its auth entry with a vec
-of `{ public_key, signature }` maps; a smart account signs with its own
-contract-defined `SignerKey`/`Signature` shape. Everything else — the transfer,
-the extension echo, the retry — is identical.
+One thing that will cost you time otherwise:
 
-Two things that will cost you time otherwise:
+- **Signatures expire in ledgers (~5s each), not wall-clock.** The scheme derives
+  the expiry ledger from `maxTimeoutSeconds` at signing time. Do not cache a
+  signed payload — sign a fresh one per attempt, which also matters because
+  retrying a failed settle is mandatory (see below).
 
-- **Step 4 is not optional if you want discovery to work.** Echoing the
-  extensions is what tells the facilitator to catalog the resource. Skip it and
-  the payment succeeds and nothing is listed.
-- **Signatures expire in ledgers (~5s each), not wall-clock.** The examples sign
-  for current + 12. Do not cache a signed payload.
+If you are writing the payer by hand instead — as `buyer.mjs` must — the flow
+underneath is: GET → 402, build the SEP-41 transfer, sign the auth entry, echo
+`required.extensions`, retry with `PAYMENT-SIGNATURE`. Skipping the echo still
+pays, but lists nothing.
 
 ---
 
@@ -420,10 +469,18 @@ Nothing breaks, and your payments are unaffected. The cost is borne by everyone
 reading the catalog: agents see a localhost URL they cannot call, listed
 alongside real resources.
 
+**`seller.mjs` now refuses to boot in exactly this combination** — an
+unverifiable resource URL (http, loopback, private range) pointed at a
+non-local facilitator — and names both fixes: run a local facilitator, or set
+`PUBLIC_BASE_URL`. It is deliberately narrow: a public seller on the hosted
+instance is the normal deployed case and is untouched, as is a localhost seller
+on a localhost facilitator. `ALLOW_UNVERIFIABLE_ON_SHARED=1` overrides it if you
+genuinely mean it.
+
 **If you would rather not leave one:** run your own facilitator for the
 walkthrough (`docs/guide.md`, one command and a local database), and point at the
 hosted instance only once your seller has a public https URL. If you do settle
-from localhost, that is accepted and expected here — just do it knowing it is a
+from localhost deliberately, that is accepted here — just do it knowing it is a
 one-way write to shared state.
 
 ### About that settle failure

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -38,20 +38,31 @@ CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
   → USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5, 7 decimals
 ```
 
-Verified live: the contract exists on testnet and the asset sets
-`auth_required: false`, so **anyone can open a trustline without the issuer's
-permission**. Use it when you want two parties who have never met to transact —
-agent-to-agent payment needs an asset both sides already accept, and a token you
-minted yourself is one nobody else holds.
+**You can obtain it with no faucet and no human step** — verified end to end on
+2026-08-12:
 
-What is *not* verified here: how you obtain a **balance**. Trustlines are
-permissionless; the tokens still have to come from a faucet or another holder.
-Confirm that before committing to this path.
+```sh
+cd examples && USE_USDC=1 node provision-testnet.mjs
+```
 
-**A token you mint yourself.** Fully self-contained, no faucet, no external
-dependency — and correspondingly useless to anyone but you. Right for walking
-the loop and for testing your own integration end to end. That is what
-`provision-testnet.mjs` below produces.
+Circle's testnet issuer sets `auth_required: false`, so trustlines are
+permissionless, and there is a live XLM/USDC market on the testnet DEX. The
+script funds an account from friendbot, opens the trustline, and buys USDC with
+a path payment — **10 USDC cost 5.59 XLM** against a 10,000 XLM friendbot grant,
+so the budget is not close to binding. A full x402 payment then settled in it
+(`f9b743c5…`, merchant balance reconciling exactly).
+
+Use USDC when two parties who have never met need to transact. Agent-to-agent
+payment requires an asset both sides already accept, and a token you minted
+yourself is one nobody else holds.
+
+**A token you mint yourself.** The default, and still the right choice for
+walking the loop: fully self-contained, no dependency on an external market, and
+you can mint as much as you want. Correspondingly useless to anyone but you.
+
+```sh
+cd examples && node provision-testnet.mjs
+```
 
 **You cannot use the demo seller's token.** The `X402TST` asset (`CDYCX4PE…`)
 advertised by `vellar-seller-demo` was minted by an issuer keypair generated

--- a/examples/buyer-classic.mjs
+++ b/examples/buyer-classic.mjs
@@ -1,41 +1,39 @@
 // BUYER (classic keypair) — pay for an x402 resource with a plain Stellar
 // account. No smart account, no passkey-kit, no policy contract.
 //
-// This is the minimal payer. If you want an agent with an on-chain budget, use
-// `buyer.mjs` instead — that one signs with a Vellar smart account's session
-// key and the spend limit is enforced by the wallet contract.
+// This is the minimal payer, and it is deliberately built on the OFFICIAL x402
+// client rather than hand-rolled. `@x402/stellar/exact/client` already builds
+// the SEP-41 transfer, signs the auth entry and computes ledger-based expiry;
+// `@x402/core/client` already echoes the seller's discovery extension into the
+// payload. Copy this file, not the mechanics underneath it.
 //
-// Flow: GET → 402 → build the SEP-41 transfer → sign the auth entry with your
-// account key → echo the discovery extension → retry with PAYMENT-SIGNATURE.
+// If you want an agent with an on-chain budget, use `buyer.mjs` — that one
+// signs with a Vellar smart account's session key and the spend limit is
+// enforced by the wallet contract. It is hand-rolled because it has to be; the
+// header of that file explains why the official client cannot do it.
+//
+// Flow: GET → 402 → createPaymentPayload() → retry with PAYMENT-SIGNATURE.
 //
 // Run (testnet):
 //   RESOURCE_URL=http://127.0.0.1:4031/quote \
-//   PAYER_SECRET=S...          (your account; holds the asset + a trustline) \
-//   SIM_SOURCE_ACCOUNT=G...    (a DIFFERENT funded account — see below) \
+//   PAYER_SECRET=S...   (your account; holds the asset + a trustline) \
 //   node buyer-classic.mjs
 //
-// WHY A SEPARATE SIMULATION SOURCE
-// --------------------------------
-// The facilitator rebuilds the transaction with ITSELF as the source account
-// before submitting, so the source you build with is only ever used to
-// simulate — it is never charged and never signs anything. But it must not be
-// the payer: when the payer is also the transaction source, Soroban authorizes
-// the transfer with SOURCE-ACCOUNT credentials, and the facilitator's scheme
-// only accepts ADDRESS credentials
-// (`invalid_exact_stellar_payload_unsupported_credential_type`). Simulating
-// from a different account is what makes the auth entry an address entry that
-// you can sign detached.
+// NO SEPARATE SIMULATION SOURCE IS NEEDED.
+// ----------------------------------------
+// Earlier revisions of this file required a second funded account in
+// SIM_SOURCE_ACCOUNT, because simulating from the payer yields SOURCE-ACCOUNT
+// credentials and the facilitator's scheme accepts only ADDRESS credentials
+// (`invalid_exact_stellar_payload_unsupported_credential_type`). That was an
+// artifact of building the transaction by hand. The official client passes no
+// `publicKey` to `AssembledTransaction.build`, so simulation runs from the
+// SDK's NULL_ACCOUNT — the payer is never the transaction source and the
+// failure cannot arise. If you are porting old code, delete the variable.
 
-import {
-  Address,
-  Keypair,
-  xdr,
-  hash,
-  nativeToScVal,
-  buildAuthorizationEntryPreimage,
-  rpc,
-} from "@stellar/stellar-sdk";
-import { AssembledTransaction } from "@stellar/stellar-sdk/contract";
+import { x402Client } from "@x402/core/client";
+import { x402HTTPClient } from "@x402/core/http";
+import { ExactStellarScheme } from "@x402/stellar/exact/client";
+import { createEd25519Signer } from "@x402/stellar";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -44,125 +42,70 @@ try {
 } catch {}
 
 const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
-const PASSPHRASE = "Test SDF Network ; September 2015";
 const RESOURCE_URL = process.env.RESOURCE_URL || "http://127.0.0.1:4031/quote";
+const NETWORK = "stellar:testnet";
 const payerSecret = process.env.PAYER_SECRET;
-const simSource = process.env.SIM_SOURCE_ACCOUNT;
 
-if (!payerSecret || !simSource) {
-  console.error("PAYER_SECRET and SIM_SOURCE_ACCOUNT are required (run provision-testnet.mjs to get both)");
+if (!payerSecret) {
+  console.error("PAYER_SECRET is required (run provision-testnet.mjs to get one)");
   process.exit(1);
 }
 
-const payer = Keypair.fromSecret(payerSecret);
-const server = new rpc.Server(RPC_URL);
-
-if (payer.publicKey() === simSource) {
+if (process.env.SIM_SOURCE_ACCOUNT) {
   console.error(
-    `SIM_SOURCE_ACCOUNT must be a DIFFERENT account from the payer.\n` +
-      `  payer and sim source are both ${simSource}\n` +
-      `  Simulating from the payer produces source-account credentials, which the\n` +
-      `  facilitator rejects with invalid_exact_stellar_payload_unsupported_credential_type.`,
+    "[buyer] note: SIM_SOURCE_ACCOUNT is set and is no longer used — the official\n" +
+      "        client simulates from the SDK's null account. Ignoring it.",
   );
-  process.exit(1);
 }
+
+const signer = createEd25519Signer(payerSecret, NETWORK);
+const client = new x402Client().register(NETWORK, new ExactStellarScheme(signer, { url: RPC_URL }));
+const http = new x402HTTPClient(client);
 
 // 1. Unpaid request → 402 with payment requirements + discovery extension.
 const unpaid = await fetch(RESOURCE_URL);
 if (unpaid.status !== 402) {
   console.error(`expected 402, got ${unpaid.status} — is the seller running?`);
+  console.error("  (debug with GET, not HEAD — a HEAD request carries no challenge)");
   process.exit(2);
 }
-const required = JSON.parse(Buffer.from(unpaid.headers.get("PAYMENT-REQUIRED"), "base64").toString("utf8"));
-const req = required.accepts.find((a) => a.network === "stellar:testnet" && a.scheme === "exact");
+
+const required = http.getPaymentRequiredResponse((name) => unpaid.headers.get(name), undefined);
+const req = required.accepts?.find((a) => a.network === NETWORK && a.scheme === "exact");
 if (!req) {
-  console.error("no stellar:testnet exact requirement in the 402");
+  console.error(`no ${NETWORK} exact requirement in the 402`);
   process.exit(2);
 }
 console.error(`[buyer] 402: ${req.amount} atomic of ${req.asset} -> ${req.payTo}`);
-if (required.extensions?.bazaar) console.error("[buyer] discovery extension present — will echo");
+if (required.extensions?.bazaar) console.error("[buyer] discovery extension present — echoed automatically");
 
-// 2. Build the SEP-41 transfer, `from` = your classic account.
-const tx = await AssembledTransaction.build({
-  contractId: req.asset,
-  method: "transfer",
-  args: [
-    nativeToScVal(payer.publicKey(), { type: "address" }),
-    nativeToScVal(req.payTo, { type: "address" }),
-    nativeToScVal(BigInt(req.amount), { type: "i128" }),
-  ],
-  networkPassphrase: PASSPHRASE,
-  rpcUrl: RPC_URL,
-  publicKey: simSource, // simulate-only; the facilitator re-sources the tx
-  parseResultXdr: (r) => r,
-});
-
-// 3. Sign the payer's auth entry.
+// 2. Build + sign the payment. One call: the scheme assembles the SEP-41
+//    transfer, signs the payer's auth entry, and sets expiry from the seller's
+//    maxTimeoutSeconds. Signatures expire in LEDGERS (~5s each), not
+//    wall-clock, so never cache the result — sign a fresh one per attempt.
 //
-// Signatures expire in LEDGERS (~5s each), not wall-clock — current + 12 gives
-// about a minute. Never cache a signed payload.
-//
-// For a classic account, Soroban expects the signature as a vec of
-// { public_key, signature } maps — one per signer that contributed. A single
-// master-key account means exactly one entry. (A smart account instead expects
-// its own contract-defined shape; that is the difference between this file and
-// buyer.mjs.) Map keys must be in sorted order: public_key before signature.
-const expirationLedger = (await server.getLatestLedger()).sequence + 12;
-const auth = tx.built.operations[0].auth ?? [];
-let signed = 0;
-for (const entry of auth) {
-  if (entry.credentials().switch().name !== "sorobanCredentialsAddress") continue;
-  const creds = entry.credentials().address();
-  if (Address.fromScAddress(creds.address()).toString() !== payer.publicKey()) continue;
-
-  creds.signatureExpirationLedger(expirationLedger);
-  const preimage = buildAuthorizationEntryPreimage(entry, expirationLedger, PASSPHRASE);
-  const signature = payer.sign(hash(preimage.toXDR()));
-
-  creds.signature(
-    xdr.ScVal.scvVec([
-      xdr.ScVal.scvMap([
-        new xdr.ScMapEntry({
-          key: xdr.ScVal.scvSymbol("public_key"),
-          val: xdr.ScVal.scvBytes(payer.rawPublicKey()),
-        }),
-        new xdr.ScMapEntry({
-          key: xdr.ScVal.scvSymbol("signature"),
-          val: xdr.ScVal.scvBytes(signature),
-        }),
-      ]),
-    ]),
-  );
-  signed++;
-}
-if (signed === 0) {
-  console.error(
-    "no address auth entry for the payer to sign.\n" +
-      "  If SIM_SOURCE_ACCOUNT is the payer, simulation produced source-account\n" +
-      "  credentials instead — use a different account.",
-  );
+//    The seller's `extensions` are merged into the payload here without any
+//    client-side extension being registered. That echo is what makes the
+//    facilitator catalog the resource on settlement.
+let payload;
+try {
+  payload = await client.createPaymentPayload(required);
+} catch (err) {
+  console.error(`[buyer] could not build the payment: ${err?.message ?? err}`);
+  console.error("  Common causes: no trustline to the asset, or an empty balance.");
   process.exit(2);
 }
-tx.built.operations[0].auth = auth;
 
-// 4. Payment payload — echoing the discovery extension is what catalogs the
-//    resource. Skip it and the payment still succeeds, but nothing is listed.
-const paymentPayload = {
-  x402Version: 2,
-  resource: required.resource,
-  accepted: req,
-  payload: { transaction: tx.built.toXDR() },
-  ...(required.extensions ? { extensions: required.extensions } : {}),
-};
-
-// 5. Retry with the payment attached.
-const paid = await fetch(RESOURCE_URL, {
-  headers: { "PAYMENT-SIGNATURE": Buffer.from(JSON.stringify(paymentPayload)).toString("base64") },
-});
+// 3. Retry with the payment attached.
+const paid = await fetch(RESOURCE_URL, { headers: http.encodePaymentSignatureHeader(payload) });
 const body = await paid.json();
 console.error(`[buyer] HTTP ${paid.status}`);
 if (paid.status !== 200) {
   console.error(`[buyer] not unlocked: ${JSON.stringify(body)}`);
+  console.error(
+    "  Roughly one settle in three fails on testnet with an empty transaction.\n" +
+      "  Nothing was spent — retry the whole flow, signing a fresh payload.",
+  );
   process.exit(2);
 }
 console.log(JSON.stringify(body, null, 2));

--- a/examples/buyer.mjs
+++ b/examples/buyer.mjs
@@ -13,6 +13,30 @@
 // (docs/decisions.md 2026-07-26): a policy-governed Vellar smart account with
 // an ed25519 agent signer, no passkey, budget enforced on-chain.
 //
+// WHY THIS FILE IS HAND-ROLLED AND buyer-classic.mjs IS NOT
+// --------------------------------------------------------
+// Not a style choice, and not something to "fix" by porting this file onto the
+// official client the way buyer-classic.mjs was. The official client CANNOT
+// express a smart-account signature today. Traced through the published code:
+//
+//   1. `@x402/stellar/exact/client` signs via
+//      `tx.signAuthEntries({ address, signAuthEntry, expiration })` and never
+//      passes an `authorizeEntry` override.
+//   2. `AssembledTransaction.signAuthEntries` narrows whatever your signer
+//      returns to a NAKED BUFFER — `Buffer.from(signedAuthEntry, "base64")`.
+//   3. A naked buffer sends `authorizeEntry` down the ed25519 branch, which
+//      calls `Keypair.fromPublicKey()` on the auth entry's own address. For a
+//      smart account that address is a C-address, and it throws:
+//      `invalid version byte. expected 48, got 16`.
+//
+// The SDK core does support this — `authorizeEntry`'s signer may return
+// `{ signatureScVal }`, documented verbatim for "custom account contracts
+// (smart wallets, passkey/WebAuthn signers)" whose `__check_auth` expects its
+// own signature structure. But `signAuthEntries` closes that door, and the
+// x402 client scheme does not reopen it. Hence: hand-rolled, until upstream
+// threads `authorizeEntry` (or `signatureScVal`) through the client scheme.
+// See docs/upstream-issue-smart-accounts.md.
+//
 // Run (testnet):
 //   RESOURCE_URL=http://localhost:4031/quote \
 //   WALLET_CONTRACT_ID=C...   (the smart-account payer) \

--- a/examples/provision-testnet.mjs
+++ b/examples/provision-testnet.mjs
@@ -265,7 +265,10 @@ console.log(`
   Done. Paste this into examples/.env.recording (testnet keys — do not reuse)
 ════════════════════════════════════════════════════════════════════════════
 
-FACILITATOR_URL=https://vellar-facilitator.onrender.com
+# Local by default: the walkthrough runs a localhost seller, and a localhost URL
+# written to the SHARED hosted catalog is public and permanent. Point at the
+# hosted instance only once your seller has a public https address.
+FACILITATOR_URL=http://localhost:4100
 STELLAR_RPC_URL=${RPC_URL}
 
 # The token you just created. This is YOUR asset — you can mint more.
@@ -282,6 +285,7 @@ SELLER_PORT=4031
 # Buyer — classic keypair (works with buyer-classic.mjs)
 PAYER_SECRET=${payer.secret()}
 # Simulate-only, never charged, never signs. MUST differ from the payer.
+# Needed by buyer.mjs (smart account) ONLY — buyer-classic.mjs ignores it.
 SIM_SOURCE_ACCOUNT=${simSource.publicKey()}
 ${
   walletId
@@ -301,7 +305,6 @@ Next:
   2. Pay it (classic keypair — the values above are already in .env.recording):
        RESOURCE_URL=http://127.0.0.1:4031/quote \\
        PAYER_SECRET=${payer.secret()} \\
-       SIM_SOURCE_ACCOUNT=${simSource.publicKey()} \\
        node buyer-classic.mjs
 
   Roughly 1 settle in 3 fails on testnet with an empty transaction — retry it.

--- a/examples/provision-testnet.mjs
+++ b/examples/provision-testnet.mjs
@@ -29,6 +29,7 @@
 
 import {
   Asset,
+  Horizon,
   Keypair,
   Networks,
   Operation,
@@ -57,6 +58,32 @@ const WALLET_WASM_HASH =
 
 const PAYER_MINT_ATOMIC = 1_000_000_000n; // 100 tokens @ 7 decimals
 const MERCHANT_SEED_UNITS = "1"; // so the merchant's trustline is visibly live
+
+/**
+ * USE_USDC=1 provisions against CANONICAL testnet USDC instead of minting a
+ * throwaway token.
+ *
+ * Which you want depends on who has to hold the asset. A token you mint is
+ * self-contained and needs nothing external — right for walking the loop. But
+ * it is a token nobody else holds, so two parties who have never met cannot
+ * transact in it, which is the whole premise of agent-to-agent payment. USDC is
+ * the asset both sides already have.
+ *
+ * No faucet is involved and no human step: the asset sets auth_required=false
+ * so trustlines are permissionless, and there is a live XLM/USDC market on the
+ * testnet DEX. Verified 2026-08-12 — 10 USDC cost 5.59 XLM against friendbot
+ * funds, so the ~10,000 XLM friendbot hands out is ample.
+ *
+ * Circle's testnet issuer (home_domain centre.io). The contract id is DERIVED
+ * from the asset rather than pasted, so it cannot drift from the issuer above.
+ */
+const USE_USDC = process.env.USE_USDC === "1";
+const USDC_ISSUER = process.env.USDC_ISSUER || "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const USDC_ACQUIRE_UNITS = process.env.USDC_ACQUIRE_UNITS || "100";
+// Cap on XLM spent buying that. Generous against a thin testnet order book, and
+// still far inside friendbot's grant — a runaway price fails the op rather than
+// silently draining the account.
+const USDC_MAX_XLM = "5000";
 
 if (!/^[A-Za-z0-9]{1,12}$/.test(ASSET_CODE)) {
   console.error(`ASSET_CODE must be 1-12 alphanumeric characters, got "${ASSET_CODE}"`);
@@ -161,17 +188,54 @@ const deployer = Keypair.random();
 // credentials. Its secret is never needed, so it is never printed.
 const simSource = Keypair.random();
 
-const asset = new Asset(ASSET_CODE, issuer.publicKey());
+const assetCode = USE_USDC ? "USDC" : ASSET_CODE;
+const assetIssuer = USE_USDC ? USDC_ISSUER : issuer.publicKey();
+const asset = new Asset(assetCode, assetIssuer);
 const sacId = asset.contractId(PASSPHRASE);
 
-console.log(`\nProvisioning ${ASSET_CODE} on testnet — this takes 2-4 minutes.\n`);
+/**
+ * Buy `destAmount` of the asset on the DEX, paying in XLM. Used only in USDC
+ * mode — there is no mint authority to call, so the open market is how a
+ * balance is obtained.
+ */
+async function acquireOnDex(kp, destAmount) {
+  const horizon = new Horizon.Server(HORIZON);
+  const paths = await retry("usdc-path", async () => {
+    const res = await horizon.strictReceivePaths([Asset.native()], asset, destAmount).call();
+    if (!res.records.length) throw new Error("no XLM->USDC path offered");
+    return res.records;
+  });
+  const best = paths[0];
+  await submit("acquire-usdc", kp, [
+    Operation.pathPaymentStrictReceive({
+      sendAsset: Asset.native(),
+      sendMax: USDC_MAX_XLM,
+      destination: kp.publicKey(),
+      destAsset: asset,
+      destAmount,
+      path: best.path.map((p) =>
+        p.asset_type === "native" ? Asset.native() : new Asset(p.asset_code, p.asset_issuer),
+      ),
+    }),
+  ]);
+  return best.source_amount;
+}
+
+console.log(
+  `\nProvisioning ${assetCode} on testnet — this takes 2-4 minutes.` +
+    (USE_USDC ? "\nUsing CANONICAL testnet USDC — no token is minted.\n" : "\n"),
+);
 
 console.log("[1/7] funding accounts (friendbot, then waiting for RPC visibility)…");
 await Promise.all([issuer, merchant, payer, deployer, simSource].map((k) => fundAndWait(k.publicKey())));
 console.log("  ok — 5 accounts funded and visible");
 
-console.log(`[2/7] deploying the SAC for ${ASSET_CODE}:${issuer.publicKey().slice(0, 6)}…`);
-const sacHash = await submit("sac-deploy", deployer, [Operation.createStellarAssetContract({ asset })]);
+if (USE_USDC) {
+  console.log(`[2/7] using canonical USDC:${USDC_ISSUER.slice(0, 6)}… — skipping SAC deploy`);
+} else {
+  console.log(`[2/7] deploying the SAC for ${ASSET_CODE}:${issuer.publicKey().slice(0, 6)}…`);
+  await submit("sac-deploy", deployer, [Operation.createStellarAssetContract({ asset })]);
+}
 console.log(`  ok — ${sacId}`);
 
 console.log("[3/7] waiting for the contract instance to be readable…");
@@ -192,18 +256,29 @@ await submit("merchant-trustline", merchant, [Operation.changeTrust({ asset })])
 await submit("payer-trustline", payer, [Operation.changeTrust({ asset })]);
 console.log("  ok — both trustlines live");
 
-console.log("[5/7] funding the payer with tokens…");
-const mintHash = await submit("mint-to-payer", issuer, [
-  Operation.invokeContractFunction({
-    contract: sacId,
-    function: "mint",
-    args: [nativeToScVal(payer.publicKey(), { type: "address" }), nativeToScVal(PAYER_MINT_ATOMIC, { type: "i128" })],
-  }),
-]);
-await submit("seed-merchant", issuer, [
-  Operation.payment({ destination: merchant.publicKey(), asset, amount: MERCHANT_SEED_UNITS }),
-]);
-console.log(`  ok — payer holds ${PAYER_MINT_ATOMIC} atomic (100 ${ASSET_CODE})`);
+if (USE_USDC) {
+  console.log(`[5/7] buying ${USDC_ACQUIRE_UNITS} USDC for the payer on the DEX…`);
+  const spent = await acquireOnDex(payer, USDC_ACQUIRE_UNITS);
+  // The merchant needs a live trustline, not a balance — but seeding one unit
+  // makes it visible in the [7/7] check the same way the minted path does.
+  await submit("seed-merchant", payer, [
+    Operation.payment({ destination: merchant.publicKey(), asset, amount: MERCHANT_SEED_UNITS }),
+  ]);
+  console.log(`  ok — payer holds ${USDC_ACQUIRE_UNITS} USDC (cost ${spent} XLM)`);
+} else {
+  console.log("[5/7] funding the payer with tokens…");
+  await submit("mint-to-payer", issuer, [
+    Operation.invokeContractFunction({
+      contract: sacId,
+      function: "mint",
+      args: [nativeToScVal(payer.publicKey(), { type: "address" }), nativeToScVal(PAYER_MINT_ATOMIC, { type: "i128" })],
+    }),
+  ]);
+  await submit("seed-merchant", issuer, [
+    Operation.payment({ destination: merchant.publicKey(), asset, amount: MERCHANT_SEED_UNITS }),
+  ]);
+  console.log(`  ok — payer holds ${PAYER_MINT_ATOMIC} atomic (100 ${ASSET_CODE})`);
+}
 
 let walletId;
 if (agentPublic) {
@@ -235,13 +310,32 @@ if (agentPublic) {
   );
   const { result: walletClient } = await deployTx.signAndSend();
   walletId = walletClient.options.contractId;
-  await submit("mint-to-wallet", issuer, [
-    Operation.invokeContractFunction({
-      contract: sacId,
-      function: "mint",
-      args: [nativeToScVal(walletId, { type: "address" }), nativeToScVal(PAYER_MINT_ATOMIC, { type: "i128" })],
-    }),
-  ]);
+  if (USE_USDC) {
+    // No mint authority for USDC, so the wallet is funded by transfer. The payer
+    // is the transaction source and authorizes with source-account credentials,
+    // which is fine for a direct submission — it is only the x402 payment path
+    // that requires address credentials.
+    const half = (BigInt(USDC_ACQUIRE_UNITS) * 10_000_000n) / 2n;
+    await submit("fund-wallet", payer, [
+      Operation.invokeContractFunction({
+        contract: sacId,
+        function: "transfer",
+        args: [
+          nativeToScVal(payer.publicKey(), { type: "address" }),
+          nativeToScVal(walletId, { type: "address" }),
+          nativeToScVal(half, { type: "i128" }),
+        ],
+      }),
+    ]);
+  } else {
+    await submit("mint-to-wallet", issuer, [
+      Operation.invokeContractFunction({
+        contract: sacId,
+        function: "mint",
+        args: [nativeToScVal(walletId, { type: "address" }), nativeToScVal(PAYER_MINT_ATOMIC, { type: "i128" })],
+      }),
+    ]);
+  }
   console.log(`  ok — ${walletId} (funded)`);
 } else {
   console.log("[6/7] skipping the smart account (set AGENT_PUBLIC to create one)");
@@ -254,7 +348,7 @@ for (const [label, kp] of [
 ]) {
   const acct = await (await fetch(`${HORIZON}/accounts/${kp.publicKey()}`)).json();
   const line = (acct.balances ?? []).find(
-    (b) => b.asset_code === ASSET_CODE && b.asset_issuer === issuer.publicKey(),
+    (b) => b.asset_code === assetCode && b.asset_issuer === assetIssuer,
   );
   if (!line) throw new Error(`${label} trustline missing after provisioning`);
   console.log(`  ok — ${label} balance: ${line.balance}`);
@@ -271,10 +365,19 @@ console.log(`
 FACILITATOR_URL=http://localhost:4100
 STELLAR_RPC_URL=${RPC_URL}
 
-# The token you just created. This is YOUR asset — you can mint more.
+${
+  USE_USDC
+    ? `# Canonical testnet USDC — the asset strangers can also hold. Not yours to
+# mint; buy more on the DEX the way this script just did.
 ASSET=${sacId}
-ASSET_CODE_ISSUER=${ASSET_CODE}:${issuer.publicKey()}
-ISSUER_SECRET=${issuer.secret()}
+ASSET_CODE_ISSUER=${assetCode}:${assetIssuer}`
+    : `# The token you just created. This is YOUR asset — you can mint more.
+# Nobody else holds it, so it is fine for testing your own loop and useless for
+# transacting with anyone else. Re-run with USE_USDC=1 for canonical USDC.
+ASSET=${sacId}
+ASSET_CODE_ISSUER=${assetCode}:${assetIssuer}
+ISSUER_SECRET=${issuer.secret()}`
+}
 
 # Seller (the paid API)
 PAYTO=${merchant.publicKey()}

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -93,6 +93,46 @@ const ASSET_SOURCE = sourceOf(shellAsset, "ASSET");
 function publicBase() {
   return process.env.PUBLIC_BASE_URL ?? `http://localhost:${PORT}`;
 }
+
+/**
+ * Can this resource URL ever pass the facilitator's ownership verification?
+ *
+ * The facilitator's precondition is public https: http is rejected before a
+ * socket opens, and so are loopback, private ranges and link-local. This is the
+ * seller-side mirror of that rule, and it is deliberately the ONLY copy — both
+ * /whoami's `verifiable` and the boot guard read it, so they cannot drift.
+ *
+ * Previously /whoami tested `startsWith("https://") && !includes("localhost")`,
+ * which passed `https://127.0.0.1` and `https://192.168.1.10` — URLs the
+ * facilitator refuses. Reporting `verifiable: true` for a URL that can never
+ * verify is the exact failure this endpoint exists to prevent.
+ */
+function isPubliclyVerifiable(url) {
+  let host;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "https:") return false;
+    host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  } catch {
+    return false;
+  }
+  if (host === "localhost" || host.endsWith(".localhost") || host.endsWith(".local")) return false;
+  if (host === "::1" || host.startsWith("fc") || host.startsWith("fd")) return false;
+  if (/^127\./.test(host) || /^10\./.test(host) || /^192\.168\./.test(host)) return false;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return false;
+  if (/^169\.254\./.test(host)) return false; // link-local, incl. cloud metadata
+  return true;
+}
+
+/** Is the configured facilitator this machine, rather than a shared one? */
+function isLocalFacilitator(url) {
+  try {
+    const host = new URL(url).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+    return host === "localhost" || host === "::1" || /^127\./.test(host);
+  } catch {
+    return false;
+  }
+}
 // PORT first: Render (and most PaaS) inject it and health-check that port, so
 // binding SELLER_PORT there would fail the deploy. SELLER_PORT still wins
 // locally when PORT is unset, so `docs/guide.md`'s walkthrough is unchanged.
@@ -314,6 +354,50 @@ async function preflightMerchant() {
   );
 }
 
+/**
+ * Refuse the one combination that writes permanent junk into shared state.
+ *
+ * A resource is cataloged the first time a payment settles for it, keyed by URL,
+ * and there is no self-service removal and no supported operator one. So a
+ * seller advertising `http://localhost:4031/quote` while pointed at a SHARED
+ * facilitator leaves a public entry that every agent can see, no one can call,
+ * and nobody can delete — it can never pass ownership verification, so it is
+ * `ownerVerified: false` forever and counted in the facilitator's
+ * `unverifiableEntries`.
+ *
+ * The trap was that this is the DEFAULT path: FACILITATOR_URL defaults to the
+ * hosted instance and PUBLIC_BASE_URL is usually unset locally, so following the
+ * walkthrough literally produced exactly this. docs/using-it.md warned about it
+ * at length while the tooling walked people into it.
+ *
+ * Deliberately narrow: it refuses ONLY remote-facilitator + unverifiable-URL.
+ * A public seller on a shared facilitator is the normal deployed case and is
+ * untouched; a localhost seller on a localhost facilitator is the walkthrough
+ * and is untouched. Both fixes are named because either one is legitimate
+ * depending on what you are doing.
+ */
+function preflightCatalogSafety() {
+  const resourceUrl = `${publicBase()}/quote`;
+  if (isLocalFacilitator(FACILITATOR_URL) || isPubliclyVerifiable(resourceUrl)) return;
+
+  console.error(
+    `\n[seller] REFUSING TO BOOT — this would write a permanent entry into a shared catalog.\n\n` +
+      `  advertising : ${resourceUrl}\n` +
+      `  facilitator : ${FACILITATOR_URL}  (not local)\n\n` +
+      `  That URL can never pass ownership verification (public https only — no http,\n` +
+      `  no loopback, no private ranges). The first settlement would list it publicly,\n` +
+      `  permanently, with ownerVerified: false. There is no removal path.\n\n` +
+      `  Fix it whichever way matches what you are doing:\n\n` +
+      `    • Walking the guide locally — run your own facilitator and point at it:\n` +
+      `        FACILITATOR_URL=http://localhost:4100 node seller.mjs\n\n` +
+      `    • Deploying for real — advertise your public address:\n` +
+      `        PUBLIC_BASE_URL=https://your-seller.example node seller.mjs\n\n` +
+      `  Override with ALLOW_UNVERIFIABLE_ON_SHARED=1 if you genuinely mean it.\n`,
+  );
+  process.exit(1);
+}
+
+if (!process.env.ALLOW_UNVERIFIABLE_ON_SHARED) preflightCatalogSafety();
 await preflightMerchant();
 await initializeWithRetry();
 
@@ -370,7 +454,7 @@ app.get("/whoami", (_req, res) => {
       : {}),
     // Decided here rather than by the reader: an ownership-verifiable resource
     // URL must be public https. This is the per-settle precondition.
-    verifiable: resourceUrl.startsWith("https://") && !resourceUrl.includes("localhost"),
+    verifiable: isPubliclyVerifiable(resourceUrl),
   });
 });
 

--- a/render.yaml
+++ b/render.yaml
@@ -164,3 +164,19 @@ services:
       # permanently unverified.
       - key: PUBLIC_BASE_URL
         value: "https://vellar-seller-demo.onrender.com"
+      # PINNED DELIBERATELY. These were previously unset, so the deployed demo
+      # silently inherited seller.mjs's built-in defaults — meaning an edit to a
+      # source default would change what a PUBLIC service advertises, with no
+      # sign of it in this file. Pin them here so the deployment states its own
+      # configuration and source defaults only affect local runs.
+      #
+      # These are the values the service already advertises; setting them is a
+      # no-op today. The asset is the DEAD X402TST — its issuer secret no longer
+      # exists, so nobody can obtain a balance and nobody can pay this resource.
+      # That is why the catalog entry is stuck at ownerVerified:false: the badge
+      # only re-checks on the next settlement, and no settlement can happen.
+      # See docs/diagnosis-demo-listing.md for the full chain and the fix.
+      - key: PAYTO
+        value: "GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH"
+      - key: ASSET
+        value: "CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR"

--- a/render.yaml
+++ b/render.yaml
@@ -167,16 +167,25 @@ services:
       # PINNED DELIBERATELY. These were previously unset, so the deployed demo
       # silently inherited seller.mjs's built-in defaults — meaning an edit to a
       # source default would change what a PUBLIC service advertises, with no
-      # sign of it in this file. Pin them here so the deployment states its own
-      # configuration and source defaults only affect local runs.
+      # sign of it in this file.
       #
-      # These are the values the service already advertises; setting them is a
-      # no-op today. The asset is the DEAD X402TST — its issuer secret no longer
-      # exists, so nobody can obtain a balance and nobody can pay this resource.
-      # That is why the catalog entry is stuck at ownerVerified:false: the badge
-      # only re-checks on the next settlement, and no settlement can happen.
-      # See docs/diagnosis-demo-listing.md for the full chain and the fix.
+      # The demo previously advertised the DEAD X402TST asset, whose issuer
+      # secret no longer exists. Nobody could obtain a balance, so nobody could
+      # pay it, so the catalog entry was frozen at ownerVerified:false — the
+      # badge only re-checks on the next settlement, and no settlement was
+      # possible. See docs/diagnosis-demo-listing.md.
+      #
+      # Now: canonical testnet USDC, which anyone can obtain from the DEX with
+      # no faucet (examples/provision-testnet.mjs USE_USDC=1). The resource is
+      # payable by strangers for the first time.
+      #
+      # PAYTO is a new merchant holding a live USDC trustline. The catalog's URL
+      # binding still points at the old GBJX3E4G… address, whose secret is not
+      # known to be held. That resolves itself WITHOUT operator involvement: the
+      # old binding was never verified, so the first settlement naming this
+      # address displaces it. Runbook §1 is only needed to move an
+      # already-verified binding.
       - key: PAYTO
-        value: "GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH"
+        value: "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC"
       - key: ASSET
-        value: "CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR"
+        value: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA"


### PR DESCRIPTION
This PR carries the seller-demo deployment fix from fb1027b: it pins the hosted seller demo to canonical testnet USDC and a merchant with a live trustline so the Render service advertises a payable resource again.\n\nScope: docs/diagnosis-demo-listing.md and render.yaml only.\n\nThe branch is intentionally clean and excludes the later final-provisioning-verify skippable change.