### PR TITLE
Probe control arm: the true 'before' runs concurrently with the 'after'

### DIFF
--- a/.github/workflows/settle-probe.yml
+++ b/.github/workflows/settle-probe.yml
@@ -36,6 +36,18 @@ jobs:
   probe:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # The controlled A/B: both arms every cycle, same clock, same RPC
+        # conditions. retries-off boots the facilitator with the retry knobs at
+        # zero — pre-retry behaviour, the true "before" — so no waiting period
+        # is needed to compare.
+        variant: [retries-on, retries-off]
+    env:
+      PROBE_VARIANT: ${{ matrix.variant }}
+      SUBMIT_RETRY_MAX: ${{ matrix.variant == 'retries-off' && '0' || '2' }}
+      SKEW_RETRY_MAX: ${{ matrix.variant == 'retries-off' && '0' || '1' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -84,7 +96,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: probe-${{ github.run_id }}
+          name: probe-${{ github.run_id }}-${{ matrix.variant }}
           path: |
             probe-results.jsonl
             facilitator.log

--- a/scripts/collect-probe-results.mjs
+++ b/scripts/collect-probe-results.mjs
@@ -27,6 +27,23 @@ for (const run of runs.filter((r) => r.conclusion === "success")) {
     }
   } catch { /* expired or empty artifact */ }
 }
