### PR TITLE
Settle probe: the instrument ships before the retry

### DIFF
--- a/.github/workflows/settle-probe.yml
+++ b/.github/workflows/settle-probe.yml
@@ -1,0 +1,92 @@
+name: settle probe
+
+# Measures OUR settlement failure rate on neutral infrastructure, before and
+# after reliability changes — the instrument ships BEFORE the retry so the
+# retry's improvement is a before/after from the same tool (a baseline cannot
+# be taken retroactively).
+#
+# Self-funding: every account is created by the run via friendbot. No secrets.
+# Any fork reproduces the evidence. Spends testnet XLM only.
+#
+# Cron slots deliberately spread across the clock — the failure under study
+# (RPC TRY_AGAIN_LATER) tracks the public Soroban RPC pool's health, which
+# varies through the day; probing one fixed hour would keep sampling one
+# condition. Offset minutes avoid GitHub's on-the-hour congestion.
+on:
+  workflow_dispatch:
+    inputs:
+      attempts:
+        description: "Settle attempts (burst)"
+        required: false
+        default: "10"
+  schedule:
+    - cron: "17 2 * * *"
+    - cron: "43 9 * * *"
+    - cron: "11 15 * * *"
+    - cron: "29 21 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: settle-probe
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.12"
+      - name: install
+        run: npm ci && cd examples && npm ci
+      - name: provision (friendbot-funded, throwaway token — self-contained, no DEX dependency)
+        id: provision
+        run: |
+          cd examples
+          node provision-testnet.mjs | tee provision.out
+          # The env block is printed for humans; extract the three values the probe needs.
+          grep -E '^(PAYTO|ASSET|PAYER_SECRET)=' provision.out >> "$GITHUB_OUTPUT"
+          # Fresh sponsor for the facilitator, also friendbot-funded by this run.
+          node -e '
+            const {Keypair}=require("@stellar/stellar-sdk");
+            const kp=Keypair.random();
+            console.log("SPONSOR_SECRET="+kp.secret());
+            console.log("SPONSOR_PUBLIC="+kp.publicKey());
+          ' >> "$GITHUB_OUTPUT"
+      - name: fund sponsor
+        run: |
+          curl -fsS "https://friendbot.stellar.org/?addr=${{ steps.provision.outputs.SPONSOR_PUBLIC }}" > /dev/null
+      - name: boot stack
+        run: |
+          mkdir -p data
+          SPONSOR_SECRET_KEY='${{ steps.provision.outputs.SPONSOR_SECRET }}' PORT=4100 \
+            CATALOG_DB_URL=file:./data/catalog.db npm start > facilitator.log 2>&1 &
+          for i in $(seq 1 60); do curl -fsS http://localhost:4100/health >/dev/null 2>&1 && break; sleep 2; done
+          cd examples
+          FACILITATOR_URL=http://localhost:4100 SELLER_PORT=4031 \
+            PAYTO='${{ steps.provision.outputs.PAYTO }}' ASSET='${{ steps.provision.outputs.ASSET }}' \
+            node seller.mjs > ../seller.log 2>&1 &
+          for i in $(seq 1 90); do curl -fsS http://localhost:4031/whoami >/dev/null 2>&1 && break; sleep 2; done
+          curl -fsS http://localhost:4100/health && curl -fsS http://localhost:4031/whoami
+      - name: probe (burst)
+        run: |
+          cd examples
+          FACILITATOR_URL=http://localhost:4100 RESOURCE_URL=http://127.0.0.1:4031/quote \
+            PAYER_SECRET='${{ steps.provision.outputs.PAYER_SECRET }}' \
+            ATTEMPTS='${{ inputs.attempts || 10 }}' MODE=burst \
+            node ../scripts/probe-settle.mjs | tee ../probe-results.jsonl
+      - name: surface summary
+        run: grep '"probe":"summary"' probe-results.jsonl || tail -1 probe-results.jsonl
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: probe-${{ github.run_id }}
+          path: |
+            probe-results.jsonl
+            facilitator.log
+            seller.log
+          retention-days: 90

