### PR TITLE
Refuse verified_only honestly, file the upstream issue, and close out today's register

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The catalog survives either way: it lives in libSQL/Turso rather than on the
 container, so your listings and ownership bindings are there when it wakes.
 
 **2. THE TRUST LAYER IS INERT HERE. Every verification badge reads `"unknown"`,
-and `?verified_only=true` returns an empty list.** Not a bug and not
+and `?verified_only=true` is refused with an explicit 400.** Not a bug and not
 misconfiguration:
 
 ```json
@@ -83,12 +83,13 @@ both must be true before one would be worth trusting.
 | `ownerVerified` | **working, proven live** | Whether the resource's own 402 challenge names its bound `payTo` — fetched by this facilitator, no external service involved |
 
 So ownership verification works and is enforced; *reputation* verification is
-switched off. If you filter on `verified_only`, you are filtering on the inert
-one and will get nothing.
+switched off. If you filter on `verified_only`, you are asking about the inert
+one, and the API now says so instead of pretending: a 400 with
+`verified_only_unavailable` and a pointer at `ownerVerified`.
 
-**A rough edge, so it does not surprise you twice:** `verified_only=true` filters
-`items` but `pagination.total` still reports the unfiltered count, so you will
-see `items: []` alongside `total: 1`.
+That refusal replaced an older, worse behaviour: a silent `items: []` — a
+correct-looking answer to a question this deployment cannot answer, which read
+as "nothing here is verified" when the truth was "nothing is being checked".
 
 ## What it does
 
@@ -101,9 +102,10 @@ see `items: []` alongside `total: 1`.
 | `GET /discovery/search` | Keyword search over the catalog — tokenized and relevance-scored, not semantic (`query`, same filters, cursor-paginated) |
 | `GET /health` | Liveness, plus the deployed `commit`, `uptimeSeconds`, `catalogSize`, `catalogFrozen` when bindings are frozen, and `unverifiableEntries` when any seller advertises an address the facilitator cannot fetch |
 
-† `verified_only` returns an **empty list** on this deployment. The verdicts it
-filters on come from a service that is deployed nowhere — see *Two things to
-know* above. `ownerVerified` is the field that works.
+† `verified_only` is **refused with a 400** (`verified_only_unavailable`) on
+this deployment. The verdicts it filters on come from a service that is deployed
+nowhere — see *Two things to know* above — so an empty list would describe the
+deployment, not the resources. `ownerVerified` is the field that works.
 
 **Smart accounts welcome.** Policy-governed smart-account payments cost ~130k
 stroops of simulation fee (the policy contract runs inside `__check_auth`);
@@ -139,7 +141,7 @@ before you build on it:
   permanently unverified. `PUBLIC_BASE_URL` is how the example declares its real
   address; `/health` reports `unverifiableEntries` when any entry is in this state.
 - **Verification verdicts read `"unknown"` on this deployment and
-  `?verified_only=true` returns nothing** — see *Two things to know* at the top.
+  `?verified_only=true` is refused with a 400** — see *Two things to know* at the top.
   `ownerVerified` is the field that does work here.
 
 ## Integration limits

--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -1,0 +1,57 @@
+# Account inventory — what we depend on, and who holds the key
+
+**The rule this file exists to enforce: every account this project depends on
+gets a row here BEFORE anything is deployed against it.** Public keys only —
+never a secret, never a hint of where inside a store a secret sits.
+
+Why it exists, concretely: on 2026-08-14 the question "do we still control
+`GBJX3E4G…`?" cost a morning of archaeology and the honest answer was *we don't
+know* — which stalled the demo fix and forced the displacement path. Before
+that, two demo asset issuers were burned without a record, each time leaving a
+live public service advertising an asset nobody could ever obtain. All three
+incidents are the same failure: an account was used without anyone writing down
+what it was for and where its key went.
+
+`custody` values: **held** (a named store), **external** (not ours, never was),
+**burned** (destroyed on purpose — say when and why), **unknown** (the state
+this file exists to abolish; anything `unknown` is a standing action item).
+
+---
+
+## Live — the service depends on these today
+
+| Account | Role | Custody | Notes |
+| --- | --- | --- | --- |
+| `GBUCR6H22CZC5OYHBJIEUS2JFZBOB63AHEGTCV6UEPMD2TMLKG2ZMIW4` | **Hosted sponsor.** Signs fee-bumps for every settlement on `vellar-facilitator.onrender.com`; its XLM balance IS the service's availability (the balance guard refuses `/settle` below the hard floor) | **held** — Render env var `SPONSOR_SECRET_KEY` on the facilitator service | Testnet. Verified against live `/supported` 2026-08-14. Losing this key means redeploying with a new funded sponsor — an inconvenience, not a disaster, since it holds no user funds |
+| `GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC` | **Demo merchant.** `vellar-seller-demo`'s `payTo`; receives the demo's USDC. Live USDC trustline | **held** — operator secret store (moved off the dev machine 2026-08-14) | Created 2026-08-13 to replace `GBJX3E4G…`. The seller only ever uses the public address; the secret has no runtime role |
+| `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5` | **Testnet USDC issuer** (SAC `CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA`) — the demo's payment asset | **external** — Circle (`home_domain centre.io`) | This is the point: the demo's asset issuer is **not ours to destroy**, which is what ends the burned-issuer pattern below. Balances come from the testnet DEX (`USE_USDC=1 node provision-testnet.mjs`) |
+
+## Unresolved — action items wearing table rows
+
+| Account | Role | Custody | Notes |
+| --- | --- | --- | --- |
+| `GBJX3E4GDO6IT5ZHWM5LVCXYCHN5L3HWZNKFHJMCR6JZJNBL3VVQL2RH` | **Former demo merchant.** Still the bound `payTo` of the hosted catalog's demo entry; holds 13 X402TST + ~10k XLM | **unknown** — no record of where its key went, and nobody has produced it | The account that motivated this file. If the key surfaces: record it here and it becomes a normal rotation. If it is confirmed gone: mark burned and the catalog binding can only move by displacement or runbook §1 |
+
+## Burned — dead on purpose, recorded so nobody digs twice
+
+| Account | Role | Custody | Notes |
+| --- | --- | --- | --- |
+| `GCS2VRHGJRLFCNM5Y74YJL63V2B3LYWYF5DZ4HHHZZUPWZYXMO4NIUOE` | **X402TST issuer** (SAC `CDYCX4PEXXTPIS67E7WPYM37UFCC5XW7QZX5LQ6UQBR65PQZWZ7HTBHR`) | **burned** — keypair generated in-process by a throwaway script, never persisted | Nobody can mint X402TST, ever. Any resource advertising this asset is permanently unpayable — this is what froze the demo listing (`diagnosis-demo-listing.md`) |
+| `GBDZH5KZ…` / SAC `CBIN4HTP…` | The demo pair before that | **burned** — issuer destroyed during provisioning, noted 2026-08-10 in `seller.mjs`'s history | Same failure, one generation earlier. Two burned issuers in two months is why the live demo now uses an asset we cannot burn |
+
+## Deliberately not tracked
+
+- **Throwaway test accounts** printed by `provision-testnet.mjs` (issuer,
+  merchant, payer, deployer, sim-source): per-run, testnet-only, and the script
+  prints their secrets to the operator by design. Tracking them here would
+  drown the accounts that matter. If one is ever promoted into a deployed
+  service's config, it graduates to the Live table **first**.
+- **The Vellar wallet WASM install** (`WALLET_WASM_HASH` in
+  `provision-testnet.mjs`): a contract hash, not an account. Its rot mode is
+  documented at the constant.
+
+---
+
+**Maintenance:** change a deployed service's env keys, create a demo account,
+rotate or burn anything → update this file in the same PR. An entry here is
+cheap; the archaeology it replaces was not.

--- a/docs/closing-state.md
+++ b/docs/closing-state.md
@@ -106,7 +106,7 @@ path after these changes is **~2m30s**.
 | **O-12** | **The advertised warm window did not exist.** Docs claimed a keep-alive held the instance warm `00:00–07:59` / `12:00–19:59 UTC`. Measured: **6 of 96** requested pings delivered, shortest gap **47 min** against a 15-min idle timeout, **0 of 10** gaps under it | closed-by-doc — claim withdrawn from `using-it.md`, `README.md` and the handover. **The underlying gap is open**: a warm window needs an external pinger, which a GitHub cron cannot provide |
 | **O-13** | **`guide.md`'s self-hosting start command fails on a fresh clone** — `./data/` does not exist and libSQL will not create it (`SQLITE_CANTOPEN`, error 14) | closed-by-doc — `mkdir -p data` added with the error it prevents |
 | **O-14** | **`walkthrough-wallet-spec.md` was linked from nowhere** and was the only place explaining how to generate `AGENT_PUBLIC` — the smart-account path dead-ended for anyone who had not read it | closed-by-doc — generation inlined in `using-it.md`, spec linked from both it and `guide.md` |
-| **O-15** | **The verifier allows 3 seconds; the README documents a 45-second cold start. Both facts have been in this repo the whole time, and nothing checked them against each other.** Ownership verification aborts at `FETCH_TIMEOUT_MS = 3_000`, while the hosted instance's ~45s spin-up is a headline caveat in `README.md` and `using-it.md`. So Layer 2 could never verify a resource that sleeps — it succeeded only if a probe happened to fire during a warm window. Measured 2026-08-14 against `vellar-seller-demo`: **asleep → `unverifiable` at 3006ms and 4046ms; warm → `match` in 679ms**. This is what left the demo listing permanently unverified and what silently blocked displacement (see [`diagnosis-demo-listing.md`](./diagnosis-demo-listing.md)). Two correct, individually-documented facts that contradict each other in a way no test could catch, because no test ran against a sleeping host | partially closed — a timeout is now a distinct verdict from `unverifiable`, earns a **60s** cooldown rather than 15 minutes, and gets **one** bounded retry. Retries extended to **three attempts** (45s, 120s), sized from the measured 31.7s / 42.5s / 43.7s cold starts. **The underlying gap stays open and is now a documented limitation rather than a pending fix**: verification is triggered by settlement and nothing else, so a resource asleep when its last-ever payment arrives stays unverified. A periodic sweep was designed and refused — see [`decision-no-verification-sweep.md`](./decision-no-verification-sweep.md), which keeps the argument for why a timeout-only sweep *would* clear the original no-background-prober objection, and the three reasons it is still not worth building. Chief among them: it would have failed on the >200s run in O-16 too |
+| **O-15** | **The verifier allows 3 seconds; the README documents a 45-second cold start. Both facts have been in this repo the whole time, and nothing checked them against each other.** Ownership verification aborts at `FETCH_TIMEOUT_MS = 3_000`, while the hosted instance's ~45s spin-up is a headline caveat in `README.md` and `using-it.md`. So Layer 2 could never verify a resource that sleeps — it succeeded only if a probe happened to fire during a warm window. Measured 2026-08-14 against `vellar-seller-demo`: **asleep → `unverifiable` at 3006ms and 4046ms; warm → `match` in 679ms**. This is what left the demo listing permanently unverified and what silently blocked displacement (see [`diagnosis-demo-listing.md`](./diagnosis-demo-listing.md)). Two correct, individually-documented facts that contradict each other in a way no test could catch, because no test ran against a sleeping host | partially closed — a timeout is now a distinct verdict from `unverifiable`, earns a **60s** cooldown rather than 15 minutes, and gets **one** bounded retry. Retries extended to **three attempts** (45s, 120s), sized from the measured 31.7s / 42.5s / 43.7s cold starts. **The underlying gap stays open and is now a documented limitation rather than a pending fix**: verification is triggered by settlement and nothing else, so a resource asleep when its last-ever payment arrives stays unverified. A periodic sweep was designed and refused — see [`decision-no-verification-sweep.md`](./decision-no-verification-sweep.md), which keeps the argument for why a timeout-only sweep *would* clear the original no-background-prober objection, and the three reasons it is still not worth building. Chief among them: it would have failed on the >200s run in O-16 too. **CAUSE CORRECTION 2026-08-14 (late):** the recorded cause — "the seller was asleep" — is half right at best. `buyer-classic.mjs` opens with an unpaid GET that itself wakes the seller, so by settle time the target has been warming for the whole payment flow; and a settlement against a measurably WARM seller (0.82s response), with the retry deployed, still did not displace. The 3s budget being blown is established; *whose* latency blows it is not. Leading candidates: the facilitator's own cold outbound path (a fresh container's first DNS resolution + TLS handshake to a new host), or in-provider DNS resolving `.onrender.com` to a private range from inside Render — which would trip the SSRF guard into an instant `unverifiable`, matching both the speed and the 15-minute cooldown observed. The #57 logging is now deployed, so the next settlement's `[catalog] displacement …` line names its verdict and settles this |
 | **O-16** | **A resource was unreachable for over three minutes, which is an availability floor no verification strategy can cross.** Separate from O-15's budget mismatch: on 2026-08-14 `vellar-seller-demo` returned nothing to a 200-second request, then nothing to a further 60-second one, then answered in 2.9s. It was not down — Render's wake latency simply has a long tail (31.7s / 42.5s / 43.7s measured, one run >200s). This bounds every strategy, not just the current one: **no retry schedule, sweep or budget can verify a resource that is not answering**, so on this hosting some fraction of verification attempts must fail regardless of design. Consequences: `unverifiableEntries` on the hosted instance is partly a hosting artifact rather than a merchant defect, and any SLA-style claim about verification would be false | open — accepted as a property of free-tier hosting, not a defect to fix. Mitigation is hosting (a paid tier that does not spin down), not code. Recorded so that a future "why is verification flaky" investigation starts here instead of re-deriving it |
 | **O-11** | **A gitignored `.env.recording` silently outranks the built-in defaults** — found while regression-testing O-3. With no shell vars the seller advertised the *dead* `GBDZH5KZ…`/`CBIN4HTP…` pair from a stale local file, not the in-code defaults. This is the exact hazard the hardcoding existed to prevent, re-entering through the env-file path | closed — boot log now prints the **provenance** of each value (`environment` / `examples/.env.recording` / `built-in default`) and the trustline preflight runs regardless. Deployment is unaffected: the file is gitignored and never shipped |
 
@@ -782,7 +782,7 @@ reachable here), **G-9** (not reachable in production), **G-12** (self-closing).
 
 ## 6. Pubnet go / no-go
 
-**Not yet. Three blockers, all tractable.**
+**Not yet. Four blockers — three tractable, one a hosting decision.**
 
 ### Blockers — must be true before `STELLAR_NETWORK=pubnet`
 
@@ -798,6 +798,19 @@ reachable here), **G-9** (not reachable in production), **G-12** (self-closing).
    testnet sample of one wallet. G-10 says the spend ceiling is 22× more
    conservative than its name implies; nobody knows yet whether that is
    comfortable or crippling at real volume.
+4. **Hosting that does not sleep — IF `ownerVerified` is meant to carry weight
+   for real merchants.** Added 2026-08-14 (O-15/O-16). On free-tier hosting,
+   verification has an availability floor we do not control: the probe budget
+   is 3s, wake latency is 30–45s with a tail past 200s, and no retry schedule
+   crosses that gap. On testnet that is an annoyance; on pubnet, `ownerVerified`
+   is the anti-squat signal buyers are told to read before paying real money —
+   a signal that silently fails for any merchant whose host sleeps is worse
+   than no signal, because it converts "our probe could not reach you" into
+   what reads as an adverse trust verdict. Either the facilitator (and the
+   badge's dependability claim) moves to hosting that does not spin down, or
+   the docs must demote `ownerVerified` to best-effort BEFORE real money reads
+   it. This is a decision, not a task — but it must be made deliberately, not
+   inherited from the demo setup.
 
 ### Conditions — true at cutover, watched afterwards
 
@@ -809,9 +822,13 @@ reachable here), **G-9** (not reachable in production), **G-12** (self-closing).
   binding. Database-scoped, read-write, non-expiring — and rotated deliberately,
   never on a timer, because we fail closed and an expiring token is a scheduled
   outage.
-- **A squat no longer self-heals.** Displacement recovers the unverified case
-  automatically; a verified binding needs runbook §1 and an operator who is
-  actually available.
+- **Displacement is designed to recover the unverified squat case, and has
+  never yet been observed doing so live.** Three settlements against a real
+  stale binding (2026-08-14) all failed to displace it; the staged tests pass,
+  including against a restored binding. Cause under investigation with the
+  per-exit logging now deployed. Until one real displacement is witnessed,
+  treat squat recovery as unproven — and a verified binding needs runbook §1
+  and an operator who is actually available either way.
 - **`VERIFICATION_API_URL` stays unset** until F4-ts lands. Configuring it makes
   that service a trust root, and it is unauthenticated with no per-record
   timestamp.

--- a/docs/diagnosis-demo-listing.md
+++ b/docs/diagnosis-demo-listing.md
@@ -166,9 +166,10 @@ The values are the fix:
   secret was generated straight to disk and never printed; it is **not** needed
   at runtime — `seller.mjs` only ever uses the public address.
 
-The old binding to `GBJX3E4G…` resolves itself. Because it was never verified,
-the first settlement naming the new address **displaces** it automatically. No
-operator step, no runbook §1.
+The old binding to `GBJX3E4G…` was *predicted* to resolve itself by
+displacement, since it was never verified. **That prediction is falsified** —
+three live settlements naming the new address have not displaced it (see
+above). The design intent stands; the observed behaviour does not match it yet.
 
 ## Where it stands
 
@@ -180,8 +181,34 @@ the point of the change, and it is finished.
 and the badge still reads false. That is a display problem in shared state, not a
 payment problem — nothing about paying this resource is broken.
 
-**Do not** expect a further settlement to fix it. Two already failed to, which is
-the whole finding above. The next step is the log grep, not another payment.
+**Do not** expect a further settlement to fix it. Two already failed to — and a
+**third** (2026-08-14T12:28:38Z, `cda3cbaa…`, ledger 4137813) failed under the
+conditions the cold-seller explanation said should succeed: seller measurably
+warm (0.82s response), the 3-attempt retry deployed (`commit 6e4845d`), monitor
+watching for 8 minutes. Catalog unchanged.
+
+That falsifies "the seller was asleep" as the whole story. `buyer-classic.mjs`
+opens with an unpaid GET that itself wakes the seller, so the target was never
+cold at probe time in ANY of the three attempts. What remains consistent with
+everything observed: the **facilitator's own outbound path** — a fresh
+container's first DNS + TLS to a new host blowing the 3s budget — or in-provider
+DNS resolving `.onrender.com` to a private range from inside Render, which the
+SSRF guard would refuse as an instant `unverifiable` (matching both the speed
+and the 15-minute cooldown of the original incident).
+
+The #57/#58 logging was live for the third settlement, so the discriminating
+evidence now exists:
+
+```
+grep "\[catalog\] displacement" 
+# window: 2026-08-14 12:28–12:33 UTC
+```
+
+The line names its verdict. `timeout` → facilitator outbound latency, and the
+retry should also appear. `unverifiable` arriving fast → the SSRF-guard/DNS
+hypothesis, which no timeout retry will ever fix and which would mean the
+facilitator can never verify a sibling Render service from inside Render.
+The next step is that grep, not another payment.
 
 To re-check the badge at any point:
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -164,7 +164,7 @@ const { resources } = await bazaar.search({ query: "weather data" });
 For AI agents, the MCP server (`src/mcp.ts`) exposes the same two operations
 as MCP tools — see the README for client config.
 
-> **Do not filter on `verified_only` here.** It returns an empty list on the
+> **Do not filter on `verified_only` here.** It is refused with a 400 on the
 > hosted instance, and will on yours too unless you run your own verification
 > API. The `verification` / `acceptsVerification` badges it filters on come from
 > an external attestation service that is **deployed nowhere** (the wallet repo's

--- a/docs/upstream-issue-smart-accounts.md
+++ b/docs/upstream-issue-smart-accounts.md
@@ -1,4 +1,12 @@
-# Upstream issue — DRAFT, NOT FILED
+# Upstream issue — FILED
+
+**Open: https://github.com/x402-foundation/x402/issues/3158** (2026-08-14),
+cross-referenced with #3125. The text below is what was submitted, from
+[Summary](#summary) down, plus a PR offer.
+
+---
+
+## Original draft notes
 
 **Target:** `x402-foundation/x402` (the repo `@x402/stellar` points at).
 **Confirmed against:** `@x402/stellar@2.22.0` — the latest published release,

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -370,7 +370,9 @@ README has the client config.
 
 **Read `ownerVerified` before you pay.** It is the signal that a listing is not a
 squat — the resource's own 402 names the address you would be paying. Do **not**
-filter on `verified_only`; it is inert here and returns nothing.
+filter on `verified_only`; it is inert here, and asking for it is refused with
+an explicit `400 verified_only_unavailable` rather than answered with a silent
+empty list.
 
 ### Paying
 
@@ -425,7 +427,7 @@ Six things, in the order you will meet them.
 | **1** | **~45s on the first request, at any hour.** The service sleeps after 15 minutes idle and there is **no reliable warm window** — see below | **Assume you will pay it.** Send a warming `GET /health` first (exempt from rate limiting) and give it a 120s timeout, or expect your first real call to hang for ~45s. It then stays warm 15 min past your last call |
 | **2** | **Roughly 1 settle in 3 fails**, with an empty `transaction` and one of two reasons: `settle_exact_stellar_transaction_submission_failed` or `settle_exact_stellar_transaction_failed` | **Retry — and no, you did not pay twice.** See below |
 | **3** | **Trust badges are inert.** `verification` and `acceptsVerification` are always `"unknown"` | Read `ownerVerified` instead — that one works. The badge source is deployed nowhere and is not switching on soon (README has the dependency chain) |
-| **4** | **`?verified_only=true` returns an empty list** | Do not use it. It filters on the inert field |
+| **4** | **`?verified_only=true` is refused with a 400** (`verified_only_unavailable`) | Do not use it. It filters on the inert field, and the refusal names `ownerVerified` as the signal that works |
 | **5** | **`curl -I` on a paid route returns 200, not 402** | Debug with `GET`, not `HEAD` — a HEAD request does not carry the payment challenge, so the route looks unpaid when it is working correctly |
 | **6** | **Your first settlement writes to a shared catalog, and the write is one-way** | Know this before you settle, not after — see below |
 

--- a/src/catalog.restart-verification.test.ts
+++ b/src/catalog.restart-verification.test.ts
@@ -67,7 +67,7 @@ function disc(url = URL_X): DiscoveredResource {
 
 /** Every asset reads "verified", so any non-verified verdict below is caused by
  * owner-clamping alone — the thing under test. */
-const allVerified: TrustResolver = { assetStatus: async () => "verified" };
+const allVerified: TrustResolver = { hasVerdictSource: true, assetStatus: async () => "verified" };
 
 const testConfig = {
   port: 0,

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -41,13 +41,35 @@ const sharedFilters = {
 
 /** Trust-layer client-side filter: keeps wire compatibility with the canonical
  * bazaar client (which has no verified_only param) by filtering on the
- * additive `trust.verification` field the facilitator annotates. */
+ * additive `trust.verification` field the facilitator annotates.
+ *
+ * Returns a `note` alongside the filtered items when the filter is being asked
+ * a question the facilitator visibly cannot answer: if EVERY observed verdict
+ * is "unknown", the deployment has no verdict source, and an empty result
+ * describes the deployment rather than the resources. This server cannot see
+ * the facilitator's config, so it reasons from what it observed — which is
+ * also why the note only appears when there were items to observe. The note is
+ * data for the model, not an error: silently returning [] taught agents that
+ * nothing is trustworthy, when the truth was that nothing was being checked. */
 function applyVerifiedOnly<T extends { trust?: { verification?: string } }>(
   items: T[],
   verifiedOnly: boolean | undefined,
-): T[] {
-  if (!verifiedOnly) return items;
-  return items.filter((item) => item.trust?.verification === "verified");
+): { items: T[]; note?: string } {
+  if (!verifiedOnly) return { items };
+  const filtered = items.filter((item) => item.trust?.verification === "verified");
+  const allUnknown =
+    items.length > 0 && items.every((item) => (item.trust?.verification ?? "unknown") === "unknown");
+  if (allUnknown) {
+    return {
+      items: filtered,
+      note:
+        "verified_only matched nothing, and every verdict this facilitator returned was \"unknown\" — " +
+        "which means it has no verification service configured, not that these resources failed a check. " +
+        "Do not read this as \"nothing is trustworthy\". For a per-resource trust signal that does work " +
+        "here, read trust.ownerVerified.",
+    };
+  }
+  return { items: filtered };
 }
 
 /**
@@ -83,13 +105,19 @@ server.registerTool(
   },
   async ({ verified_only, ...params }) => {
     const result = await bazaar.listResources(compact(params));
-    const items = frameDescriptions(
-      applyVerifiedOnly(
-        result.items as Array<(typeof result.items)[number] & { trust?: { verification?: string } }>,
-        verified_only,
-      ),
+    const { items: filtered, note } = applyVerifiedOnly(
+      result.items as Array<(typeof result.items)[number] & { trust?: { verification?: string } }>,
+      verified_only,
     );
-    return { content: [{ type: "text", text: JSON.stringify({ ...result, items }, null, 2) }] };
+    const items = frameDescriptions(filtered);
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ ...result, items, ...(note ? { verifiedOnlyNote: note } : {}) }, null, 2),
+        },
+      ],
+    };
   },
 );
 
@@ -108,16 +136,24 @@ server.registerTool(
   },
   async ({ verified_only, ...params }) => {
     const result = await bazaar.search(compact(params) as { query: string });
-    const resources = frameDescriptions(
-      applyVerifiedOnly(
-        result.resources as Array<
-          (typeof result.resources)[number] & { trust?: { verification?: string } }
-        >,
-        verified_only,
-      ),
+    const { items: filtered, note } = applyVerifiedOnly(
+      result.resources as Array<
+        (typeof result.resources)[number] & { trust?: { verification?: string } }
+      >,
+      verified_only,
     );
+    const resources = frameDescriptions(filtered);
     return {
-      content: [{ type: "text", text: JSON.stringify({ ...result, resources }, null, 2) }],
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { ...result, resources, ...(note ? { verifiedOnlyNote: note } : {}) },
+            null,
+            2,
+          ),
+        },
+      ],
     };
   },
 );

--- a/src/server.pagination.test.ts
+++ b/src/server.pagination.test.ts
@@ -47,9 +47,12 @@ describe("pagination.total counts what the caller can page through", () => {
     await catalog.upsertFromPayment(disc("https://a.example/one"), reqs("GA"));
     await catalog.upsertFromPayment(disc("https://b.example/two"), reqs("GB"));
 
-    // No verification API configured, which is the deployed reality: every
-    // verdict is "unknown", so verified_only filters everything out.
-    const trust = createTrustResolver({ verificationApiUrl: undefined, rpcUrl: "https://rpc.invalid" });
+    // A CONFIGURED verdict source whose answer is "unverified" for everything.
+    // This test used to run with no source at all — the deployed reality — but
+    // that case is now refused with a 400 rather than answered (see the
+    // refusal suite below), so the total-agrees-with-items concern needs a
+    // deployment where the filter legitimately drops entries.
+    const trust = { hasVerdictSource: true, assetStatus: async () => "unverified" as const };
     const app = await buildServer(buildFacilitator(testConfig), catalog, trust);
 
     const unfiltered = (await app.inject({ method: "GET", url: "/discovery/resources" })).json();
@@ -64,6 +67,48 @@ describe("pagination.total counts what the caller can page through", () => {
       filtered.pagination.total,
       "total must agree with items — a self-contradicting page teaches clients to trust nothing in it",
     ).toBe(0);
+  });
+
+  it("verified_only with NO verdict source is refused, not answered with an empty list", async () => {
+    // The old behaviour was `items: []` — a correct-LOOKING answer to a
+    // question this deployment cannot answer. A caller read it as "nothing
+    // here is verified" when the truth was "this deployment cannot tell".
+    //
+    // MUTATION THAT MUST BREAK THIS: drop the hasVerdictSource gate and let
+    // the filter run over all-"unknown" verdicts. The 400 becomes a silent 200.
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(disc("https://a.example/one"), reqs("GA"));
+    const trust = createTrustResolver({ verificationApiUrl: undefined, rpcUrl: "https://rpc.invalid" });
+    const app = await buildServer(buildFacilitator(testConfig), catalog, trust);
+
+    for (const url of [
+      "/discovery/resources?verified_only=true",
+      "/discovery/search?query=one&verified_only=true",
+    ]) {
+      const res = await app.inject({ method: "GET", url });
+      expect(res.statusCode, url).toBe(400);
+      const body = res.json();
+      expect(body.error).toBe("verified_only_unavailable");
+      expect(body.reason).toBe("no_verdict_source_configured");
+      expect(body.detail, "must point at the signal that works").toContain("ownerVerified");
+    }
+
+    // Without the filter the same deployment answers normally.
+    const plain = await app.inject({ method: "GET", url: "/discovery/resources" });
+    expect(plain.statusCode).toBe(200);
+    expect(plain.json().items).toHaveLength(1);
+  });
+
+  it("verified_only with NO trust layer at all is refused too — it used to return everything", async () => {
+    // The quietly WORSE case: with no resolver, the filter was ignored
+    // entirely, so a caller asking for verified-only entries got every entry.
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(disc("https://a.example/one"), reqs("GA"));
+    const app = await buildServer(buildFacilitator(testConfig), catalog, undefined);
+
+    const res = await app.inject({ method: "GET", url: "/discovery/resources?verified_only=true" });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("verified_only_unavailable");
   });
 
   it("an unfiltered request is untouched", async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -288,8 +288,34 @@ export async function buildServer(
     return result;
   });
 
-  app.get<{ Querystring: ListQuery }>("/discovery/resources", async (request) => {
+  /**
+   * verified_only asks a question only a deployment with a verdict source can
+   * answer. Without one, every verdict is the constant "unknown", so the filter
+   * can never match — and the old behaviour, a silent `items: []`, was a
+   * correct-LOOKING answer to a question the system could not answer. A caller
+   * read it as "nothing here is verified" when the truth was "this deployment
+   * cannot tell". Refused loudly instead, naming the field that does work.
+   *
+   * Also covers the no-trust-layer case, which was quietly WORSE: with no
+   * resolver at all, verified_only was ignored entirely and the caller who
+   * asked for verified-only entries got every entry, unfiltered.
+   */
+  const verifiedOnlyRefusal = () => ({
+    error: "verified_only_unavailable",
+    reason: "no_verdict_source_configured",
+    detail:
+      "This deployment has no verification API configured, so every verification " +
+      "verdict is \"unknown\" and a verified_only filter can never match anything. " +
+      "An empty list here would describe the deployment, not the resources. " +
+      "For a per-resource trust signal that does work, read trust.ownerVerified.",
+  });
+  const verifiedOnlyUnanswerable = () => !trust || !trust.hasVerdictSource;
+
+  app.get<{ Querystring: ListQuery }>("/discovery/resources", async (request, reply) => {
     const q = request.query;
+    if (q.verified_only === "true" && verifiedOnlyUnanswerable()) {
+      return reply.status(400).send(verifiedOnlyRefusal());
+    }
     const response = catalog.list({
       ...(q.type !== undefined ? { type: q.type } : {}),
       ...(q.payTo !== undefined ? { payTo: q.payTo } : {}),
@@ -325,6 +351,9 @@ export async function buildServer(
       return reply
         .status(400)
         .send({ error: "invalid_query", detail: "the `query` parameter is required" });
+    }
+    if (q.verified_only === "true" && verifiedOnlyUnanswerable()) {
+      return reply.status(400).send(verifiedOnlyRefusal());
     }
     const response = catalog.search({
       query: q.query,

--- a/src/trust.peraccepts.test.ts
+++ b/src/trust.peraccepts.test.ts
@@ -9,7 +9,7 @@ import { annotateTrust, type TrustedDiscoveryResource, type TrustResolver } from
 // is the strict minimum across accepts, further clamped by owner-verification.
 
 function resolver(map: Record<string, "verified" | "unverified" | "unknown">): TrustResolver {
-  return { assetStatus: async (id) => map[id] ?? "unknown" };
+  return { hasVerdictSource: true, assetStatus: async (id) => map[id] ?? "unknown" };
 }
 
 function item(assets: string[], resource = "https://api.example.com/r"): TrustedDiscoveryResource {

--- a/src/trust.test.ts
+++ b/src/trust.test.ts
@@ -25,7 +25,7 @@ function historyResponse(status: string, outputHash?: string) {
 }
 
 function fixedResolver(map: Record<string, "verified" | "unverified" | "unknown">): TrustResolver {
-  return { assetStatus: async (id) => map[id] ?? "unknown" };
+  return { hasVerdictSource: true, assetStatus: async (id) => map[id] ?? "unknown" };
 }
 
 function item(asset: string | string[], over: Partial<TrustedDiscoveryResource> = {}): TrustedDiscoveryResource {

--- a/src/trust.ts
+++ b/src/trust.ts
@@ -85,6 +85,15 @@ export const TRUST_LIMITS = Object.freeze({
 export interface TrustResolver {
   /** Verification verdict for one contract id (cached). */
   assetStatus(contractId: string): Promise<TrustVerification>;
+  /**
+   * Whether a verdict source is configured at all. When false, every
+   * `assetStatus` answer is the constant "unknown" — so a filter on
+   * `verification === "verified"` can never match anything, and serving an
+   * empty list for it is a correct-looking answer to a question this
+   * deployment cannot answer. Routes read this to refuse that question
+   * loudly instead (see server.ts, verified_only).
+   */
+  readonly hasVerdictSource: boolean;
 }
 
 export interface TrustResolverOptions {
@@ -223,6 +232,7 @@ export function createTrustResolver(options: TrustResolverOptions): TrustResolve
   }
 
   return {
+    hasVerdictSource: Boolean(options.verificationApiUrl),
     async assetStatus(contractId) {
       if (!options.verificationApiUrl) return "unknown";
 


### PR DESCRIPTION
Four items from today's list, one branch — they share the register.

## `verified_only` stops pretending

Filtering on `verified_only` against a deployment with no verdict source returned a **silent empty list** — a correct-looking answer to a question the system cannot answer. A caller read *"nothing here is verified"* when the truth was *"nothing is being checked"*. Now:

```
400 { "error": "verified_only_unavailable",
      "reason": "no_verdict_source_configured",
      "detail": "… read trust.ownerVerified." }