+// Group by variant: "retries-on" vs "retries-off" is the controlled A/B.
+const variants = {};
+for (const a of all) (variants[a.variant ?? "default"] ??= []).push(a);
+const table = {};
+for (const [v, rows] of Object.entries(variants)) {
+  const okV = rows.filter((r) => r.ok).length;
+  const br = {};
+  for (const r of rows.filter((r) => !r.ok)) {
+    const k = `${r.stage}:${r.reason}${r.rpcStatus ? ":" + r.rpcStatus : ""}`;
+    br[k] = (br[k] ?? 0) + 1;
+  }
+  const lv = rows.filter((r) => r.ok).map((r) => r.ms).sort((x, y) => x - y);
+  const pv = (p) => (lv.length ? lv[Math.min(lv.length - 1, Math.floor((p / 100) * lv.length))] : null);
+  table[v] = { attempts: rows.length, settled: okV, failed: rows.length - okV,
+    failureRate: rows.length ? +((rows.length - okV) / rows.length).toFixed(3) : null,
+    byReason: br, latencyMs: { min: lv[0] ?? null, p50: pv(50), p95: pv(95), max: lv[lv.length - 1] ?? null } };
+}
 const ok = all.filter((a) => a.ok).length;
 const byReason = {};
 for (const a of all.filter((a) => !a.ok)) {
@@ -36,6 +53,13 @@ for (const a of all.filter((a) => !a.ok)) {
 const lat = all.filter((a) => a.ok).map((a) => a.ms).sort((x, y) => x - y);
 const pct = (p) => (lat.length ? lat[Math.min(lat.length - 1, Math.floor((p / 100) * lat.length))] : null);
 console.log(JSON.stringify({
+  provenance:
+    "Single-instrument A/B: retries-on vs retries-off run CONCURRENTLY each cycle on the same " +
+    "crons and RPC conditions, retries-off being pre-retry behaviour (the true 'before'). Any " +
+    "earlier figures (docs/diagnosis-settle-failures.md, the '1 in 3') are a DIFFERENT " +
+    "instrument on different infrastructure — one machine, burst access. Acceptable baseline, " +
+    "not a controlled comparison; only the variants table below is.",
+  byVariant: table,
   runsSampled: runs.length, attempts: all.length, settled: ok, failed: all.length - ok,
   failureRate: all.length ? +((all.length - ok) / all.length).toFixed(3) : null,
   byReason, latencyMs: { min: lat[0] ?? null, p50: pct(50), p95: pct(95), max: lat[lat.length - 1] ?? null },

--- a/scripts/probe-settle.mjs
+++ b/scripts/probe-settle.mjs
@@ -48,7 +48,7 @@ const out = (o) => console.log(JSON.stringify(o));
 const results = [];
 
 for (let i = 1; i <= ATTEMPTS; i++) {
-  const rec = { probe: "settle", i, mode: MODE, t: new Date().toISOString() };
+  const rec = { probe: "settle", i, mode: MODE, variant: process.env.PROBE_VARIANT ?? "default", t: new Date().toISOString() };
   const t0 = Date.now();
   try {
     const unpaid = await fetch(RESOURCE_URL);
@@ -86,7 +86,7 @@ const okCount = results.filter((r) => r.ok).length;
 const lat = results.filter((r) => r.ok).map((r) => r.ms).sort((a, b) => a - b);
 const pct = (p) => lat.length ? lat[Math.min(lat.length - 1, Math.floor((p / 100) * lat.length))] : null;
 out({
-  probe: "summary", mode: MODE, attempts: ATTEMPTS, ok: okCount, failed: ATTEMPTS - okCount,
+  probe: "summary", mode: MODE, variant: process.env.PROBE_VARIANT ?? "default", attempts: ATTEMPTS, ok: okCount, failed: ATTEMPTS - okCount,
   byReason: results.filter((r) => !r.ok).reduce((m, r) => ((m[`${r.stage}:${r.reason}${r.rpcStatus ? ":" + r.rpcStatus : ""}`] = (m[`${r.stage}:${r.reason}${r.rpcStatus ? ":" + r.rpcStatus : ""}`] ?? 0) + 1), m), {}),
   latencyMs: { min: lat[0] ?? null, p50: pct(50), max: lat[lat.length - 1] ?? null },
 });

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -21,7 +21,8 @@
 // retry to share the budget with.
 
 export const LEDGER_SKEW_REASON = "invalid_exact_stellar_signature_expiration_too_far";
-export const SKEW_RETRY_MAX = 1;
+// Env-tunable only for the probe's control arm — see rpcstatus.ts. Clamped 0-1.
+export const SKEW_RETRY_MAX = Math.min(1, Math.max(0, Number(process.env.SKEW_RETRY_MAX ?? 1) || 0));
 export const SKEW_RETRY_DELAY_MS = 6_000;
 
 let delayFn = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));

--- a/src/rpcstatus.ts
+++ b/src/rpcstatus.ts
@@ -87,7 +87,11 @@ const store = new AsyncLocalStorage<{ captured?: CapturedRpcStatus }>();
  * can see it (#3125), so this wrapper is the only place that can distinguish
  * retryable from terminal. When upstream fixes #3125, this moves there.
  */
-const SUBMIT_RETRY_MAX = 2;
+// Env-tunable ONLY for the probe's control arm (SUBMIT_RETRY_MAX=0 boots a
+// facilitator with pre-retry behaviour, so the A/B runs both arms on the same
+// crons and infrastructure). Production default unchanged; clamped 0-2 so the
+// knob cannot widen the budget, only close it.
+const SUBMIT_RETRY_MAX = Math.min(2, Math.max(0, Number(process.env.SUBMIT_RETRY_MAX ?? 2) || 0));
 const SUBMIT_RETRY_DELAY_MS = 6_000;
 
 let delayFn = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));


### PR DESCRIPTION
Answers 'is there a cheap way to get a true before' with: cheaper than proposed — a `retries-off` matrix job (retry knobs clamped to zero = pre-retry behaviour) beside `retries-on` in every cycle. Same crons, same RPC conditions, one instrument, no delay. Knobs are probe-only and clamp downward — config can close the budget, never widen it; production defaults unchanged and still test-asserted. Collector groups `byVariant` and embeds the provenance note in every generated table: the diagnosis doc's '1 in 3' is a different instrument on different infrastructure — acceptable baseline, not a controlled comparison.