### PR TITLE
Make displacement say why it did nothing, and correct the claim that it recovers

### DIFF
--- a/docs/diagnosis-demo-listing.md
+++ b/docs/diagnosis-demo-listing.md
@@ -68,22 +68,85 @@ something obtainable — the natural choice is canonical testnet USDC
 `USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5`, 7 decimals,
 `auth_required: false` so trustlines are permissionless).
 
-**Which path depends on one unanswered question: is the secret for
-`GBJX3E4G…` still held?** The account exists and is funded (9999.99 XLM, 13.0
-X402TST), but the key's whereabouts is not recorded anywhere in this repo.
+The secret for `GBJX3E4G…` is not known to be held — the account exists and is
+funded, but its key's whereabouts is recorded nowhere in this repo. So the demo
+moved to a merchant we control (`GAATVGLR…`) with a live USDC trustline.
 
-| | If the secret is held | If it is lost |
+**The prediction was that displacement would recover the binding automatically.
+It was tested live, and it is false — see below.**
+
+---
+
+## What actually happened, 2026-08-14
+
+The demo was redeployed on canonical USDC and the served 402 was confirmed by
+content:
+
+```
+resource.url : https://vellar-seller-demo.onrender.com/quote
+payTo        : GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC
+asset        : CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA
+```
+
+Two payments then settled against it:
+
+| tx | ledger | on-chain |
 | --- | --- | --- |
-| Merchant | Keep `GBJX3E4G…` | Use a merchant you control |
-| Trustline | Add one to USDC on that account | Provision the new merchant with one |
-| Binding | Untouched — `payTo` is unchanged | Transfers by **displacement** on first settlement |
-| Operator involvement | none | none |
+| `bc7e4a157fd8e433…` | 4133889 | successful |
+| `2d1c3c78d3f174c4…` | 4133905 | successful |
 
-The displacement path works here specifically because this binding was **never
-verified**. Runbook §1 is only required to move an already-verified binding.
+The merchant received exactly 0.2 USDC, so both were real. **The catalog did not
+move**: still bound to `GBJX3E4G…`, still advertising the dead asset,
+`ownerVerified: false`, `settlements: 0`.
 
-Then: redeploy the demo with the new `ASSET` (and `PAYTO`, if changed), pay it
-once, and the badge flips to `true` on that settlement.
+Two settlements were used deliberately, because `tryDisplace`'s own contract says
+the settle that *triggers* a displacement is still refused and the next one lands
+normally. The second one did not land either.
+
+### What this rules out
+
+| Suspect | Excluded by |
+| --- | --- |
+| Trailing-slash key mismatch | `normalizePath` strips it; both spellings map to one key |
+| The `everVerified` one-way latch | `ownerVerified` **is** that latch (`annotateTrust` → `isVerifiedOwner`), and it reads false |
+| Catalog frozen | `/health` reports no freeze |
+| Ownership probe timing out | 3s budget; the demo answers warm in ~0.8s |
+| Displacement not wired up | Fires fire-and-forget on every settle (`bazaar.ts`) |
+| "First settle reveals, second lands" | Two were run |
+| **Restoration from storage** | **New test** — a restored *unverified* binding displaces correctly |
+
+That last row was the leading hypothesis and it is wrong. The suite had no
+coverage for "restored, unverified, claimant proves ownership" — every passing
+displacement test built its binding in the same process, and the only restart
+test covered a *verified* binding, where the right answer is "skipped". So a
+test was added for the production shape. **It passes**, which excludes
+restoration rather than reproducing the failure.
+
+### Why it took source-reading to get this far
+
+Every remaining candidate lives behind a guard that returned a bare `"skipped"`.
+Eight of them, no signal, so a displacement that silently did not happen could
+not be diagnosed from outside the process — the same defect as `settle`
+collapsing every submission failure into one constant `errorReason`, and this
+time inside the control built to prevent squatting.
+
+Both `tryDisplace` and `reverify` now log a reason on every exit, excluding the
+two that fire on ordinary settlements. The next occurrence names its own cause.
+
+### Still open
+
+The cause. The remaining candidates are the empty-binding skip and a cooldown
+from a prior verdict, and distinguishing them needs the deployment's logs:
+
+```
+grep -E "displacement (skipped|refused|check failed)|rejected upsert for|DISPLACED" 
+# window: 2026-08-14 07:00–07:05 UTC
+```
+
+`rejected upsert for … is not bound … (F11)` is the discriminator. If it is
+**present**, the settlement reached the catalog and the key matched, so the
+failure is inside `tryDisplace`. If it is **absent**, the settlement never
+reached cataloging at all and the question is upstream of displacement entirely.
 
 ## What changed here
 