```

`TrustResolver` gains `hasVerdictSource`, so routes ask the resolver rather than reaching into config. Found on the way, and quietly **worse**: with no trust layer at all, `verified_only` was ignored entirely — a caller asking for verified-only entries got *every* entry. Also refused now, with a test.

The MCP server can't see server config, so it reasons from observation: when the filter empties the list and every verdict it saw was `"unknown"`, the tool result carries a `verifiedOnlyNote` telling the model this means *no verification service*, not *nothing is trustworthy*. The silent `[]` was teaching agents the wrong lesson.

## Upstream issue filed

[x402-foundation/x402#3158](https://github.com/x402-foundation/x402/issues/3158) — the smart-account signing gap, live reproduction and stack trace, cross-referenced with #3125. Both of this repo's upstream findings are now filed.

## Account inventory (`docs/accounts.md`)

Role, custody, burned-or-not, for every account the project depends on — the rule is a row **before** deployment. Written because "do we still control `GBJX3E4G…`?" cost a morning and the honest answer was *unknown*, and two demo issuers were burned without a record. `GBJX3E4G…` sits in an **unresolved** section as a standing action item. Hosted sponsor verified against live `/supported` rather than assumed.

## O-15 cause corrected; third settlement recorded

"The seller was asleep" is half right at best: `buyer-classic.mjs` opens with an unpaid GET that itself wakes the seller — and a **third settlement** (`cda3cbaa…`, ledger 4137813) against a measurably warm seller (0.82s), with the retry deployed, still did not displace. Remaining candidates: the facilitator's own cold outbound path, or in-provider DNS resolving `.onrender.com` to a private range from inside Render — which the SSRF guard would refuse as an instant `unverifiable`, matching both the speed and the 15-minute cooldown of the original incident.

The #57 logging was live for this one. **The grep window 2026-08-14 12:28–12:33 UTC now discriminates:** the `[catalog] displacement` line names its verdict — `timeout` → facilitator outbound latency; fast `unverifiable` → the DNS/SSRF hypothesis, which no timeout retry will ever fix.

## Pubnet gate: fourth blocker

**Hosting that does not sleep, if `ownerVerified` is meant to carry weight for real merchants.** A trust signal that silently fails for any merchant whose host sleeps converts "our probe could not reach you" into what reads as an adverse verdict. Either the badge gets hosting that does not spin down, or the docs demote `ownerVerified` to best-effort *before* real money reads it. Section 6's "a squat self-heals via displacement" condition is also corrected to match live evidence: designed to, never yet observed, three settlements failed.

## Verification

362 tests passing (3 new), typecheck clean. Docs updated everywhere the old empty-list behaviour was described (README ×5, using-it ×2, guide ×1).