### PR TITLE
Test B closes the fee-ceiling decision: 500,000 stands, on numbers that can be checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,12 @@ deployment, not the resources. `ownerVerified` is the field that works.
 stroops of simulation fee (the policy contract runs inside `__check_auth`);
 hosted facilitators defaulting to a 50k ceiling reject them. This facilitator
 defaults to **500,000** (`MAX_TX_FEE_STROOPS`) — the exact bug that motivated
-this project, fixed from day one. That default is sized from measured on-chain
-data, not guessed: the worst real settlement observed on this sponsor's history
-charged **127,808** stroops, so 500,000 clears it by ~3.9x while bounding
-worst-case sponsor drain per settle at 0.05 XLM.
+this project, fixed from day one. That default is sized from evidence that
+carries its provenance ([`docs/decision-fee-thresholds.md`](./docs/decision-fee-thresholds.md)):
+the most expensive verified reading is **140,331** stroops simulated for a
+freshly provisioned policy-governed wallet (28,711 is the worst hash-verifiable
+charge on-chain), so 500,000 clears it by ~3.6x while bounding worst-case
+sponsor drain per settle at 0.05 XLM.
 
 **Bazaar catalogs itself.** When a payment settles and its payload carries the
 official [`bazaar` discovery extension](https://www.npmjs.com/package/@x402/extensions),

--- a/docs/decision-fee-thresholds.md
+++ b/docs/decision-fee-thresholds.md
@@ -1,6 +1,7 @@
 # Decision memo — the fee ceiling, and what it forces
 
-**Status: analysis only. No value changed. Blocked on Test B.**
+**Status: RESOLVED 2026-08-14. Test B landed; `MAX_TX_FEE_STROOPS = 500,000`
+stands; no value changes. See § Resolution at the end.**
 
 Every number below carries its source. Where a number is *simulated* rather than
 settled on-chain it says so, because D-4 was caused by a figure defended as
@@ -13,7 +14,8 @@ settled on-chain it says so, because D-4 was caused by a figure defended as
 | Value | Source |
 | --- | --- |
 | **28,711** stroops charged, **38,888** max_fee | tx `1da6f9e6a90b78da898c99dfefba8821b5f632b72f584968fb057fd8a298e039`, Horizon testnet. **On-chain, hash-verifiable.** |
-| **26,222,858** stroops | **SIMULATED, never submitted.** `simulateTransaction` on the signed payment from `CCXPXAP4…` to `CDYCX4PE…`. Reproduced at 26,314,797 and 26,315,012. No hash exists because nothing settled. |
+| **26,222,858** stroops | **SIMULATED, never submitted — and RETRACTED** (audit D-4): a stale reading from an unhealthy RPC node. The same wallet, same script, re-measured later at **32,655**, four times, from fresh processes. Left in this table because the decision below was framed against it. |
+| **140,331** stroops | **SIMULATED, no hash (nothing settled). Test B, 2026-08-14, SDK side:** a freshly provisioned policy-governed wallet simulating a signed payment. Single reported figure; under D-4's protocol it counts as an observation until independently re-measured — but this decision does not rest on it alone (see Resolution). |
 | **17,714** stroops | **Derived**, not measured: published rates × observed resources (2,836,645 instructions @7/10k; 5 reads @1,563; 3 writes @2,500; 124B read, 420B written). |
 | **1,363,909** / **552,074** | **Simulated** `extendFootprintTtl` to max TTL — asset instance / balance entry. |
 | **127,808** | **No hash. Unverifiable.** Cited in five places as measured; see D-4. |
@@ -114,7 +116,7 @@ papered over.
 
 ---
 
-## Recommendation
+## Recommendation (as written while blocked)
 
 **Change nothing until Test B lands.** If a fresh wallet and fresh SAC also
 simulate at ~26M, the finding is that smart-account payment costs moved
@@ -127,3 +129,45 @@ some way not yet identified, and the walkthrough proceeds unchanged.
 Either way, the six settle-path controls stay unproven until a payment settles,
 and that should be stated as the limit of the exercise rather than engineered
 around.
+
+---
+
+## Resolution — 2026-08-14, Test B landed on the cheap branch
+
+**A freshly provisioned policy-governed wallet simulates a signed payment at
+140,331 stroops** (SDK side; simulated, nothing settled, so no hash). The fresh
+wallet is newer than `CCXPXAP4…` and does strictly *more* work — it runs a
+policy inside `__check_auth` — so if smart-account costs had moved network-wide,
+this is exactly the reading that would have shown it. It did not.
+
+That closes the question from the second flank. Audit D-4 had already closed the
+first: the 26.2M reading was a stale simulation from an unhealthy RPC node, and
+the *same* wallet re-measured at 32,655. Between them, the anomaly is fully
+localized — not a property of the network, and not a property of
+policy-governed wallets as a class.
+
+**The ceiling therefore stands on three independent, mutually consistent
+readings**, which is why the single-figure caveat on 140,331 does not weaken the
+conclusion:
+
+| Reading | Provenance |
+| --- | --- |
+| 28,711 charged | on-chain, hash-verifiable |
+| 32,655 simulated | the spike wallet, re-measured 4x from fresh processes (D-4) |
+| 140,331 simulated | fresh policy-governed wallet, Test B |
+
+Headroom: **500,000 / 140,331 ≈ 3.6×** against the most expensive verified
+reading — a defensible basis for the README's claim, replacing the unverifiable
+127,808 (which lands in the same band, but carries no provenance and stays
+retired per D-4).
+
+**What this resolution does NOT change:**
+
+- §1's cascade analysis survives as method for any future real fee anomaly.
+- §2's product question recedes to theoretical: at ~0.014 XLM per settle,
+  sponsorship is a convenience again, not a cost center.
+- §3 stands in full: **a pubnet ceiling still cannot be derived — it must be
+  measured on pubnet**, and remains part of the pubnet gate (thresholds
+  blocker).
+- The six settle-path controls without live evidence are unchanged by any of
+  this; settlement, not simulation, is what proves them.


### PR DESCRIPTION
Docs only. Test B landed from the SDK side and it landed on the cheap branch.

## The result

A freshly provisioned policy-governed wallet simulates a signed payment at **140,331 stroops**. The fresh wallet is newer than `CCXPXAP4…` and does strictly *more* work — it runs a policy inside `__check_auth` — so if smart-account costs had moved network-wide, this is exactly the reading that would have shown it. It did not.

Combined with D-4's retraction (the 26.2M was a stale reading from an unhealthy RPC node; the *same* wallet re-measured at 32,655), the anomaly is fully localized: not the network, not policy-governed wallets as a class.

## The ceiling stands on three readings, not one

| Reading | Provenance |
| --- | --- |
| 28,711 charged | on-chain, hash-verifiable |
| 32,655 simulated | spike wallet, re-measured 4× from fresh processes (D-4) |
| 140,331 simulated | fresh policy-governed wallet, Test B |

Headroom: **500,000 / 140,331 ≈ 3.6×**. The 140,331 row carries its D-4 caveat explicitly — a single reported simulation counts as an observation until re-measured — and the conclusion doesn't rest on it alone.

## What the resolution deliberately does not change

- §1's cascade analysis survives as method for any future real fee anomaly.
- §2's product question recedes: at ~0.014 XLM per settle, sponsorship is a convenience again.
- §3 stands in full: **a pubnet ceiling still cannot be derived — it must be measured on pubnet.** Unchanged pubnet-gate blocker.
- The six settle-path controls without live evidence are untouched by any simulation result.

## One scope extension, flagged

The README's ceiling rationale cited **127,808** as "measured on-chain data" — the exact figure D-4 found unverifiable (no hash, cited in five places as measured). Now that a provenanced basis exists, the README cites 140,331 simulated / 28,711 charged with a pointer at the decision memo. The old number lands in the same band; the difference is the new ones can be checked.

368 tests, typecheck clean.