@@ -107,19 +170,20 @@ The old binding to `GBJX3E4G…` resolves itself. Because it was never verified,
 the first settlement naming the new address **displaces** it automatically. No
 operator step, no runbook §1.
 
-## What is still outstanding
+## Where it stands
 
-This repo's part is done. Two actions remain and neither can happen here:
+**Done:** the demo is deployed on canonical USDC and is payable by a stranger
+for the first time — proven by two settlements from an unrelated payer. That was
+the point of the change, and it is finished.
 
-1. **Deploy.** Render picks up `render.yaml` on push. Until it redeploys, the
-   live demo still advertises the dead asset.
-2. **Settle once against the hosted facilitator.** That is what creates the
-   displacement, triggers re-verification, and flips the badge. Provision a
-   payer with `USE_USDC=1`, point `buyer-classic.mjs` at
-   `https://vellar-seller-demo.onrender.com/quote`, and pay once. Retry if it
-   fails — roughly one settle in three does, and nothing is spent when it does.
+**Not done:** the catalog entry still shows the old binding and the dead asset,
+and the badge still reads false. That is a display problem in shared state, not a
+payment problem — nothing about paying this resource is broken.
 
-Afterwards, confirm with:
+**Do not** expect a further settlement to fix it. Two already failed to, which is
+the whole finding above. The next step is the log grep, not another payment.
+
+To re-check the badge at any point:
 
 ```sh
 curl -s https://vellar-facilitator.onrender.com/discovery/resources \

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -257,10 +257,21 @@ Ownership is trust-on-first-use: the first settlement for a canonical URL
 settles for your URL first, they hold the binding** and your own settlements are
 refused from the catalog — though your payments still go through.
 
-This is recoverable without an operator: settle once, and if your 402 names your
-address, you take the binding back automatically (displacement). What is *not*
-automatic is changing the address on a binding that was already verified — that
-needs [runbook §1](./operator-runbook.md).
+This is *designed* to be recoverable without an operator: settle once, and if
+your 402 names your address, you take the binding back automatically
+(displacement). Changing the address on a binding that was already **verified**
+is not automatic and needs [runbook §1](./operator-runbook.md).
+
+**Do not rely on that recovery yet.** It works in tests, including against a
+binding restored from storage — and on 2026-08-14 it did **not** recover a real
+stale binding on the hosted instance. Two settlements naming the claimant landed
+on-chain and the catalog did not move. The cause is not yet established, and
+until it is, treat displacement as a mechanism that should work rather than one
+observed working in production. Detail, including everything ruled out:
+[`diagnosis-demo-listing.md`](./diagnosis-demo-listing.md).
+
+The practical advice is unchanged and now matters more: **be first to settle for
+your own URL.**
 
 ### What you see in discovery
 

--- a/render.yaml
+++ b/render.yaml
@@ -181,10 +181,20 @@ services:
       #
       # PAYTO is a new merchant holding a live USDC trustline. The catalog's URL
       # binding still points at the old GBJX3E4G… address, whose secret is not
-      # known to be held. That resolves itself WITHOUT operator involvement: the
-      # old binding was never verified, so the first settlement naming this
-      # address displaces it. Runbook §1 is only needed to move an
-      # already-verified binding.
+      # known to be held.
+      #
+      # CORRECTED 2026-08-14. This comment previously claimed the old binding
+      # "resolves itself WITHOUT operator involvement" because it was never
+      # verified. That prediction was tested and is FALSE: two settlements
+      # naming this address landed on-chain (bc7e4a15…, 2d1c3c78…) and the
+      # catalog did not move — same binding, same dead asset, settlements still
+      # 0. Displacement is a documented mechanism, it passes in tests including
+      # against a restored unverified binding, and it did not recover this one.
+      # Cause not yet established; see docs/diagnosis-demo-listing.md.
+      #
+      # Do not wait for a recovery that has not been observed. The demo is
+      # payable either way — the stale entry is a catalog-display problem, not
+      # a payment one.
       - key: PAYTO
         value: "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC"
       - key: ASSET

--- a/src/catalog.displacement.test.ts
+++ b/src/catalog.displacement.test.ts
@@ -187,6 +187,40 @@ describe("one-way — proof never displaces proof", () => {
     expect(await restarted.tryDisplace(URL_V, C, reqs(C), disc(), endpointNaming(C).fn)).toBe("skipped");
     expect(restarted.isBound(URL_V, A)).toBe(true);
   });
+
+  it("an UNVERIFIED binding restored from storage is still displaceable", async () => {
+    // THE SHAPE PRODUCTION IS ACTUALLY IN, and the one this suite did not cover.
+    //
+    // Every passing displacement above builds its binding in the SAME PROCESS
+    // that then displaces it. The only restart test covers a VERIFIED binding,
+    // where the correct answer is "skipped". So "restored, unverified, claimant
+    // proves ownership" — which is exactly the hosted demo entry
+    // (statsSource:"persisted", observedSettlements:0, ownerVerified:false) —
+    // had no coverage at all.
+    //
+    // Written because two live settlements against that entry recovered
+    // nothing, and a suite that is green while production does not recover is
+    // a suite proving something adjacent. This asserts the mechanism survives
+    // restoration; it passes, which RULES OUT restoration as the cause and
+    // leaves the live failure to the logged reasons added alongside.
+    //
+    // MUTATION: make tryDisplace read boundPayTo from the in-memory entry only,
+    // or have bindLoadedEntry leave a restored binding empty. This goes red
+    // while every other test here stays green.
+    const { store, url } = tmpStore();
+    const first = await BazaarCatalog.create(store);
+    await first.upsertFromPayment(disc(), reqs(B));
+    await first.flush();
+
+    const restarted = await BazaarCatalog.create(reopen(url));
+    expect(restarted.isBound(URL_V, B), "the binding survived the restart").toBe(true);
+    expect(restarted.isEverVerified(URL_V), "and it was never proven").toBe(false);
+
+    const v = endpointNaming(A);
+    expect(await restarted.tryDisplace(URL_V, A, reqs(A), disc(), v.fn)).toBe("displaced");
+    expect(restarted.isBound(URL_V, A), "the real owner took it back").toBe(true);
+    expect(restarted.isBound(URL_V, B), "and the squatter lost it").toBe(false);
+  });
 });
 
 describe("the ownership rows — neither an UPDATE nor an append", () => {

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1094,9 +1094,20 @@ export class BazaarCatalog {
     if (existing && !existing.boundPayTo.includes(requirements.payTo)) {
       // Unbound payTo for an already-established URL: reject the whole write.
       // Do not append accepts, do not overwrite metadata, do not touch stats.
+      // WORDING MATTERS HERE. This said "possible resource-URL hijack" alone,
+      // which is accurate about the mechanism and misleading about the
+      // situation: the same line fires for the LEGITIMATE owner, because the
+      // settle that triggers a displacement is refused by design while the
+      // rebinding lands behind it. An operator meeting this line first
+      // concludes they are under attack, when the real event may be that
+      // displacement did not run. Observed 2026-08-14 — this line appeared
+      // twice for the demo's own merchant.
       console.warn(
         `[catalog] rejected upsert for ${key}: payTo ${requirements.payTo} is not bound ` +
-          `(bound: ${existing.boundPayTo.join(", ")}) — possible resource-URL hijack (F11)`,
+          `(bound: ${existing.boundPayTo.join(", ")}). This is EXPECTED for the settle that ` +
+          `triggers a displacement, and is also what a hijack attempt looks like — the two are ` +
+          `indistinguishable here. Read the "[catalog] displacement …" line for this key to tell ` +
+          `them apart before treating it as an attack (F11)`,
       );
       return false;
     }

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -761,30 +761,53 @@ export class BazaarCatalog {
   ): Promise<"match" | "mismatch" | "unverifiable" | "skipped"> {
     const key = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
     const entry = this.entries.get(key);
-    if (!entry) return "skipped";
+
+    /** Same contract as tryDisplace's: a silent skip is an undiagnosable one.
+     *  This is the path that flips `ownerVerified`, so "the badge did not
+     *  change and nothing said why" is the exact question an operator arrives
+     *  with. The two benign, per-settlement cases stay quiet — see below. */
+    const skip = (reason: string): "skipped" => {
+      console.warn(`[catalog] reverify skipped for ${key} (settler ${settlingPayTo || "<empty>"}): ${reason}`);
+      return "skipped";
+    };
+
+    if (!entry) return skip("no catalog entry for this key");
     // Already verified: nothing to re-establish, and re-probing a good entry is
     // pure outbound traffic. This is also what makes an existing verification
     // undowngradable — the verifier is never consulted again — so the
     // match-only write below can only ever act on an unverified entry.
+    //
+    // NOT LOGGED: fires on every settlement for every healthy entry, which is
+    // the steady state we want, and a line per payment would drown the rest.
     if (entry.verifiedOwner) return "skipped";
     // An entry that binds to nothing (bindLoadedEntry's empty-accepts branch)
     // has no claim to test — asking would read back a false mismatch. Checked
     // BEFORE the bound-owner gate: that gate would reject an empty binding too,
     // which would make this line dead code that merely looks load-bearing.
-    if (entry.boundPayTo.length === 0) return "skipped";
+    if (entry.boundPayTo.length === 0)
+      return skip("binding is empty — tampered or unbound state, nothing to test");
     // Only the bound owner's own settlement may trigger a probe. Note this is
     // 1:1, not zero: under TOFU the bound owner is the FIRST SETTLER, not
     // necessarily whoever controls the endpoint, so a stranger who bound a
     // victim's URL can still cause one probe per settlement. The cooldowns
     // below, not this gate, are the actual brake.
+    //
+    // NOT LOGGED: this is the mirror of tryDisplace's already-bound skip. An
+    // unbound settler lands here on every claim attempt, and tryDisplace
+    // already logs that same event with more detail.
     if (!settlingPayTo || !entry.boundPayTo.includes(settlingPayTo)) return "skipped";
     // A routeTemplate key is `origin + /quote/:symbol`; fetching it would GET a
     // literal `:symbol`. Structurally unverifiable, so never probe it.
-    if (isTemplatedKey(key)) return "skipped";
-    if (this.verifyInFlight.has(key)) return "skipped";
+    if (isTemplatedKey(key)) return skip("templated key — structurally unverifiable, never probed");
+    if (this.verifyInFlight.has(key)) return skip("a probe for this key is already in flight");
 
     const last = this.verifyState.get(key);
-    if (last && now - last.at < cooldownFor(last.verdict)) return "skipped";
+    if (last && now - last.at < cooldownFor(last.verdict)) {
+      const remainingMs = cooldownFor(last.verdict) - (now - last.at);
+      return skip(
+        `cooling down after a previous "${last.verdict}" verdict — ${Math.ceil(remainingMs / 1000)}s remaining`,
+      );
+    }
 
     this.verifyInFlight.add(key);
     try {
@@ -886,25 +909,57 @@ export class BazaarCatalog {
   ): Promise<"displaced" | "refused" | "skipped"> {
     const key = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
     const entry = this.entries.get(key);
+    /**
+     * EVERY EXIT SAYS WHY.
+     *
+     * Eight guards used to return a bare "skipped", which made a displacement
+     * that silently did not happen undiagnosable from outside the process. That
+     * is the same defect as `settle` collapsing every submission failure into
+     * one constant `errorReason` (docs/diagnosis-settle-failures.md) — and it
+     * bit us inside the control built to prevent squatting: two live
+     * settlements against a real stale binding recovered nothing, and every
+     * candidate cause had to be excluded by reading source rather than a log.
+     * See docs/diagnosis-demo-listing.md.
+     */
+    const outcome = (result: "skipped" | "refused", reason: string): "skipped" | "refused" => {
+      console.warn(
+        `[catalog] displacement ${result} for ${key} (claimant ${claimant || "<empty>"}): ${reason}`,
+      );
+      return result;
+    };
+
     // No entry: this is a first catalog, which TOFU handles. Nothing to displace.
-    if (!entry) return "skipped";
-    if (!claimant) return "skipped";
-    // Already bound: an ordinary settlement, not a claim.
+    if (!entry) return outcome("skipped", "no catalog entry for this key — first catalog, TOFU handles it");
+    if (!claimant) return outcome("skipped", "settlement carried no payTo to claim with");
+    // Already bound: an ordinary settlement, not a claim. DELIBERATELY NOT
+    // LOGGED — bazaar.ts calls this on every settle, so the bound owner's own
+    // payments arrive here every time. A line per payment would bury the
+    // outcomes that matter under the one that never does.
     if (entry.boundPayTo.includes(claimant)) return "skipped";
     // THE ONE-WAY GATE. Read from the durable latch, never from the badge.
-    if (this.everVerified.has(key)) return "skipped";
+    if (this.everVerified.has(key))
+      return outcome("skipped", "binding was PROVEN once and is permanently non-displaceable (one-way latch)");
     // An empty binding has no claimant to displace and no proof to weigh; it is
     // the tampered state bindLoadedEntry warns about, not a live URL.
-    if (entry.boundPayTo.length === 0) return "skipped";
+    if (entry.boundPayTo.length === 0)
+      return outcome("skipped", "binding is empty — tampered or unbound state, not a live URL");
     // A templated key would GET a literal `:symbol`. Never probe it.
-    if (isTemplatedKey(key)) return "skipped";
+    if (isTemplatedKey(key)) return outcome("skipped", "templated key — never probed");
     // A frozen catalog must not rebind anything.
-    if (this.frozen === "ownership-unreachable" || this.frozen === "ownership-invalid") return "skipped";
+    if (this.frozen === "ownership-unreachable" || this.frozen === "ownership-invalid")
+      return outcome("skipped", `catalog is frozen (${this.frozen}) — rebinding refused`);
 
     const cooldownKey = `${key}\u0000${claimant}`;
-    if (this.displaceInFlight.has(cooldownKey)) return "skipped";
+    if (this.displaceInFlight.has(cooldownKey))
+      return outcome("skipped", "a probe for this (url, claimant) is already in flight");
     const last = this.displaceState.get(cooldownKey);
-    if (last && now - last.at < cooldownFor(last.verdict)) return "skipped";
+    if (last && now - last.at < cooldownFor(last.verdict)) {
+      const remainingMs = cooldownFor(last.verdict) - (now - last.at);
+      return outcome(
+        "skipped",
+        `cooling down after a previous "${last.verdict}" verdict — ${Math.ceil(remainingMs / 1000)}s remaining`,
+      );
+    }
 
     this.displaceInFlight.add(cooldownKey);
     let verdict: OwnershipVerdict;
@@ -913,19 +968,27 @@ export class BazaarCatalog {
       // "does this endpoint name anyone we know", which a squatter's own
       // endpoint could answer yes to.
       verdict = await verify(key, [claimant]);
-    } catch {
+    } catch (err) {
       this.displaceState.set(cooldownKey, { verdict: "unverifiable", at: now });
-      return "refused";
+      return outcome(
+        "refused",
+        `the ownership probe threw — ${String((err as Error)?.message ?? err)}`,
+      );
     } finally {
       this.displaceInFlight.delete(cooldownKey);
     }
     this.displaceState.set(cooldownKey, { verdict, at: now });
-    if (verdict !== "match") return "refused";
+    if (verdict !== "match")
+      return outcome(
+        "refused",
+        `the resource's own 402 challenge did not name the claimant (verdict "${verdict}")`,
+      );
 
     // Re-check the latch: the probe was awaited, and a concurrent re-verify may
     // have proven the incumbent while we were off the CPU. Losing that race
     // would displace a binding that had become non-displaceable mid-flight.
