### PR TITLE
Free tier is the reality: starter becomes a priced option behind a loud warning

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -15,10 +15,11 @@ name: keepalive
 #      warm-window claim documented in 2026-08-12; re-enabling did not change
 #      GitHub's delivery.
 #
-# The fix was never a tighter cron: the facilitator now runs on a paid
-# always-on instance (render.yaml, plan: starter). A keepalive for a service
-# that does not sleep is pure spend. This stays for one purpose — manually
-# waking the FREE-TIER demo seller before a walkthrough.
+# The fix was never a tighter cron. The durable fix is a paid always-on
+# instance — approved then RESCINDED for budget 2026-08-15; render.yaml holds
+# the one-line change and its billing warning. Retirement stands on the
+# delivery measurement alone. This stays for one purpose — manually waking the
+# free-tier services before a walkthrough or review.
 
 on:
   workflow_dispatch: {}

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ free service down after 15 minutes without traffic and the container is
 replaced, not paused; measured cold start **44.76 seconds**. You pay it once —
 the service then stays warm for 15 minutes past your last request.
 
-**Update 2026-08-15: the instance is configured always-on** (`render.yaml`
-`plan: starter`) — the cold start above is retired once that deploy is verified
-live; until then, assume it. The keep-alive cron era is over: re-enabled
-2026-08-11 against measured budget headroom, it still never delivered a warm
-window — GitHub's scheduler delivered pings 18–52 minutes apart against a
-15-minute idle timeout (measured again 2026-08-15) — so it spent pool hours on
-a coin flip. Paying for the instance ends the category; the workflow remains
-manual-dispatch only. History: [`using-it.md` § About the cold
+The keep-alive cron era is over: re-enabled 2026-08-11 against measured budget
+headroom, it never delivered a warm window — GitHub's scheduler delivered pings
+18–52 minutes apart against a 15-minute idle timeout (measured 2026-08-15) — so
+it spent pool hours on a coin flip and is retired to manual dispatch. **The
+instance remains on the free tier** (a paid always-on move was approved and
+rescinded for budget the same day; `render.yaml` carries the ready-to-apply
+config behind a loud billing warning). So: assume the ~45s cold start. History:
+[`using-it.md` § About the cold
 start](./docs/using-it.md#about-the-cold-start--there-is-no-warm-window).
 
 The catalog survives either way: it lives in libSQL/Turso rather than on the
@@ -173,7 +173,8 @@ pool-budget reasons, **re-enabled 2026-08-11** against measured headroom, and
 **retired 2026-08-15** when measurement showed GitHub's cron delivery (18–52
 minute gaps) could never beat the 15-minute idle timeout — hours spent, warmth
 not delivered. The durable catalog had already removed half the reason to want
-it; the paid always-on instance removes the rest.
+it; the rest waits on a paid always-on instance, which is budgeted-not-bought
+as of 2026-08-15 (`render.yaml` holds the one-line change and its price).
 
 **Resource-URL ownership is trust-on-first-use.** The first settlement for a
 canonical URL (`origin + pathname`) binds it to that payment's `payTo`; later

--- a/docs/handover-docs-site.md
+++ b/docs/handover-docs-site.md
@@ -14,10 +14,10 @@ item (§6) turned out to be actively wrong rather than merely missing.
 
 **One thing the site gets right — do not "fix" it.** It says the first request
 after idle "can take up to a minute (cold start)" and claims **no warm window**.
-That was correct when written. **Update 2026-08-15: the facilitator moved to a
-paid always-on instance** (`render.yaml`, keepalive retired) — once verified
-live, the docs site should retire the facilitator cold-start warning too; the
-free-tier demo *seller* still sleeps. The facilitator's own docs claimed warm hours until 2026-08-12
+That is correct and remains the state to document: free tier, ~45s cold start,
+no warm window, keepalive manual-only. (An always-on move was approved and
+rescinded for budget on 2026-08-15; if it is ever bought and verified live, THEN
+retire the cold-start warning — not before.) The facilitator's own docs claimed warm hours until 2026-08-12
 and the claim was withdrawn as false — the keep-alive delivered 6 of 96 pings,
 shortest gap 47 min against a 15-min idle timeout. Do not import a warm-window
 claim from anywhere. Every fact

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -548,8 +548,10 @@ keep-alive.
 2026-08-15** after its full arc: initially unscheduled (the pool-budget
 reasoning below), re-enabled 2026-08-11 against measured headroom, then retired
 when delivery measurement (18–52 minute ping gaps vs a 15-minute idle timeout)
-showed it spent hours without delivering warmth. The facilitator now runs on a
-paid always-on instance instead. Free instance hours are pooled per **workspace** (750/month,
+showed it spent hours without delivering warmth. The durable fix is a paid
+always-on instance — approved then rescinded for budget on 2026-08-15, with the
+ready-to-apply (and billing-starting) config preserved in `render.yaml`. Until
+bought: free tier, ~45s cold start, keepalive manual-only. Free instance hours are pooled per **workspace** (750/month,
 shared by every free service), and exhausting the pool **suspends every free
 service in the workspace** — including services unrelated to this one. Keeping
 this facilitator warm 20 h/day would consume 83% of that pool; even 4 h/day is

--- a/docs/using-it.md
+++ b/docs/using-it.md
@@ -450,12 +450,9 @@ Six things, in the order you will meet them.
 
 ### About the cold start — there is no warm window
 
-> **Update 2026-08-15:** the facilitator is configured **always-on**
-> (`render.yaml` `plan: starter`). Once that deploy is verified live, the cold
-> start below is history for the facilitator (the demo *seller* stays on free
-> tier and still sleeps). Until you observe a fast first request yourself,
-> assume the behaviour documented below — it is measured, and the always-on
-> claim is not yet.
+> **Status 2026-08-15:** still free tier — an always-on move was approved and
+> rescinded for budget the same day; `render.yaml` carries the ready one-line
+> change behind a billing warning. Everything below remains current behaviour.
 
 This page used to claim a keep-alive held the instance warm during
 `00:00–07:59` and `12:00–19:59 UTC`, and that inside those hours there was

--- a/render.yaml
+++ b/render.yaml
@@ -20,14 +20,17 @@ services:
   - type: web
     name: vellar-facilitator
     runtime: node
-    # PAID TIER — approved 2026-08-15, deliberately. Free-tier spin-down gave the
-    # first request of every idle period a measured ~45s stall (O-15/O-16), made
-    # ownership verification of sleeping siblings structurally flaky, and the
-    # keepalive workaround burned pool hours without beating the 15-minute idle
-    # timeout (GitHub cron delivery: 18-52 minute gaps, measured 2026-08-15).
-    # $7/month ends the whole category for this service. The demo SELLER remains
-    # on free tier — its cold start is a separate, cheaper-to-tolerate exposure.
-    plan: starter
+    # ── PLAN: FREE — DELIBERATELY, FOR BUDGET, 2026-08-15 ────────────────────
+    # A move to `starter` was approved and then RESCINDED the same day: the $7
+    # is not currently in the budget. The analysis stands (free-tier spin-down
+    # = ~45s cold start, O-15/O-16; the keepalive cron cannot beat the
+    # 15-minute idle timeout — 18-52 minute delivery gaps measured), so the
+    # moment budget exists, the change below is the whole fix.
+    #
+    #   ⚠ CHANGING THE LINE BELOW TO `plan: starter` STARTS BILLING (~$7/mo)
+    #   ⚠ ON THE NEXT BLUEPRINT SYNC. Do not apply it casually; do not let a
+    #   ⚠ routine sync be the thing that starts a charge.
+    plan: free
     buildCommand: "npm install --omit=dev && npm install -g tsx"
     startCommand: "tsx src/server.ts"
     healthCheckPath: /health

--- a/technical-doc.md
+++ b/technical-doc.md
@@ -224,10 +224,11 @@ Implemented, tested, and live:
 
 Hosted-demo caveats, stated plainly. **The catalog is durable** — libSQL/Turso
 since 2026-08-11, verified across a real spin-down with ownership bindings
-intact; an empty catalog means an empty catalog, not a restart. Historically
-the free tier slept when idle (~45 s cold start, measured); the instance is
-being moved to an always-on paid tier — until that deploy is verified live,
-assume the cold start. Roughly 1 settle in 3 fails at the testnet RPC with
+intact; an empty catalog means an empty catalog, not a restart. The free tier
+sleeps when idle (~45 s cold start, measured; no reliable warm window — the
+keepalive cron measurably cannot beat the idle timeout and is retired to
+manual). An always-on move is specified and priced in `render.yaml`, pending
+budget. Roughly 1 settle in 3 fails at the testnet RPC with
 nothing spent (`TRY_AGAIN_LATER`, diagnosed in
 `docs/diagnosis-settle-failures.md`); clients must retry, and error bodies
 carry the real RPC status. Third-party trust verdicts require


### PR DESCRIPTION
The paid move was approved then rescinded for budget the same day — but #67's `plan: starter` would start billing on the next blueprint sync. Reverted to `plan: free` with the one-line fix preserved above it behind a ⚠ billing warning. All seven files that implied always-on now state the actual state (free, ~45s cold start, no warm window, keepalive manual). Keepalive retirement rewritten to stand on the delivery measurement alone. Residue-grepped; the two remaining 'always-on' strings are pre-existing and accurate.