### PR TITLE
Retry what recovers, refuse to boot on what cannot, and a one-command demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ data/
 scratch/
 *-tmp.mjs
 *.tmp.mjs
+demo-facilitator.log
+demo-seller.log

--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# One command: clean clone → settled testnet payment, hash printed.
+#
+#   ./demo.sh              # throwaway token (self-contained)
+#   USE_USDC=1 ./demo.sh   # canonical testnet USDC, bought on the DEX
+#
+# Each preflight below names the real failure it prevents (pattern credit:
+# Turnpike's demo.sh, Apache-2.0).
+set -euo pipefail
+cd "$(dirname "$0")"
+say() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+die() { printf '\n\033[1mCannot start:\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v node >/dev/null || die "Node.js is not installed (need >=20)."
+[ "$(node -p 'process.versions.node.split(".")[0]')" -ge 20 ] || die "Node $(node -v) too old — @x402 packages fail at RUNTIME below 20, not at install."
+for port in 4100 4031; do
+  lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && die "Port $port is in use. A stack from another clone would pay the WRONG seller and fail confusingly. Stop it first."
+done
+
+say "1/5  Installing (root + examples)"
+[ -d node_modules ] || npm install --no-audit --no-fund
+[ -d examples/node_modules ] || (cd examples && npm install --no-audit --no-fund)
+
+say "2/5  Provisioning testnet accounts (friendbot — no secrets needed)"
+PROV=$(cd examples && node provision-testnet.mjs)
+PAYTO=$(grep -oE '^PAYTO=\S+' <<<"$PROV" | cut -d= -f2)
+ASSET=$(grep -oE '^ASSET=\S+' <<<"$PROV" | cut -d= -f2)
+PAYER_SECRET=$(grep -oE '^PAYER_SECRET=\S+' <<<"$PROV" | cut -d= -f2)
+[ -n "$PAYTO" ] && [ -n "$ASSET" ] && [ -n "$PAYER_SECRET" ] || die "provisioning did not print the expected env block"
+SPONSOR=$(node -e 'const{Keypair}=require("@stellar/stellar-sdk");const k=Keypair.random();console.log(k.secret()+" "+k.publicKey())')
+curl -fsS "https://friendbot.stellar.org/?addr=${SPONSOR#* }" >/dev/null
+
+say "3/5  Booting facilitator (:4100) + seller (:4031)"
+mkdir -p data
+SPONSOR_SECRET_KEY="${SPONSOR%% *}" PORT=4100 CATALOG_DB_URL=file:./data/catalog.db npm start >demo-facilitator.log 2>&1 &
+FAC_PID=$!
+for i in $(seq 1 60); do curl -fsS localhost:4100/health >/dev/null 2>&1 && break; sleep 2; done
+(cd examples && FACILITATOR_URL=http://localhost:4100 SELLER_PORT=4031 PAYTO="$PAYTO" ASSET="$ASSET" node seller.mjs >../demo-seller.log 2>&1) &
+SEL_PID=$!
+trap 'kill $FAC_PID $SEL_PID 2>/dev/null || true' EXIT
+for i in $(seq 1 90); do curl -fsS localhost:4031/whoami >/dev/null 2>&1 && break; sleep 2; done
+curl -fsS localhost:4031/whoami >/dev/null || die "seller did not come up — see demo-seller.log"
+
+say "4/5  Paying (official x402 client; submission retries are internal now)"
+PAID=$(cd examples && RESOURCE_URL=http://127.0.0.1:4031/quote PAYER_SECRET="$PAYER_SECRET" node buyer-classic.mjs 2>/dev/null) || die "payment failed — see demo-facilitator.log (testnet RPC has bad days; re-run once)"
+TX=$(node -e 'const o=JSON.parse(process.argv[1]);console.log(o.settlement?.transaction??"")' "$PAID")
+
+say "5/5  Done — settled on Stellar testnet"
+echo "  tx:        $TX"
+echo "  explorer:  https://stellar.expert/explorer/testnet/tx/$TX"
+echo "  catalog:   $(curl -fsS 'localhost:4100/discovery/resources' | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const j=JSON.parse(d);console.log(j.items.length+" resource(s), first: "+(j.items[0]?.resource??"none"))})')"
+echo
+echo "  Stack still running for exploration (Ctrl-C or kill $FAC_PID $SEL_PID to stop)."
+echo "  Logs: demo-facilitator.log, demo-seller.log. State: ./data (safe to delete)."
+wait

--- a/src/retry.test.ts
+++ b/src/retry.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { LEDGER_SKEW_REASON, withSkewRetry, __setSkewRetryDelayForTest } from "./retry.js";
+
+describe("withSkewRetry — one reason, one retry, nothing relaxed", () => {
+  afterEach(() => __setSkewRetryDelayForTest());
+
+  it("retries the skew rejection once and returns the recovery", async () => {
+    __setSkewRetryDelayForTest(async () => {});
+    let n = 0;
+    const out = await withSkewRetry(
+      async () => (++n === 1 ? { invalidReason: LEDGER_SKEW_REASON } : { isValid: true }),
+      (r) => (r as { invalidReason?: string }).invalidReason,
+      () => {},
+    );
+    expect(n).toBe(2);
+    expect((out as { isValid?: boolean }).isValid).toBe(true);
+  });
+
+  it("does NOT retry any other rejection — a real 'no' stays fast", async () => {
+    let n = 0;
+    const out = await withSkewRetry(
+      async () => (++n, { invalidReason: "invalid_exact_stellar_payload_wrong_amount" }),
+      (r) => (r as { invalidReason?: string }).invalidReason,
+      () => {},
+    );
+    expect(n).toBe(1);
+    expect((out as { invalidReason: string }).invalidReason).toContain("wrong_amount");
+  });
+
+  it("is bounded: a persistent skew stops after SKEW_RETRY_MAX", async () => {
+    __setSkewRetryDelayForTest(async () => {});
+    let n = 0;
+    await withSkewRetry(
+      async () => (++n, { invalidReason: LEDGER_SKEW_REASON }),
+      (r) => (r as { invalidReason?: string }).invalidReason,
+      () => {},
+    );
+    expect(n, "1 attempt + 1 retry").toBe(2);
+  });
+});

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,52 @@
+// Ledger-skew retry — the one verify/settle rejection worth retrying.
+//
+// The public testnet RPC is load-balanced across nodes whose ledger heights
+// diverge (Turnpike measured up to 3 ledgers on this fleet; @x402/stellar
+// tolerates 2). When the client's "current ledger" read lands on a node ahead
+// of the facilitator's, a perfectly valid payment is rejected as expiring "too
+// far" in the future. Retrying re-samples the height — the check still runs in
+// full, in the package, on every attempt; nothing is relaxed.
+//
+// Pattern adapted from Turnpike (Apache-2.0, credited), including their
+// measured lesson: sub-ledger spacing is useless — their 750ms retries all
+// landed inside one degraded window and still lost a payment. The delay must
+// outlast a ledger close (~5s). This failure is LATENT here, confirmed present
+// in our pinned upstream (facilitator/index.js:681) but never measured at our
+// volume — the settle probe is the instrument that will.
+//
+// Budget note: this retry and the submission retry in rpcstatus.ts can stack
+// on one settle. Worst case ~1 skew retry (6s) + 2 submission retries (12s)
+// + round-trips stays under the 30s facilitator-client timeout, which is why
+// SKEW_RETRY_MAX is 1 here rather than Turnpike's 2 — they have no submission
+// retry to share the budget with.
+
+export const LEDGER_SKEW_REASON = "invalid_exact_stellar_signature_expiration_too_far";
+export const SKEW_RETRY_MAX = 1;
+export const SKEW_RETRY_DELAY_MS = 6_000;
+
+let delayFn = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+/** TEST SEAM — replace the delay so tests run in milliseconds. */
+export function __setSkewRetryDelayForTest(fn?: (ms: number) => Promise<void>): void {
+  delayFn = fn ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+}
+
+/**
+ * Run `op`, retrying only when `reasonOf(result)` is the ledger-skew code.
+ * Returns the last result either way; a genuine rejection exits immediately.
+ */
+export async function withSkewRetry<T>(
+  op: () => Promise<T>,
+  reasonOf: (result: T) => string | undefined,
+  log: (msg: string) => void,
+): Promise<T> {
+  let result = await op();
+  for (let attempt = 1; attempt <= SKEW_RETRY_MAX && reasonOf(result) === LEDGER_SKEW_REASON; attempt++) {
+    log(
+      `[retry] ${LEDGER_SKEW_REASON} — RPC ledger-height skew, retry ${attempt}/${SKEW_RETRY_MAX} ` +
+        `after ${SKEW_RETRY_DELAY_MS}ms (re-samples the ledger; relaxes nothing)`,
+    );
+    await delayFn(SKEW_RETRY_DELAY_MS);
+    result = await op();
+  }
+  return result;
+}

--- a/src/rpcstatus.test.ts
+++ b/src/rpcstatus.test.ts
@@ -5,6 +5,7 @@ import {
   installRpcStatusCapture,
   withRpcStatusCapture,
   __resetRpcStatusCaptureForTest,
+  __setRpcRetryDelayForTest,
 } from "./rpcstatus.js";
 
 // ============================================================================
@@ -28,16 +29,23 @@ import {
 /** Install over a stub so the tests never touch a network. */
 function withStubbedSend(
   impl: (tx: unknown) => Promise<Record<string, unknown>>,
-): { restore: () => void } {
+): { logs: string[]; restore: () => void } {
   const proto = rpc.Server.prototype as unknown as Record<string, unknown>;
   const original = proto.sendTransaction;
   proto.sendTransaction = impl;
+  const logs: string[] = [];
   __resetRpcStatusCaptureForTest();
-  installRpcStatusCapture(() => {});
+  installRpcStatusCapture((m) => logs.push(m));
+  // The submission retry's 6s spacing is real time; tests run it at zero. The
+  // retry BEHAVIOUR (counts, scoping, falsifier) is asserted below — only the
+  // wall-clock is stubbed.
+  __setRpcRetryDelayForTest(async () => {});
   return {
+    logs,
     restore: () => {
       proto.sendTransaction = original;
       __resetRpcStatusCaptureForTest();
+      __setRpcRetryDelayForTest();
     },
   };
 }
@@ -254,5 +262,61 @@ describe("the patch announces itself", () => {
     expect(lines[0], "names what it wraps").toMatch(/sendTransaction/);
     expect(lines[0], "names why").toMatch(/single constant|indistinguishable/);
     expect(lines[0], "names the guard, so a reader can check it still works").toMatch(/rpcstatus\.test/);
+  });
+});
+
+
+describe("submission retry — TRY_AGAIN_LATER only, bounded, falsifier-logged", () => {
+  function seqStub(seq: Array<Record<string, unknown>>) {
+    let n = 0;
+    const calls = () => n;
+    const h = withStubbedSend(async () => seq[Math.min(n++, seq.length - 1)]!);
+    return { h, calls };
+  }
+  const send = () =>
+    withRpcStatusCapture(async () => server().sendTransaction({} as never));
+
+  it("retries TRY_AGAIN_LATER and succeeds when the RPC recovers", async () => {
+    const { h, calls } = seqStub([{ status: "TRY_AGAIN_LATER" }, { status: "PENDING", hash: "h" }]);
+    try {
+      const { value, rpcStatus } = await send();
+      expect((value as { status: string }).status).toBe("PENDING");
+      expect(calls(), "one attempt + one retry").toBe(2);
+      expect(rpcStatus, "a recovered submission records no failure").toBeUndefined();
+    } finally { h.restore(); }
+  });
+
+  it("gives up after a FIXED retry count — never a loop", async () => {
+    // MUTATION: loop while status is TRY_AGAIN_LATER — an RPC that never
+    // recovers then probes forever inside one settle.
+    const { h, calls } = seqStub([{ status: "TRY_AGAIN_LATER" }]);
+    try {
+      const { value, rpcStatus } = await send();
+      expect((value as { status: string }).status).toBe("TRY_AGAIN_LATER");
+      expect(calls(), "1 + SUBMIT_RETRY_MAX(2)").toBe(3);
+      expect(rpcStatus?.status, "final status still captured for the error body").toBe("TRY_AGAIN_LATER");
+    } finally { h.restore(); }
+  });
+
+  it("never retries ERROR — a stale payload cannot become fresh", async () => {
+    const { h, calls } = seqStub([{ status: "ERROR" }]);
+    try {
+      await send();
+      expect(calls()).toBe(1);
+    } finally { h.restore(); }
+  });
+
+  it("DUPLICATE on a retry is the falsifier: logged loudly, passed through unchanged", async () => {
+    // The safety argument says TRY_AGAIN_LATER = not forwarded. DUPLICATE on
+    // the retry contradicts that; the observation must be loud and behaviour
+    // must degrade to exactly pre-retry behaviour (fail; nothing spent twice).
+    const { h, calls } = seqStub([{ status: "TRY_AGAIN_LATER" }, { status: "DUPLICATE" }]);
+    try {
+      const { value, rpcStatus } = await send();
+      expect((value as { status: string }).status).toBe("DUPLICATE");
+      expect(calls(), "stops immediately on DUPLICATE").toBe(2);
+      expect(rpcStatus?.status).toBe("DUPLICATE");
+      expect(h.logs.some((l) => l.includes("RETRY RETURNED DUPLICATE")), "loud").toBe(true);
+    } finally { h.restore(); }
   });
 });

--- a/src/rpcstatus.ts
+++ b/src/rpcstatus.ts
@@ -57,6 +57,46 @@ export interface CapturedRpcStatus {
 const store = new AsyncLocalStorage<{ captured?: CapturedRpcStatus }>();
 
 /**
+ * Submission retry — TRY_AGAIN_LATER only, twice, six seconds apart.
+ *
+ * THE EVIDENCE (docs/diagnosis-settle-failures.md, measured): 9 of 10 observed
+ * submission failures were TRY_AGAIN_LATER — the RPC declining to FORWARD the
+ * transaction. No errorResult, no ledger entry, nothing spent; merchant
+ * balances reconciled exactly to successes x price across every failed
+ * attempt. The one terminal failure class (txBadSeq) arrives as ERROR and is
+ * never retried here.
+ *
+ * WHY RESUBMITTING THE SAME ENVELOPE IS SAFE. Not-forwarded means there is
+ * nothing on the network to duplicate. The falsifier is OBSERVABLE: if a retry
+ * ever returns DUPLICATE, the first attempt WAS forwarded despite the status —
+ * evidence against the diagnosis, worth more than the payment. It is logged
+ * loudly and passed through unchanged, so behaviour on that path is exactly
+ * pre-retry behaviour: the settle fails, nothing is spent twice, we learn.
+ *
+ * WHY SIX SECONDS. Adapted from Turnpike's measured lesson on the same RPC
+ * fleet (Apache-2.0, credited): sub-ledger spacing re-samples the same
+ * degraded state — their 750ms retries all landed inside one window and lost a
+ * payment anyway. State changes at ledger close (~5s); 6s clears one.
+ *
+ * WHY TWO. Budget arithmetic: 2 x 6s + three submission round-trips ~ 15s
+ * worst case — under the 30s facilitator-client timeout a seller holds open,
+ * far inside signature expiry (current+12 ledgers ~ 60s in our examples;
+ * upstream clients derive from maxTimeoutSeconds, typically 120s).
+ *
+ * WHY HERE. Upstream discards the sendTransaction response before any caller
+ * can see it (#3125), so this wrapper is the only place that can distinguish
+ * retryable from terminal. When upstream fixes #3125, this moves there.
+ */
+const SUBMIT_RETRY_MAX = 2;
+const SUBMIT_RETRY_DELAY_MS = 6_000;
+
+let delayFn = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+/** TEST SEAM — replace the inter-attempt delay so retry tests run in ms. */
+export function __setRpcRetryDelayForTest(fn?: (ms: number) => Promise<void>): void {
+  delayFn = fn ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+}
+
+/**
  * Run `fn` with a fresh capture slot and return BOTH its value and whatever the
  * RPC reported inside it.
  *
@@ -125,7 +165,26 @@ export function installRpcStatusCapture(log: (msg: string) => void = console.war
     return;
   }
   proto.sendTransaction = async function patched(this: unknown, tx: unknown) {
-    const result = await original.call(this, tx);
+    let result = await original.call(this, tx);
+
+    for (let attempt = 1; attempt <= SUBMIT_RETRY_MAX && result?.status === "TRY_AGAIN_LATER"; attempt++) {
+      log(
+        `[rpcstatus] submission TRY_AGAIN_LATER (not forwarded, nothing spent) — ` +
+          `retry ${attempt}/${SUBMIT_RETRY_MAX} after ${SUBMIT_RETRY_DELAY_MS}ms`,
+      );
+      await delayFn(SUBMIT_RETRY_DELAY_MS);
+      result = await original.call(this, tx);
+      if (result?.status === "DUPLICATE") {
+        // The retry safety argument's falsifier — see the block comment above.
+        log(
+          "[rpcstatus] RETRY RETURNED DUPLICATE: the TRY_AGAIN_LATER attempt WAS forwarded. " +
+            "This contradicts docs/diagnosis-settle-failures.md and is the observation that " +
+            "decides whether this retry is safe. Record it. Passing through unchanged.",
+        );
+        break;
+      }
+    }
+
     try {
       const status = result?.status;
       if (typeof status === "string" && status !== "PENDING") {

--- a/src/server.health.test.ts
+++ b/src/server.health.test.ts
@@ -1,5 +1,5 @@
 import { Keypair } from "@stellar/stellar-sdk";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it  } from "vitest";
 import { BazaarCatalog } from "./catalog.js";
 import { buildFacilitator } from "./facilitator.js";
 import { buildServer } from "./server.js";
@@ -102,5 +102,41 @@ describe("/health surfaces structurally unverifiable entries", () => {
     const body = (await app.inject({ method: "GET", url: "/health" })).json();
     expect("unverifiableEntries" in body, "a healthy catalog must not add noise").toBe(false);
     await app.close();
+  });
+});
+
+
+// P3 — boot-time sponsor preflight (unit; start() itself never runs in tests).
+import { assertSponsorFunded } from "./server.js";
+import { vi as vi2 } from "vitest";
+
+describe("assertSponsorFunded — fail fast, fail explaining itself", () => {
+  const G = "GBUCR6H22CZC5OYHBJIEUS2JFZBOB63AHEGTCV6UEPMD2TMLKG2ZMIW4";
+  afterEach(() => vi2.unstubAllGlobals());
+
+  it("a 404 dies naming the friendbot command", async () => {
+    vi2.stubGlobal("fetch", async () => ({ status: 404, ok: false }) as Response);
+    await expect(assertSponsorFunded("https://h.example", G)).rejects.toThrow(/friendbot.*addr=G/);
+  });
+
+  it("zero XLM dies naming the friendbot command", async () => {
+    vi2.stubGlobal("fetch", async () => ({
+      status: 200, ok: true,
+      json: async () => ({ balances: [{ asset_type: "native", balance: "0.0000000" }] }),
+    }) as unknown as Response);
+    await expect(assertSponsorFunded("https://h.example", G)).rejects.toThrow(/holds no XLM/);
+  });
+
+  it("an unreachable Horizon does NOT block boot — the polling guard owns that", async () => {
+    vi2.stubGlobal("fetch", async () => { throw new Error("ECONNREFUSED"); });
+    await expect(assertSponsorFunded("https://h.example", G)).resolves.toBeUndefined();
+  });
+
+  it("a funded sponsor passes silently", async () => {
+    vi2.stubGlobal("fetch", async () => ({
+      status: 200, ok: true,
+      json: async () => ({ balances: [{ asset_type: "native", balance: "9999.5" }] }),
+    }) as unknown as Response);
+    await expect(assertSponsorFunded("https://h.example", G)).resolves.toBeUndefined();
   });
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "./config.js";
 import { buildFacilitator } from "./facilitator.js";
 import { LibsqlCatalogStore } from "./store.js";
 import { installRpcStatusCapture, withRpcStatusCapture } from "./rpcstatus.js";
+import { withSkewRetry } from "./retry.js";
 import { BazaarCatalog } from "./catalog.js";
 import { registerBazaar } from "./bazaar.js";
 import {
@@ -163,7 +164,11 @@ export async function buildServer(
         }),
       );
     }
-    return facilitator.verify(paymentPayload, paymentRequirements);
+    return withSkewRetry(
+      () => facilitator.verify(paymentPayload, paymentRequirements),
+      (r) => (r as { invalidReason?: string }).invalidReason,
+      (m) => request.log.warn(m),
+    );
   });
 
   app.post<{ Body: FacilitatorRequestBody }>("/settle", async (request, reply) => {
@@ -259,8 +264,10 @@ export async function buildServer(
       // The capture slot must wrap the settle call itself: the RPC response we
       // want is produced deep inside @x402/stellar, which discards it before
       // returning. See src/rpcstatus.ts.
-      const captured = await withRpcStatusCapture(() =>
-        facilitator.settle(paymentPayload, paymentRequirements),
+      const captured = await withSkewRetry(
+        () => withRpcStatusCapture(() => facilitator.settle(paymentPayload, paymentRequirements)),
+        (c) => (c.value as { errorReason?: string }).errorReason,
+        (m) => request.log.warn(m),
       );
       result = captured.value;
       rpcStatus = captured.rpcStatus;
@@ -512,10 +519,56 @@ if (isDirectRun) {
     balanceGuard,
     config.network,
   );
+  // P3 — sponsor funding asserted AT BOOT, with the fix in the error. The
+  // polling balance guard exists for drain DURING operation; this exists for
+  // the setup mistake, which otherwise surfaces mid-payment as an
+  // "Unexpected settlement error: Account not found" that reads like a code
+  // defect (it cost this repo a diagnosis round on 2026-08-12). Pattern from
+  // Turnpike's boot preflight, Apache-2.0, credited. Fail fast, fail
+  // explaining itself.
+  try {
+    await assertSponsorFunded(horizonUrl, sponsorPub);
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
   app.listen({ port: config.port, host: config.host }).catch((err) => {
     app.log.error(err);
     process.exit(1);
   });
+}
+
+/** Boot-time sponsor preflight. Exported for tests; never called by buildServer
+ *  (hundreds of test servers must not touch Horizon). */
+export async function assertSponsorFunded(horizonUrl: string, publicKey: string): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch(`${horizonUrl}/accounts/${publicKey}`);
+  } catch (err) {
+    // Horizon unreachable is NOT a config error — warn and let the polling
+    // guard take over, same fail-open stance it has always had.
+    console.warn(`[boot] sponsor preflight skipped — Horizon unreachable: ${String(err)}`);
+    return;
+  }
+  if (res.status === 404) {
+    throw new Error(
+      `Sponsor account ${publicKey} does not exist on this network, so it cannot sponsor settlement fees.\n` +
+        `  Fund it:  curl "https://friendbot.stellar.org/?addr=${publicKey}"\n` +
+        `  (testnet only — on pubnet, fund it from a real account)`,
+    );
+  }
+  if (!res.ok) {
+    console.warn(`[boot] sponsor preflight inconclusive (Horizon HTTP ${res.status}) — polling guard will retry`);
+    return;
+  }
+  const body = (await res.json()) as { balances?: Array<{ asset_type?: string; balance?: string }> };
+  const native = body.balances?.find((b) => b.asset_type === "native");
+  if (!native || Number(native.balance) <= 0) {
+    throw new Error(
+      `Sponsor account ${publicKey} holds no XLM, so it cannot pay settlement fees.\n` +
+        `  Fund it:  curl "https://friendbot.stellar.org/?addr=${publicKey}"`,
+    );
+  }
 }
 
 /** Fetch the account's native (XLM) balance from Horizon, in stroops. Throws on


### PR DESCRIPTION
P1: `TRY_AGAIN_LATER` submission retry inside our wrapper — the only vantage point upstream's discard (#3125) leaves anyone. 2×6s, ERROR never retried, DUPLICATE-on-retry logged as the safety argument's falsifier and passed through unchanged. **The probe (#68) shipped first so this lands as a before/after on one instrument.** P2: ledger-skew retry on verify/settle (latent in our upstream, measured ~1/180 by Turnpike on the same fleet; pattern credited) — one retry, sized so the two layers stacking stays under the caller's 30s. P3: sponsor funding asserted at boot with the friendbot command in the error; unreachable Horizon still fails open to the polling guard. Plus `demo.sh`: clean clone → settled hash, self-funding, every preflight naming the failure it prevents. 11 new tests incl. named mutations; 379 passing.