### PR TITLE
Truth sweep: fix every catchable stale claim, retire the keepalive, go always-on

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,3 +83,20 @@ STELLAR_NETWORK=testnet
 
 # PORT=4100
 # HOST=0.0.0.0
+
+# ── Catalog persistence (libSQL/Turso) ───────────────────────────────────────
+# Unset is LEGAL and means IN-MEMORY: the service boots with a loud warning and
+# every restart (or free-tier spin-down) empties the catalog and its ownership
+# bindings. Any real deployment sets both. Token: DATABASE-SCOPED read-write,
+# minted with `turso db tokens create <db> --expiration never` — see
+# render.yaml's comment block for why never-expiring and single-database scope
+# are the deliberate choices, and what the token permits (F6).
+# CATALOG_DB_URL=libsql://<database>-<org>.turso.io
+# CATALOG_DB_AUTH_TOKEN=
+
+# ── Third-party trust verdicts ───────────────────────────────────────────────
+# DELIBERATELY UNSET. Configuring this makes that API a trust root; it is
+# currently unauthenticated and carries no per-record timestamps (F4-ts,
+# docs/security-audit.md). Unset, every verdict honestly reads "unknown" and
+# verified_only refuses loudly instead of serving a misleading empty list.
+# VERIFICATION_API_URL=

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,193 +1,27 @@
-## Keep-alive ping for the hosted testnet facilitator.
-##
-## WHY THIS EXISTS — and what it is NOT, since that changed.
-##
-## It used to be the *emptiness* fix: the catalog lived on the container's
-## filesystem, and spin-down destroyed it. That is no longer true. The catalog is
-## in libSQL/Turso and survives a container replacement — verified live across a
-## 42-second cold start with the ownership binding intact.
-##
-## So this is now purely a LATENCY fix, and should be judged as one. The first
-## request after 15 minutes idle takes ~50 seconds (42 s measured). Nothing is
-## lost by sleeping; a developer just waits.
-##
-## THE BUDGET, and why this is not 24/7 by default.
-##
-## Render grants 750 Free instance hours per WORKSPACE per calendar month —
-## workspace, not service. Exhausting it SUSPENDS EVERY Free web service in the
-## workspace until the 1st of the next month.
-##
-##   24/7 in a 31-day month = 744 h  ->  6 h of margin (<1%)
-##   20 h/day               = 620 h  ->  130 h of margin
-##
-## 24/7 fits arithmetically and only if this is the ONLY Free service in the
-## workspace. A second Free service, or one added later by anyone, blows the
-## budget and takes this one down with it. So the default below is 20 h/day.
-##
-## Outside the window the service sleeps as before: the first request takes
-## ~1 minute and the catalog comes back EMPTY, repopulating from the next
-## settled payment per resource.
-##
-## TO RUN 24/7 instead: change the cron to "*/10 * * * *" and first confirm this
-## is the only Free service in the workspace.
-##
-## RELIABILITY — MEASURED 2026-08-12. THIS DOES NOT HOLD A WARM WINDOW.
-##
-## This was written as a caveat ("mostly works, silent and intermittent"). It is
-## now a measurement, and the answer is worse than the caveat implied: the
-## workflow does not keep the service warm at all, and cannot be made to.
-##
-## From this workflow's own run history:
-##
-##   cron requested            */5  -> 12 runs/hour
-##   delivered 12:00-19:59 UTC on 2026-08-11:  6 runs out of 96   (6.2%)
-##   gaps between consecutive runs (10 samples):
-##     shortest 47.2 min | median 68.3 min | longest 1470 min
-##   gaps shorter than Render's 15-minute idle timeout:  0 of 10
-##
-## GitHub delivered roughly ONE run per hour regardless of the interval asked
-## for. Render sleeps after 15 minutes idle, so a ~60-minute gap leaves ~45
-## minutes of sleep inside every "warm" hour.
-##
-## TIGHTENING THE CRON CANNOT FIX THIS. */5 is already the tightest useful value
-## and it produced ~1 run/hour; the limit is delivery, not the schedule. A
-## measured consequence: a 44.76s cold start at 17:01 UTC — inside the window
-## below, between the 16:24 and 17:25 runs — with /health reporting
-## uptimeSeconds:48 straight after, i.e. the process started on that request.
-##
-## WHAT WOULD WORK: an external uptime monitor (UptimeRobot free tier: 50
-## monitors, 5-minute checks, ~5 minutes to set up, no code). Keep this workflow
-## as a backup and as the stale-deploy check, but do not describe it as a warm
-## window — the docs claimed one until 2026-08-12 and it was not real.
-##
-## BUDGET, IF YOU ADD ONE: a monitor left on 24/7 keeps the instance awake ~744
-## h/month against a 750 h per-WORKSPACE allowance, which would suspend every
-## Free service in the workspace. Give it a maintenance window matching the
-## hours below rather than leaving it always-on.
-##
-## BUDGET INTERACTION — the pinger schedule is not free to choose.
-## An external monitor checking every 5 minutes runs 24/7 by default, which keeps
-## the instance awake 24/7 = 744 h/month against a 750 h WORKSPACE allowance.
-## That silently overrides the 20 h/day decision below and leaves <1% margin. If
-## you add an external monitor, either configure its maintenance window to match
-## the gap here, or accept 24/7 and first confirm this is the only Free service
-## in the workspace.
-##
-## HOW TO TELL IF IT IS WORKING: /health reports `uptimeSeconds`. A value shorter
-## than the ping interval means the container was replaced since the last ping —
-## the step below warns on it. That is the data signal; do not wait for a
-## developer to report an empty catalog.
-##
-## GitHub also disables scheduled workflows on repositories with no activity for
-## 60 days.
-
 name: keepalive
 