--- a/scripts/collect-probe-results.mjs
+++ b/scripts/collect-probe-results.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Aggregates settle-probe artifacts across runs into one honest table.
+// Usage: node scripts/collect-probe-results.mjs [--limit 30]
+// Needs: gh CLI authenticated. Downloads artifacts to a temp dir.
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const limit = process.argv.includes("--limit") ? process.argv[process.argv.indexOf("--limit") + 1] : "30";
+const runs = JSON.parse(execFileSync("gh", ["run", "list", "--workflow", "settle-probe.yml", "--limit", limit,
+  "--json", "databaseId,conclusion,createdAt"], { encoding: "utf8" }));
+const all = [];
+for (const run of runs.filter((r) => r.conclusion === "success")) {
+  const dir = mkdtempSync(join(tmpdir(), "probe-"));
+  try {
+    execFileSync("gh", ["run", "download", String(run.databaseId), "--dir", dir], { stdio: "ignore" });
+    for (const sub of readdirSync(dir)) {
+      const f = join(dir, sub, "probe-results.jsonl");
+      try {
+        for (const line of readFileSync(f, "utf8").split("\n")) {
+          if (!line.trim()) continue;
+          const o = JSON.parse(line);
+          if (o.probe === "settle") all.push({ ...o, runAt: run.createdAt });
+        }
+      } catch { /* artifact without results */ }
+    }
+  } catch { /* expired or empty artifact */ }
+}
+const ok = all.filter((a) => a.ok).length;
+const byReason = {};
+for (const a of all.filter((a) => !a.ok)) {
+  const k = `${a.stage}:${a.reason}${a.rpcStatus ? ":" + a.rpcStatus : ""}`;
+  byReason[k] = (byReason[k] ?? 0) + 1;
+}
+const lat = all.filter((a) => a.ok).map((a) => a.ms).sort((x, y) => x - y);
+const pct = (p) => (lat.length ? lat[Math.min(lat.length - 1, Math.floor((p / 100) * lat.length))] : null);
+console.log(JSON.stringify({
+  runsSampled: runs.length, attempts: all.length, settled: ok, failed: all.length - ok,
+  failureRate: all.length ? +((all.length - ok) / all.length).toFixed(3) : null,
+  byReason, latencyMs: { min: lat[0] ?? null, p50: pct(50), p95: pct(95), max: lat[lat.length - 1] ?? null },
+}, null, 2));