-    if (this.everVerified.has(key)) return "skipped";
+    if (this.everVerified.has(key))
+      return outcome("skipped", "incumbent was proven by a concurrent re-verify while the probe was in flight");
 
     const displaced = [...entry.boundPayTo];
     if (this.store) {


### PR DESCRIPTION
## Displacement did not recover a real stale binding

Two payments settled against the redeployed demo on 2026-08-14:

| tx | ledger | on-chain |
| --- | --- | --- |
| `bc7e4a157fd8e433…` | 4133889 | successful |
| `2d1c3c78d3f174c4…` | 4133905 | successful |

The merchant received exactly 0.2 USDC, so both were real. **The catalog did not move** — still bound to `GBJX3E4G…`, still advertising the dead asset, `ownerVerified: false`, `settlements: 0`.

Two were used deliberately: `tryDisplace`'s own contract says the settle that *triggers* a displacement is refused and the next one lands normally. The second did not land either.

## Every exit now says why

Eight guards returned a bare `"skipped"`, so a displacement that silently did not happen couldn't be diagnosed from outside the process. Same defect as `settle` collapsing every submission failure into one constant `errorReason` — except this time **inside the control built to prevent squatting**, which is the strongest argument for fixing it.

`tryDisplace` and `reverify` now log a reason on every exit:

```
[catalog] displacement skipped for <key> (claimant <payTo>): cooling down after a
previous "mismatch" verdict — 84392s remaining
```

Two stay deliberately silent — `tryDisplace`'s already-bound skip and `reverify`'s verified-entry skip both fire on ordinary settlements, and a line per payment would bury the outcomes that matter under the one that never does.

`reverify` wasn't in scope but has the identical shape and is the path that actually flips the badge, so *"the badge didn't change and nothing said why"* is the question an operator arrives with. Widened deliberately rather than silently.

## A test for the shape production is actually in

Every passing displacement test built its binding in the **same process** that then displaced it. The only restart test covered a **verified** binding, where the correct answer is `"skipped"`. So *"restored, unverified, claimant proves ownership"* — the hosted demo entry exactly — had no coverage at all.

Added. **It passes**, which rules restoration *out* as the cause rather than reproducing the failure. A green suite while production doesn't recover was a suite proving something adjacent; it now covers the real shape.

## Three falsified claims corrected

`render.yaml`, `docs/diagnosis-demo-listing.md` and `docs/using-it.md` each asserted displacement resolves this without an operator. Live evidence says otherwise. Left uncorrected, the next operator waits for a recovery that has not been observed.

`using-it.md` now says displacement works in tests and did **not** work here — the honest state, and it keeps the practical advice that now matters more: be first to settle for your own URL.

## What is ruled out

| Suspect | Excluded by |
| --- | --- |
| Trailing-slash key mismatch | `normalizePath` strips it; both spellings map to one key |
| The `everVerified` one-way latch | `ownerVerified` **is** that latch, and it reads false |
| Catalog frozen | `/health` reports no freeze |
| Probe timing out | 3s budget; demo answers warm in ~0.8s |
| Displacement not wired | Fires fire-and-forget on every settle |
| "First reveals, second lands" | Two were run |
| Restoration from storage | The new test — passes |

## Still open

The cause. Remaining candidates are the empty-binding skip and a cooldown from a prior verdict, and distinguishing them needs the deployment's logs:

```
grep -E "displacement (skipped|refused|check failed)|rejected upsert for|DISPLACED"
# window: 2026-08-14 07:00–07:05 UTC
```

`rejected upsert for … is not bound … (F11)` is the discriminator. **Present** means the settlement reached the catalog and the key matched, so the failure is inside `tryDisplace`. **Absent** means it never reached cataloging and the question is upstream of displacement entirely.

The demo itself is fine — payable by a stranger for the first time. The stale entry is a catalog-display problem, not a payment one.

354 tests passing, typecheck clean, `render.yaml` valid.