-# DISABLED ON PURPOSE — no `schedule:` trigger. Manual only.
+# RETIRED 2026-08-15 — manual dispatch only. Full arc, kept honest:
 #
-# The workspace has EIGHT services sharing one 750-hour monthly pool, and
-# exhausting it suspends EVERY free service in the workspace — including
-# vellar-backend and the frontend, which do real work and have nothing to do
-# with this facilitator.
+#   1. Shipped unscheduled: workspace free-instance hours are pooled (750/mo
+#      across every free service) and exhausting the pool suspends ALL of them.
+#   2. Re-enabled 2026-08-11 on a 16 h/day split window, after billing showed
+#      actual usage at 2.6% of the pool — the budget was measured headroom, not
+#      a guess (closing-state §3.4e, §4b, and this file's git history for the
+#      full window arithmetic).
+#   3. Retired 2026-08-15 on DELIVERY measurement: GitHub's scheduler ran the
+#      */5 cron at 18-52 minute gaps — every gap past the 15-minute idle
+#      timeout — so the instance slept between pings while the hours burned.
+#      ~60% warm odds for a visitor was the product. Same failure the withdrawn
+#      warm-window claim documented in 2026-08-12; re-enabling did not change
+#      GitHub's delivery.
 #
-# What a keep-alive buys is a demo catalog that stays warm between deploys.
-# What it risks is taking down unrelated production services. Even a 4 h/day
-# window is 124 h/month of that exposure for a convenience. Off is the correct
-# default until the instance types are confirmed and the real divisor is known;
-# it can be re-enabled then with an informed number.
-#
-# TO RE-ENABLE, once you know how many free WEB services share the pool (static
-# sites and databases do NOT draw instance hours, so the divisor is likely
-# smaller than the service count): add back a `schedule:` block, e.g.
-#     schedule:
-#       - cron: "*/10 5-23 * * *"   # 20 h/day = 620 h  -> 83% of the pool
-#       - cron: "*/10 9-12 * * *"   #  4 h/day = 124 h  -> 17% of the pool
-# and re-do the arithmetic against the CURRENT number of free web services.
+# The fix was never a tighter cron: the facilitator now runs on a paid
+# always-on instance (render.yaml, plan: starter). A keepalive for a service
+# that does not sleep is pure spend. This stays for one purpose — manually
+# waking the FREE-TIER demo seller before a walkthrough.
+
 on:
   workflow_dispatch: {}