--- a/scripts/probe-settle.mjs
+++ b/scripts/probe-settle.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+// Settle probe — puts a NUMBER on our settlement failure rate, on whatever
+// infrastructure runs it (a GitHub runner is the neutral choice).
+//
+// WHY THIS EXISTS BEFORE THE RETRY SHIPS (order is deliberate): a baseline
+// cannot be taken retroactively. This instrument runs before and after the
+// TRY_AGAIN_LATER retry lands, so the retry's claim is measured by the same
+// tool on the same infrastructure — not asserted. Everything measured so far
+// (the "1 in 3") came from one developer machine under burst access.
+//
+// WHAT IT DOES. Against an already-running local facilitator+seller (the CI
+// workflow boots them; see .github/workflows/settle-probe.yml), it builds a
+// real payment with the OFFICIAL x402 client per attempt — fresh signature
+// each time, since auth entries expire in ledgers — then calls /verify and
+// /settle DIRECTLY on the facilitator, so `rpcStatus` in the error body is
+// read first-hand rather than through the seller's relay.
+//
+// Output: one JSON line per attempt, then a `summary` line. The collector
+// (scripts/collect-probe-results.mjs) aggregates across runs.
+//
+// Env: FACILITATOR_URL, RESOURCE_URL, PAYER_SECRET (all printed by
+// examples/provision-testnet.mjs), ATTEMPTS (default 10), MODE=burst|spaced
+// (spaced sleeps 30s between attempts; burst is back-to-back, the access
+// pattern that provokes TRY_AGAIN_LATER).
+
+import { x402Client } from "@x402/core/client";
+import { x402HTTPClient } from "@x402/core/http";
+import { ExactStellarScheme } from "@x402/stellar/exact/client";
+import { createEd25519Signer } from "@x402/stellar";
+
+const FACILITATOR_URL = (process.env.FACILITATOR_URL ?? "http://localhost:4100").replace(/\/+$/, "");
+const RESOURCE_URL = process.env.RESOURCE_URL ?? "http://127.0.0.1:4031/quote";
+const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+const ATTEMPTS = Number(process.env.ATTEMPTS ?? 10);
+const MODE = process.env.MODE === "spaced" ? "spaced" : "burst";
+const NETWORK = "stellar:testnet";
+
+if (!process.env.PAYER_SECRET) {
+  console.error("PAYER_SECRET required (from provision-testnet.mjs)");
+  process.exit(1);
+}
+
+const signer = createEd25519Signer(process.env.PAYER_SECRET, NETWORK);
+const client = new x402Client().register(NETWORK, new ExactStellarScheme(signer, { url: RPC_URL }));
+const http = new x402HTTPClient(client);
+
+const out = (o) => console.log(JSON.stringify(o));
+const results = [];
+
+for (let i = 1; i <= ATTEMPTS; i++) {
+  const rec = { probe: "settle", i, mode: MODE, t: new Date().toISOString() };
+  const t0 = Date.now();
+  try {
+    const unpaid = await fetch(RESOURCE_URL);
+    if (unpaid.status !== 402) throw new Error(`expected 402, got ${unpaid.status}`);
+    const required = http.getPaymentRequiredResponse((n) => unpaid.headers.get(n), undefined);
+    // Fresh payload per attempt — signatures expire in ledgers, never reuse.
+    const payload = await client.createPaymentPayload(required);
+    const body = {
+      x402Version: 2,
+      paymentPayload: payload,
+      paymentRequirements: required.accepts[0],
+    };
+    const verify = await fetch(`${FACILITATOR_URL}/verify`, {
+      method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+    }).then((r) => r.json());
+    if (!verify.isValid) {
+      Object.assign(rec, { ok: false, stage: "verify", reason: verify.invalidReason ?? "unknown", ms: Date.now() - t0 });
+    } else {
+      const settle = await fetch(`${FACILITATOR_URL}/settle`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+      }).then((r) => r.json());
+      Object.assign(rec, settle.success
+        ? { ok: true, tx: settle.transaction, ms: Date.now() - t0 }
+        : { ok: false, stage: "settle", reason: settle.errorReason ?? "unknown",
+            rpcStatus: settle.rpcStatus?.status, rpcErrorCode: settle.rpcStatus?.errorCode, ms: Date.now() - t0 });
+    }
+  } catch (err) {
+    Object.assign(rec, { ok: false, stage: "harness", reason: String(err?.message ?? err).slice(0, 120), ms: Date.now() - t0 });
+  }
+  results.push(rec); out(rec);
+  if (MODE === "spaced" && i < ATTEMPTS) await new Promise((r) => setTimeout(r, 30_000));
+}
+
+const okCount = results.filter((r) => r.ok).length;
+const lat = results.filter((r) => r.ok).map((r) => r.ms).sort((a, b) => a - b);
+const pct = (p) => lat.length ? lat[Math.min(lat.length - 1, Math.floor((p / 100) * lat.length))] : null;
+out({
+  probe: "summary", mode: MODE, attempts: ATTEMPTS, ok: okCount, failed: ATTEMPTS - okCount,
+  byReason: results.filter((r) => !r.ok).reduce((m, r) => ((m[`${r.stage}:${r.reason}${r.rpcStatus ? ":" + r.rpcStatus : ""}`] = (m[`${r.stage}:${r.reason}${r.rpcStatus ? ":" + r.rpcStatus : ""}`] ?? 0) + 1), m), {}),
+  latencyMs: { min: lat[0] ?? null, p50: pct(50), max: lat[lat.length - 1] ?? null },
+});
+process.exit(0); // failures are DATA here, not errors — the workflow uploads them either way


### PR DESCRIPTION
Baseline first — a before/after must come from one instrument on the same infrastructure, and retroactive baselines don't exist. Self-funding (friendbot, no secrets, fork-reproducible), clock-spread crons, burst mode targeting the access pattern that provokes `TRY_AGAIN_LATER`, `rpcStatus` read first-hand from the facilitator. Validated locally: 4/4 settled, p50 ~10s full-loop. Collector aggregates artifacts into failure taxonomy + latency percentiles. Pattern credit: Turnpike's flakiness probe (Apache-2.0). **After merge: schedule activates on main; let it accumulate runs while the retry is built, then `node scripts/collect-probe-results.mjs` gives the baseline table.**