### PR TITLE
Live demo defaults that announce themselves, and retry the provisioning verify instead of skipping it

### DIFF
--- a/examples/provision-testnet.mjs
+++ b/examples/provision-testnet.mjs
@@ -341,17 +341,37 @@ if (agentPublic) {
   console.log("[6/7] skipping the smart account (set AGENT_PUBLIC to create one)");
 }
 
+// This was the ONE unprotected network read in the script, and it failed often
+// enough that someone proposed a flag to skip it (#53, rejected). The cause is
+// not a bad check — it is that every transaction above was confirmed on SOROBAN
+// RPC, while this reads HORIZON. Two services, independent ingestion, and
+// Horizon lags. `fundAndWait` already exists because friendbot has the same
+// shape of problem.
+//
+// So it retries like everything else here, and still fails LOUDLY when the
+// trustline genuinely is not there. Skipping it instead would let broken
+// provisioning print a clean env block, and the developer would discover it at
+// settlement — where a missing trustline reads exactly like a spend control
+// refusing the payment, which is the misdiagnosis preflightMerchant() exists to
+// prevent.
 console.log("[7/7] verifying on-chain state…");
 for (const [label, kp] of [
   ["merchant", merchant],
   ["payer", payer],
 ]) {
-  const acct = await (await fetch(`${HORIZON}/accounts/${kp.publicKey()}`)).json();
-  const line = (acct.balances ?? []).find(
-    (b) => b.asset_code === assetCode && b.asset_issuer === assetIssuer,
-  );
-  if (!line) throw new Error(`${label} trustline missing after provisioning`);
-  console.log(`  ok — ${label} balance: ${line.balance}`);
+  const balance = await retry(`verify-${label}`, async () => {
+    const res = await fetch(`${HORIZON}/accounts/${kp.publicKey()}`);
+    if (!res.ok) throw new Error(`horizon returned HTTP ${res.status}`);
+    const acct = await res.json();
+    const line = (acct.balances ?? []).find(
+      (b) => b.asset_code === assetCode && b.asset_issuer === assetIssuer,
+    );
+    // Thrown, not returned, so retry() gets a chance at it — this is the case
+    // that is usually just lag.
+    if (!line) throw new Error(`${label} trustline not visible on Horizon yet`);
+    return line.balance;
+  });
+  console.log(`  ok — ${label} balance: ${balance}`);
 }
 
 console.log(`

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -59,13 +59,34 @@ const FACILITATOR_URL = process.env.FACILITATOR_URL || "https://vellar-facilitat
 // condition (does this payTo hold a trustline to this asset?) instead of
 // proxying it, and refuses to boot with a message that names the fix.
 //
-// UPDATED 2026-08-10: the previous pair (CBIN4HTP… / GBDZH5KZ…) are DEAD — the
-// old issuer was burned during provisioning. If you change these defaults,
-// redeploy vellar-seller-demo and re-run the live ownership gate
-// (docs/operator-runbook.md §4): the gate verifies the payTo the challenge
-// NAMES, so a stale 402 reads as a mismatch that looks like a control failure.
-const PAYTO = process.env.PAYTO || "GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH";
-const ASSET = process.env.ASSET || "CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR";
+// UPDATED 2026-08-13. These defaults have now died twice, both times the same
+// way: the asset's issuer key was a throwaway generated in-process, and once it
+// was gone nobody could mint, so nobody could pay, so the resource was
+// permanently unpayable. CBIN4HTP…/GBDZH5KZ… went first; CDYCX4PE… (X402TST)
+// went next and left the demo's catalog entry frozen at ownerVerified:false,
+// because the badge only re-checks on a settlement that could never happen.
+//
+// THE ASSET IS NOW CANONICAL TESTNET USDC, and the reason that ends the pattern
+// is not that it is bigger — it is that ITS ISSUER IS NOT OURS TO DESTROY.
+// Circle holds it (home_domain centre.io, 54k+ authorized accounts). Anyone can
+// obtain a balance from the testnet DEX with no faucet and no human step:
+// `USE_USDC=1 node provision-testnet.mjs`.
+//
+// PAYTO is Vellar's demo merchant, funded and holding a live USDC trustline.
+// Confirmed live before shipping — a second dead default would be worse than
+// the first, since it would arrive labelled as a fix.
+//
+// These are OUR values. Running this seller without PAYTO/ASSET set advertises
+// Vellar's merchant, not yours, so anyone paying it pays us. That is fine for a
+// demo and wrong for anything else, which is why the boot log says so out loud
+// rather than quietly naming a source.
+//
+// If you change these, redeploy vellar-seller-demo and re-run the live
+// ownership gate (docs/operator-runbook.md §4): the gate verifies the payTo the
+// challenge NAMES, so a stale 402 reads as a mismatch that looks like a control
+// failure.
+const PAYTO = process.env.PAYTO || "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC";
+const ASSET = process.env.ASSET || "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA";
 const PRICE_ATOMIC = process.env.PRICE_ATOMIC || "1000000";
 
 // Used only by the boot-time merchant preflight below — never on the payment
@@ -73,11 +94,24 @@ const PRICE_ATOMIC = process.env.PRICE_ATOMIC || "1000000";
 const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
 const PASSPHRASE = Networks.TESTNET;
 
-/** Where a value came from — shell, the env file, or the built-in default. */
+/**
+ * Where a value came from — shell, the env file, or the built-in default.
+ *
+ * The built-in case says "Vellar demo default" rather than "built-in default",
+ * because naming the source is not the useful fact. The useful fact is WHOSE
+ * value it is: run this with no PAYTO and you are advertising Vellar's merchant
+ * address, so any payment goes to us rather than to you. Someone skimming a boot
+ * log will read "built-in default" as "a sensible fallback" and move on.
+ */
 const sourceOf = (shellValue, name) =>
-  shellValue ? "environment" : process.env[name] ? "examples/.env.recording" : "built-in default";
+  shellValue
+    ? "environment"
+    : process.env[name]
+      ? "examples/.env.recording"
+      : "VELLAR DEMO DEFAULT — not yours";
 const PAYTO_SOURCE = sourceOf(shellPayTo, "PAYTO");
 const ASSET_SOURCE = sourceOf(shellAsset, "ASSET");
+const USING_DEMO_DEFAULTS = !shellPayTo && !process.env.PAYTO;
 
 /**
  * The address this merchant advertises as its own — the single source of truth
@@ -271,6 +305,15 @@ async function initializeWithRetry() {
 async function preflightMerchant() {
   console.error(`[seller] payTo ${PAYTO} (from ${PAYTO_SOURCE})`);
   console.error(`[seller] asset ${ASSET} (from ${ASSET_SOURCE})`);
+  if (USING_DEMO_DEFAULTS) {
+    console.error(
+      `[seller] NOTE: no PAYTO/ASSET set, so this is running on Vellar's DEMO merchant\n` +
+        `         and canonical testnet USDC. Payments to this seller go to US, not you.\n` +
+        `         Fine for trying the loop; wrong for your own service. To use your own:\n` +
+        `           cd examples && USE_USDC=1 node provision-testnet.mjs\n` +
+        `         then pass the PAYTO and ASSET it prints.`,
+    );
+  }
   if (!StrKey.isValidEd25519PublicKey(PAYTO)) {
     console.error(
       `\n[seller] FATAL: PAYTO is not a valid Stellar account address.\n` +


### PR DESCRIPTION
Two fixes that share a cause: something shaped like a sensible fallback was silently wrong.

## Defaults that were a trap

`seller.mjs`'s built-in `PAYTO`/`ASSET` pointed at a **dead merchant and a dead asset**. Nobody could pay that pair — X402TST's issuer key was a throwaway generated in-process and destroyed, so nobody can mint and nobody can obtain a balance.

This is the **second time** these defaults have died the same way (`CBIN4HTP…`/`GBDZH5KZ…` went first). The consequence was the demo's catalog entry frozen at `ownerVerified: false` — the badge only re-checks on the next settlement, and no settlement was possible.

**Pinning them in `render.yaml` didn't fix it.** Blueprint env vars only apply on a blueprint *sync*; an ordinary redeploy keeps reading the source defaults. So the defaults themselves had to change.

Now canonical testnet USDC plus a merchant funded with a live USDC trustline. **What ends the pattern isn't that USDC is bigger — it's that its issuer isn't ours to destroy.** Circle holds it (`home_domain centre.io`, 54k+ authorized accounts), and anyone can obtain a balance from the testnet DEX with no faucet.

Both confirmed live before shipping. A second dead default would be worse than the first, since it would arrive labelled as a fix.

## The defaults now say whose they are

Provenance logging said `built-in default`, which reads as "a sensible fallback" to anyone skimming a boot log. The useful fact isn't the source, it's the owner — run this with no `PAYTO` and you advertise **Vellar's** merchant, so payments go to us rather than you. Harmless on testnet, wrong the moment it isn't.

```
[seller] payTo GAATVGLR… (from VELLAR DEMO DEFAULT — not yours)
[seller] asset CBIELTK6… (from VELLAR DEMO DEFAULT — not yours)
[seller] NOTE: no PAYTO/ASSET set, so this is running on Vellar's DEMO merchant
         and canonical testnet USDC. Payments to this seller go to US, not you.
         Fine for trying the loop; wrong for your own service. To use your own:
           cd examples && USE_USDC=1 node provision-testnet.mjs
```

## Retry the final verify, don't skip it

Supersedes #53, which proposed `SKIP_FINAL_VERIFY=1`. That switches off the only step proving provisioning worked.

The failure is a race, not a bad check: every transaction above it is confirmed on **Soroban RPC** while the check reads **Horizon** — two services with independent ingestion, and Horizon lags. It was the one unprotected network read in a script where `fundAndWait()` already demands *three consecutive* successful reads for exactly this reason.

Now wrapped in the same `retry()` as everything else, still failing loudly when the trustline genuinely isn't there. Skipping would let broken provisioning print a clean env block, and the developer would find out at settlement — where a missing trustline reads exactly like a spend control refusing the payment, the misdiagnosis `preflightMerchant()` exists to prevent.

## Verification

Booted with **no env vars at all**, in an isolated copy without `.env.recording` so the built-in path was genuinely exercised rather than masked by a local file:

```
challenge payTo: GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC
challenge asset: CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
resource url:    https://vellar-seller-demo.onrender.com/quote
```

Trustline preflight passes, the boot guard allows the public-https + remote-facilitator combination, 342 tests pass, typecheck clean.

**After merge:** once Render redeploys, the demo becomes payable for the first time. One settlement then displaces the stale binding to `GBJX3E4G…` (never verified, so no operator step needed) and the badge should flip to `true`.