-  # ENABLED 2026-08-11, against MEASURED headroom rather than a divisor.
-  #
-  # Billing showed 19.37 h consumed 11 days into the cycle across NINE services
-  # — projecting to ~53 h/month, 7% of the pool. The 750-hour limit had been
-  # treated as a binding constraint for a day and a half of decisions; actual
-  # usage was 2.6% of it. See docs/closing-state.md §3.4e.
-  #
-  # THE ARITHMETIC (750 h/workspace/month, ~30.44 days):
-  #
-  #    8h/day ->  244 h   total  297 h   40% of pool   margin 453 h
-  #   12h/day ->  365 h   total  418 h   56%           margin 332 h
-  #   16h/day ->  487 h   total  540 h   72%           margin 210 h   <- chosen
-  #   20h/day ->  609 h   total  662 h   88%           margin  88 h
-  #   24h/day ->  731 h   total  784 h  105%           OVER BUDGET
-  #
-  # NOTE THE LAST ROW. Even with ~700 hours spare, a single always-on Free
-  # service does not fit: 24/7 is 731 h by itself, 97% of the pool before
-  # anything else runs. "We have plenty spare" and "we can leave it on" are
-  # different claims.
-  #
-  # 16h/day is chosen over 20h not on cost but on MARGIN. The projection is 11
-  # days of one cycle; 210 h absorbs being wrong about it, 88 h does not. The
-  # failure mode is not a slow demo — it suspends every Free service in the
-  # workspace, including unrelated production ones.
-  #
-  # ── THE WINDOW IS A KNOB, NOT A DECISION ─────────────────────────────────
-  #
-  # Every option below costs the SAME 16 h/day. Shifting the window is free —
-  # what changes is which region gets a warm service and which pays the ~50 s
-  # cold start. Pick against where evaluators actually are; nobody knows that
-  # yet, so this is written to be changed rather than defended.
-  #
-  # Local coverage (summer offsets: CEST +2, EDT -4, PDT -7, JST +9, SGT +8):
-  #
-  #   A. "*/5 8-23 * * *"          08:00-23:59 UTC   <- CURRENT
-  #        Europe      10:00-02:00   full working day, plus a dead evening
-  #        US East     04:00-20:00   full working day
-  #        US West     01:00-17:00   full working day
-  #        Japan       17:00-09:00   MISSES the working day entirely
-  #        Singapore   16:00-08:00   MISSES the working day entirely
-  #      Best for: the Americas. Wastes ~4 h on the European night.
-  #
-  #   B. "*/5 0-15 * * *"          00:00-15:59 UTC
-  #        Europe      02:00-18:00   full working day
-  #        US East     20:00-12:00   morning only, misses the afternoon
-  #        US West     17:00-09:00   MISSES the working day almost entirely
-  #        Japan       09:00-01:00   full working day
-  #        Singapore   08:00-00:00   full working day
-  #      Best for: Asia-Pacific + Europe. Trades the US afternoon away.
-  #
-  #   C. "*/5 0-7,12-19 * * *"     00:00-07:59 and 12:00-19:59 UTC  (split)
-  #        Europe      02:00-10:00 and 14:00-22:00   morning + afternoon
-  #        US East     20:00-04:00 and 08:00-16:00   full working day
-  #        US West     17:00-01:00 and 05:00-13:00   morning, misses afternoon
-  #        Japan       09:00-17:00 and 21:00-05:00   full working day
-  #        Singapore   08:00-16:00 and 20:00-04:00   full working day
-  #      Best OVERALL coverage: the only option where APAC, Europe and US East
-  #      all get their working day. Costs the same. The gap is US West
-  #      afternoons and a two-hour European lunch.
-  #
-  # WHAT YOU ARE TRADING, stated plainly: A gives the Americas everything and
-  # Asia-Pacific nothing. B reverses it. C spreads the same 16 hours to cover
-  # three regions' working days at the price of two holes.
-  #
-  # A is in force only because it was chosen before anyone asked where the
-  # traffic comes from. If the first real evaluators are in Asia-Pacific, B or C
-  # is strictly better and the change is one line.
-  #
-  # Winter shifts everything by an hour (CET +1, EST -5, PST -8); JST and SGT do
-  # not observe DST, so A and B get slightly better for APAC in winter and worse
-  # for the US.
-  #
-  # */5 rather than */10 because the ping is FREE: this repo is public, so
-  # GitHub Actions minutes are unmetered, and instance-hours accrue from the
-  # service being awake rather than from how often it is pinged. Scheduled
-  # workflows can be delayed under load, and a 15-minute idle timeout leaves no
-  # room for a 10-minute interval to slip. If this repo ever goes private,
-  # re-check: Actions minutes are then metered at 2,000/month free.
-  # OPTION C, chosen 2026-08-11. Not a compromise between A and B — strictly
-  # better than A at identical cost. A spent four hours a day on the European
-  # evening, when nobody is working, and gave Asia-Pacific nothing.
-  schedule:
-    - cron: "*/5 0-7,12-19 * * *"
 
 permissions:
   contents: read
@@ -199,54 +33,10 @@ concurrency:
 jobs:
   ping:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 2
     steps:
-      # Needed only so `git rev-parse` below has a repo to read: the stale-deploy
-      # check compares the deployed commit against this branch's HEAD. Without
-      # it the comparison silently never runs.
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Ping /health
-        env:
-          # /health is exempt from the per-IP rate limit, so this cannot throttle
-          # real traffic no matter how often it runs.
-          URL: https://vellar-facilitator.onrender.com/health
+      - name: ping facilitator and demo seller
         run: |
-          set -uo pipefail
-          # A cold start takes ~1 minute, so allow for it rather than failing the
-          # very request that is doing the waking up.
-          code=$(curl -sS -o /tmp/body -w '%{http_code}' --max-time 120 --retry 2 --retry-delay 15 "$URL" || echo 000)
-          echo "HTTP $code"
-          cat /tmp/body || true
-          if [ "$code" != "200" ]; then
-            echo "::warning::keepalive ping did not return 200 (got $code) — the service may be suspended or down"
-            exit 0   # never fail the workflow: a red X here is noise, not signal
-          fi
-          # Surface a frozen catalog, which is invisible from the outside otherwise.
-          if grep -q 'catalogFrozen' /tmp/body; then
-            echo "::warning::/health reports catalogFrozen — see docs/operator-runbook.md §2 and §3"
-          fi
-
-          # Did it actually stay awake? /health reports process uptime, so a
-          # value shorter than the ping interval means the container was
-          # replaced since the last ping — i.e. it slept (or redeployed) and the
-          # catalog was wiped. This is how we find out from DATA rather than
-          # from a developer reporting an empty listing.
-          # Is the running build actually what is on this branch? /health reports
-          # the deployed commit, so a stale deploy is a string comparison rather
-          # than something discovered by probing for security headers.
-          deployed=$(sed -n 's/.*"commit":"\([0-9a-f]*\)".*/\1/p' /tmp/body)
-          expected=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "")
-          if [ -n "$deployed" ] && [ -n "$expected" ] && [ "$deployed" != "$expected" ]; then
-            echo "::warning::deployed commit is $deployed but this branch is at $expected — the running build is NOT current"
-          fi
-          echo "deployed=${deployed:-unknown} expected=${expected:-unknown}"
-
-          up=$(sed -n 's/.*"uptimeSeconds":\([0-9]*\).*/\1/p' /tmp/body)
-          size=$(sed -n 's/.*"catalogSize":\([0-9]*\).*/\1/p' /tmp/body)
-          echo "uptimeSeconds=${up:-?} catalogSize=${size:-?}"
-          if [ -n "$up" ] && [ "$up" -lt 900 ]; then
-            echo "::warning::instance uptime is ${up}s — it was replaced since the last ping, so the catalog was wiped. If this recurs outside deploy windows the keep-alive is not holding (GitHub cron delay); switch to an external 5-minute pinger."
-          fi
+          curl -fsS --max-time 90 https://vellar-facilitator.onrender.com/health || true
+          curl -fsS --max-time 90 -o /dev/null -w "seller: %{http_code} in %{time_total}s\n" \
+            https://vellar-seller-demo.onrender.com/whoami || true

--- a/BUILD-PLAN.md
+++ b/BUILD-PLAN.md
@@ -1,5 +1,10 @@
 # Vellar Facilitator — Build Plan
 
+> **HISTORICAL (as of 2026-08-15).** This was the build-phase tracker; the
+> system described here has been built, audited, and operated since. Current
+> truth lives in `README.md`, `technical-doc.md`, and `docs/closing-state.md`.
+> Kept for provenance, not guidance.
+
 Single source of progress for this repo. See `technical-doc.md` for the full
 spec this plan implements. An item is not done without tests, matching the
 standard set in the Vellar wallet repo.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ free service down after 15 minutes without traffic and the container is
 replaced, not paused; measured cold start **44.76 seconds**. You pay it once —
 the service then stays warm for 15 minutes past your last request.
 
-There is a keep-alive workflow, and it does **not** deliver a warm window: it is
-a GitHub Actions cron, and scheduled workflows are best-effort. Asked for a ping
-every 5 minutes, it delivered **6 of 96** inside one 8-hour window, with a
-**47-minute shortest gap** and none under the 15-minute idle timeout. Warm hours
-were advertised here until 2026-08-12 and have been withdrawn; see
-[`using-it.md` § About the cold start](./docs/using-it.md#about-the-cold-start--there-is-no-warm-window).
-Making it real needs an external pinger, not a tighter cron.
+**Update 2026-08-15: the instance is configured always-on** (`render.yaml`
+`plan: starter`) — the cold start above is retired once that deploy is verified
+live; until then, assume it. The keep-alive cron era is over: re-enabled
+2026-08-11 against measured budget headroom, it still never delivered a warm
+window — GitHub's scheduler delivered pings 18–52 minutes apart against a
+15-minute idle timeout (measured again 2026-08-15) — so it spent pool hours on
+a coin flip. Paying for the instance ends the category; the workflow remains
+manual-dispatch only. History: [`using-it.md` § About the cold
+start](./docs/using-it.md#about-the-cold-start--there-is-no-warm-window).
 
 The catalog survives either way: it lives in libSQL/Turso rather than on the
 container, so your listings and ownership bindings are there when it wakes.
@@ -166,11 +168,12 @@ went with every spin-down, taking listings and ownership bindings. Since
 start with the binding intact. An empty catalog now means an empty catalog, not a
 restart — if yours is missing, something else is wrong.
 
-The keep-alive workflow that used to paper over this is **deliberately disabled**
-and stays that way. Free instance hours are pooled per Render *workspace*, and
-running this one warm would consume most of that pool — exhausting it suspends
-**every** free service in the workspace, including unrelated production ones.
-That was never worth it, and durable storage removed the reason to want it.
+The keep-alive workflow's full arc, honestly: disabled at first for workspace
+pool-budget reasons, **re-enabled 2026-08-11** against measured headroom, and
+**retired 2026-08-15** when measurement showed GitHub's cron delivery (18–52
+minute gaps) could never beat the 15-minute idle timeout — hours spent, warmth
+not delivered. The durable catalog had already removed half the reason to want
+it; the paid always-on instance removes the rest.
 
 **Resource-URL ownership is trust-on-first-use.** The first settlement for a
 canonical URL (`origin + pathname`) binds it to that payment's `payTo`; later

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -26,9 +26,9 @@ roles, two scripts, both in `examples/`.
   The facilitator settles in whatever SEP-41 asset you name and ships none of
   its own. Minting one is right for this walkthrough; canonical testnet USDC
   (`CBIELTK6…`) is right when strangers need to transact in something they both
-  already hold. The demo seller's `X402TST` **cannot be acquired by anyone**:
-  its issuer secret no longer exists. See [`using-it.md` § First: bring your own
-  payment asset](./using-it.md#first-bring-your-own-payment-asset).
+  already hold — it is what the hosted demo seller itself now uses. See
+  [`using-it.md` § First: bring your own payment
+  asset](./using-it.md#first-bring-your-own-payment-asset).
 
 - A **payer signer**: a plain classic keypair (`buyer-classic.mjs`) or a Vellar
   smart account with an ed25519 session key (`buyer.mjs`, the "agent with a

--- a/docs/handover-docs-site.md
+++ b/docs/handover-docs-site.md
@@ -14,7 +14,10 @@ item (§6) turned out to be actively wrong rather than merely missing.
 
 **One thing the site gets right — do not "fix" it.** It says the first request
 after idle "can take up to a minute (cold start)" and claims **no warm window**.
-That is correct. The facilitator's own docs claimed warm hours until 2026-08-12
+That was correct when written. **Update 2026-08-15: the facilitator moved to a
+paid always-on instance** (`render.yaml`, keepalive retired) — once verified
+live, the docs site should retire the facilitator cold-start warning too; the
+free-tier demo *seller* still sleeps. The facilitator's own docs claimed warm hours until 2026-08-12
 and the claim was withdrawn as false — the keep-alive delivered 6 of 96 pings,
 shortest gap 47 min against a 15-min idle timeout. Do not import a warm-window
 claim from anywhere. Every fact

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -544,8 +544,12 @@ The output names the stage. Read it literally:
 **The latency is designed behaviour on the free tier**, and is not fixed with a
 keep-alive.
 
-`.github/workflows/keepalive.yml` exists and is deliberately left with no
-`schedule:` trigger. Free instance hours are pooled per **workspace** (750/month,
+`.github/workflows/keepalive.yml` is **manual-dispatch only, retired
+2026-08-15** after its full arc: initially unscheduled (the pool-budget
+reasoning below), re-enabled 2026-08-11 against measured headroom, then retired
+when delivery measurement (18–52 minute ping gaps vs a 15-minute idle timeout)
+showed it spent hours without delivering warmth. The facilitator now runs on a
+paid always-on instance instead. Free instance hours are pooled per **workspace** (750/month,
 shared by every free service), and exhausting the pool **suspends every free
 service in the workspace** — including services unrelated to this one. Keeping
 this facilitator warm 20 h/day would consume 83% of that pool; even 4 h/day is

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -64,14 +64,13 @@ you can mint as much as you want. Correspondingly useless to anyone but you.
 cd examples && node provision-testnet.mjs
 ```
 
-**You cannot use the demo seller's token.** The `X402TST` asset (`CDYCX4PE…`)
-advertised by `vellar-seller-demo` was minted by an issuer keypair generated
-in-process by a throwaway script; that secret no longer exists anywhere. Nobody
-can mint more of it — not you, not us. Reading the contract id out of
-`/discovery/resources` will not help, because the problem is not knowing the id,
-it is that no one can obtain a balance. **A payment to that demo resource cannot
-be built by anyone except its original wallet.** Point your buyer at your own
-seller instead.
+**The demo seller now pays in canonical USDC and is payable by anyone** — it
+makes a fine first target for your buyer. (Historical note, kept because the
+lesson recurs: the demo previously advertised `X402TST`, whose throwaway issuer
+key was destroyed, making that resource permanently unpayable by everyone. Two
+demo assets died that way; USDC ends the pattern because its issuer is not ours
+to destroy. The stale catalog *entry* still shows the old binding — see
+[`diagnosis-demo-listing.md`](./diagnosis-demo-listing.md).)
 
 Making your own takes about two minutes on testnet:
 
@@ -450,6 +449,13 @@ Six things, in the order you will meet them.
 | **6** | **Your first settlement writes to a shared catalog, and the write is one-way** | Know this before you settle, not after — see below |
 
 ### About the cold start — there is no warm window
+
+> **Update 2026-08-15:** the facilitator is configured **always-on**
+> (`render.yaml` `plan: starter`). Once that deploy is verified live, the cold
+> start below is history for the facilitator (the demo *seller* stays on free
+> tier and still sleeps). Until you observe a fast first request yourself,
+> assume the behaviour documented below — it is measured, and the always-on
+> claim is not yet.
 
 This page used to claim a keep-alive held the instance warm during
 `00:00–07:59` and `12:00–19:59 UTC`, and that inside those hours there was

--- a/render.yaml
+++ b/render.yaml
@@ -20,7 +20,14 @@ services:
   - type: web
     name: vellar-facilitator
     runtime: node
-    plan: free
+    # PAID TIER — approved 2026-08-15, deliberately. Free-tier spin-down gave the
+    # first request of every idle period a measured ~45s stall (O-15/O-16), made
+    # ownership verification of sleeping siblings structurally flaky, and the
+    # keepalive workaround burned pool hours without beating the 15-minute idle
+    # timeout (GitHub cron delivery: 18-52 minute gaps, measured 2026-08-15).
+    # $7/month ends the whole category for this service. The demo SELLER remains
+    # on free tier — its cold start is a separate, cheaper-to-tolerate exposure.
+    plan: starter
     buildCommand: "npm install --omit=dev && npm install -g tsx"
     startCommand: "tsx src/server.ts"
     healthCheckPath: /health
@@ -30,13 +37,9 @@ services:
     # findings that are dormant on an ephemeral filesystem (G-5, G-6, G-7), which
     # a real store closes instead. Read that document before enabling any of this.
     #
-    # If you do enable it: uncomment BOTH the `plan: starter` above (replacing `plan: free`) and the
-    # `disk:` block below, together. They are one change: Render only offers
-    # disks on paid instance types, so a disk block under `plan: free` fails to
-    # deploy.
-    #
-    # THIS STARTS BILLING on the next deploy. It is left commented so that
-    # merging this file is never itself the thing that starts charging.
+    # If you do enable it: the plan is already `starter` (2026-08-15), so only
+    # the `disk:` block below needs uncommenting — but read the rejection above
+    # first; Turso already provides durability without activating G-5/G-6/G-7.
     #
     # It fixes TWO independent causes of the empty catalog:
     #   1. no disk  — nothing survives any restart (the disk fixes this);
@@ -61,11 +64,13 @@ services:
         value: "testnet"
       - key: STELLAR_RPC_URL
         value: "https://soroban-testnet.stellar.org"
-      # Raised fee ceiling: policy-governed smart-account payments cost ~130k
-      # stroops; the @x402/stellar default (50k) rejects them. 500k is ~3.9x the
-      # worst REAL settlement measured from this sponsor's own history (127,808)
-      # and bounds worst-case drain per settle at 0.05 XLM. Raise if a heavier
-      # policy legitimately needs it — rejection is loud, not silent.
+      # Raised fee ceiling: policy-governed smart-account payments cost ~140k
+      # stroops of simulated fee; the @x402/stellar default (50k) rejects them.
+      # 500k is ~3.6x the most expensive verified reading (140,331 simulated,
+      # fresh policy wallet; 28,711 is the worst hash-verifiable on-chain charge
+      # — docs/decision-fee-thresholds.md) and bounds worst-case drain per
+      # settle at 0.05 XLM. Raise if a heavier policy legitimately needs it —
+      # rejection is loud, not silent.
       - key: MAX_TX_FEE_STROOPS
         value: "500000"
       # Bazaar catalog persistence — libSQL/Turso, NOT a file and NOT a disk.

--- a/technical-doc.md
+++ b/technical-doc.md
@@ -47,10 +47,12 @@ policy-approved payment refused for being a smart account with programmable
 spending controls. We reproduced it, confirmed it is a facilitator constructor
 option (not a protocol limit), and settled the same payment through a
 facilitator with the ceiling raised. **This facilitator ships with that fixed:
-`MAX_TX_FEE_STROOPS` defaults to 2,000,000.** Measured live: a stacked
-double-policy payment charges 53,535 stroops of fee — above the 50,000 ceiling
-other facilitators sponsor, which is why that class of payment settles here and
-not there.
+`MAX_TX_FEE_STROOPS` defaults to 500,000** — sized from evidence rather than
+picked (a fresh policy-governed wallet simulates at 140,331 stroops; the worst
+hash-verifiable on-chain charge is 28,711 — see
+`docs/decision-fee-thresholds.md`), clearing the policy-payment class by ~3.6x
+while bounding worst-case sponsor drain per settle at 0.05 XLM. Payments above
+the 50,000 ceiling other facilitators sponsor settle here and not there.
 
 **V1 vs. V2 (CAP-0071-02) credential handling.** We confirmed empirically that
 both deployed facilitators we tested accept type-1 (`sorobanCredentialsAddress`)
@@ -135,9 +137,22 @@ ground truth rather than self-reported data:
   verification (a time-of-check/time-of-use guard). Verdict: verified /
   unverified / unknown. A verification-API outage degrades to "unknown" and
   never blocks discovery.
+- **Ownership verification (the anti-squat layer).** The first settlement for a
+  canonical URL binds it to that payment's `payTo` (trust-on-first-use); the
+  facilitator then fetches the resource's own 402 challenge over a hardened,
+  DNS-pinned, SSRF-guarded prober and confirms the challenge names the bound
+  address. A claimant who proves ownership displaces an unverified binding; a
+  once-proven binding is permanently non-displaceable (the takeover guard). The
+  wire reports the full state honestly: `ownerVerified` (currently confirmed),
+  `ownershipState` (`unverified` / `proven-unconfirmed` / `verified`), and
+  `statsSource` disclosing whether settlement counts were witnessed by the
+  running process or inherited from storage. No other Stellar x402
+  implementation, shipped or proposed, verifies listing ownership at the origin.
 - **Ranking + filter.** Search ranks verified results first (stably, within
-  relevance bands); `verified_only=true` hard-filters, on both HTTP and the MCP
-  tools.
+  relevance bands). `verified_only=true` hard-filters — and on a deployment
+  with no verdict source configured it is **refused with an explicit
+  `400 verified_only_unavailable`** rather than answered with a silent empty
+  list; the MCP tools annotate the equivalent condition as data for the model.
 
 Companion on-chain enforcement (an attestation registry and a
 verified-recipient policy that rejects unverified-contract interactions inside
@@ -190,25 +205,35 @@ Implemented, tested, and live:
   auth entries. Wire-conformance tested against unmodified canonical clients.
 - **Bazaar:** `/discovery/resources`, `/discovery/search`, auto-cataloging on
   settle, route-template safety guard, catalog persistence.
-- **Trust layer:** settlement stats, verification annotation with the live
-  wasm-hash TOCTOU check, verified-first ranking, `verified_only` filter.
+- **Trust layer:** settlement stats with provenance disclosure
+  (`statsSource`, `observedSettlements`), TOFU ownership binding with
+  origin-fetch verification and displacement, `ownershipState` tri-state on the
+  wire, verification annotation with the live wasm-hash TOCTOU check,
+  verified-first ranking, honest `verified_only` refusal when unanswerable.
 - **MCP discovery server** (stdio): `x402_list_resources`,
-  `x402_search_resources`, `verified_only` support.
-- **Developer guide + two runnable end-to-end examples** (seller + buyer).
-  Both default to the hosted facilitator and a funded demo merchant, so they
-  run with zero required configuration.
+  `x402_search_resources`, seller text fenced against prompt injection with a
+  per-block nonce (format shared with the Vellar payer-side MCP server).
+- **Developer guide + three runnable end-to-end examples** (seller, classic
+  buyer on the official x402 client at ~12 lines of payment logic, smart-account
+  buyer). One command provisions a merchant, a funded payer, and — with
+  `USE_USDC=1` — canonical testnet USDC acquired from the DEX with no faucet.
+  The seller refuses at boot to write unverifiable entries into shared state,
+  and the hosted demo resource is itself payable in USDC by any stranger.
 - **Deployed:** `https://vellar-facilitator.onrender.com`, dedicated funded
   sponsor account, `render.yaml` blueprint.
 
-Hosted-demo caveats, stated plainly. The instance runs on a free tier that
-sleeps when idle (~1 min cold start on first request). The Bazaar catalog is
-the documented single-instance JSON file store on ephemeral disk — a restart
-or redeploy clears it, so `/discovery/*` can legitimately return an empty
-catalog until the next settled payment re-seeds it (running the bundled
-examples end to end does this). Trust verdicts require `VERIFICATION_API_URL`
-to be configured on the instance; unset, every result reads `unknown` — the
-documented degrade mode (§6), not a fault. The DB-backed catalog and the real
-uptime bar are precisely the funded milestone-1 work (§9).
+Hosted-demo caveats, stated plainly. **The catalog is durable** — libSQL/Turso
+since 2026-08-11, verified across a real spin-down with ownership bindings
+intact; an empty catalog means an empty catalog, not a restart. Historically
+the free tier slept when idle (~45 s cold start, measured); the instance is
+being moved to an always-on paid tier — until that deploy is verified live,
+assume the cold start. Roughly 1 settle in 3 fails at the testnet RPC with
+nothing spent (`TRY_AGAIN_LATER`, diagnosed in
+`docs/diagnosis-settle-failures.md`); clients must retry, and error bodies
+carry the real RPC status. Third-party trust verdicts require
+`VERIFICATION_API_URL`; unset, every verdict reads `unknown` — the documented
+degrade mode (§6), not a fault — and `verified_only` refuses loudly rather
+than serving a misleading empty list.
 
 Proof (Stellar testnet):
 
@@ -222,16 +247,25 @@ Proof (Stellar testnet):
   loop is proven: with the contract attested the agent payment settles; after
   revoke the identical payment is rejected inside `__check_auth` and no funds
   move.
+- Canonical testnet USDC end to end, no faucet: provisioning buys USDC on the
+  DEX from friendbot XLM, and a full x402 payment settles in it — tx
+  `f9b743c5c7bceb0a…` (ledger 4106526), later `cda3cbaa9b4025e7…` (ledger
+  4137813) against the hosted instance, merchant balances reconciling exactly
+  to price × settlements across every attempt, including failed ones.
+- Two upstream defects in `@x402/stellar` found, reproduced, and filed:
+  x402-foundation/x402 #3125 (settle discards the RPC's submission status) and
+  #3158 (the client scheme cannot sign for a Soroban smart account).
 
 ## 9. Path to Mainnet (what the Build Award funds)
 
 The testnet system exists; the grant funds productionization and mainnet
 launch. Three milestones (final = mainnet, per SCF):
 
-1. **Production hardening.** DB-backed Bazaar catalog (replacing the file store,
-   multi-instance ready); operational telemetry + public status dashboard
-   toward the 99%+ target; load-hardening + sequence-number management under
-   concurrent settlement using the fee-bump path.
+1. **Production hardening.** ~~DB-backed Bazaar catalog~~ — **delivered ahead
+   of funding** (libSQL/Turso, live since 2026-08-11, restart-verified).
+   Remaining: operational telemetry + public status dashboard toward the 99%+
+   target; load-hardening + sequence-number management under concurrent
+   settlement using the fee-bump path (channel accounts).
 2. **Upstream + provenance.** `scheme_upto_stellar.md` (the "upto" metered
    scheme spec + implementation) contributed upstream; V2 (CAP-0071-02)
    credential support so passkey-signed x402 payments settle; the provenance


### PR DESCRIPTION
One stale claim found means the last sweep was partial — so this one grepped by **class**, not instance. Beyond the two known items (README keepalive falsehood, stale spec doc), the class-grep caught: render.yaml still citing the D-4-retracted 127,808 as "measured", using-it/guide still describing the demo as advertising dead X402TST, `.env.example` missing the catalog-persistence variables entirely, BUILD-PLAN reading as live status, and the runbook's third copy of the keepalive claim.

## The keepalive split-brain, resolved by decision rather than wording

Three files disagreed with reality (workflow re-enabled 2026-08-11; ran this morning at 18–52 min gaps — every gap past the 15-min idle timeout, so pool hours were burning for ~60% warm odds). **Resolution: `plan: starter` (approved), keepalive retired to manual dispatch** — kept only to wake the free-tier demo seller. All three files now tell the same story including the full arc: disabled → re-enabled on measured budget → retired on measured delivery.

## technical-doc.md — the spec a reviewer would open

- `MAX_TX_FEE_STROOPS` "2,000,000" → **500,000 with its evidence chain** (140,331 simulated / 28,711 charged)
- "JSON file on ephemeral disk, restart clears it" → **durable Turso since 2026-08-11**; milestone-1's DB catalog marked *delivered ahead of funding*
- **Ownership verification added to the trust section** — it wasn't mentioned at all; it's the one capability no other Stellar x402 implementation, shipped or proposed, has
- `verified_only` 400 semantics, current examples reality, recent proof hashes, both filed upstream issues (#3125, #3158)

## Also

`stellar/x402-stellar` confirmed **Apache-2.0** from its LICENSE file — clears the channel-accounts adoption path a competing proposal flagged as AGPL-encumbered.

**Merging this deploys the paid tier** (render.yaml change) — that's intentional and pre-approved. After Render syncs: verify the first idle-period request is fast, then the remaining cold-start warnings retire per the dated notes.

368 tests, typecheck clean, YAML validated.