### PR TITLE
Record the voluntary-rotation proposal in the build plan and spec

### DIFF
--- a/BUILD-PLAN.md
+++ b/BUILD-PLAN.md
@@ -137,3 +137,31 @@ HTTP history API + public RPC — no cross-repo code dependency._
 - No claims beyond what's actually tested and running — this project exists
   because a hosted facilitator overclaimed compatibility it didn't have
   (technical-doc.md §2); do not repeat that mistake here.
+
+## Phase 6 — Voluntary rotation for verified bindings (proposed 2026-08-17)
+
+_Added after the HISTORICAL freeze at the top of this file — this section is
+live planning, not archive. Closes half of O-17
+(`docs/closing-state.md`): a legitimate merchant who still holds their old
+signing key gets an in-band path to rotate a verified binding. The other
+half — the key is lost — has no in-band answer; confirmed independently by
+auditing an alternative design in a competing implementation
+(`docs/competitor-study-rail402.md` §2.1, corrected) as well as by our own
+one-way latch. That half stays an operator procedure, tracked separately and
+not yet written up as its own proposal._
+
+Full design and implementation plan: `docs/proposal-voluntary-rotation.md`.
+
+- [ ] `rotation_authorization` table + store methods (record / lookup /
+      consume), alongside the existing `ownership` table
+- [ ] `BazaarCatalog` in-memory tracking + the one-line bypass in
+      `tryDisplace`, with mutation-guarded tests (expired, already-consumed,
+      and wrong-owner markers must all still be refused)
+- [ ] Settle-time hook in `bazaar.ts`, gated on the three-way match
+      (authenticated `result.payer` == claimed `oldPayTo` == current
+      `entry.ownerPayTo`) — the one place a shortcut becomes a
+      vulnerability, so its own dedicated test
+- [ ] `examples/rotate-classic.mjs` — proves the mechanism needs no new
+      client code for a classic old-owner
+- [ ] `operator-runbook.md` addition distinguishing this self-service path
+      from §1, which stays the lost-key/emergency procedure

--- a/BUILD-PLAN.md
+++ b/BUILD-PLAN.md
@@ -165,3 +165,30 @@ Full design and implementation plan: `docs/proposal-voluntary-rotation.md`.
       client code for a classic old-owner
 - [ ] `operator-runbook.md` addition distinguishing this self-service path
       from §1, which stays the lost-key/emergency procedure
+
+## Phase 7 — Ecosystem transaction explorer (proposed 2026-08-17)
+
+_Public visibility into x402 settlements — "people can see transactions
+done." Scoped ecosystem-wide (any Stellar facilitator's traffic, not just
+ours); a comparable public explorer at `tolgayayci/rail402/apps/explorer`
+was studied source-level for engineering reference (RPC event-polling,
+attribution-from-signer-set, fee-sponsorship heuristics), but the
+architecture and phasing below are our own. Full design, architecture
+mapping onto this repo's stack, and cost/risk analysis:
+`docs/proposal-ecosystem-explorer.md`. New service, own hosting — nothing
+here authorizes provisioning or spend; that stays a separate decision._
+
+- [ ] Phase 1 — our own settlements only: a settle-time hook (same
+      fire-and-forget shape as `tryDisplace`/`reverify` in `bazaar.ts`)
+      writes a row with zero classification uncertainty; `/feed`,
+      `/tx/:hash`, `/stats` on a new service, `@libsql/client`-backed
+- [ ] Phase 2 — live-tail ingestion (`getEvents` poll) + a structural
+      classifier (exact/upto pattern match) on testnet, registered against
+      our own `/supported` only, as an independent corroboration of Phase 1
+- [ ] Phase 3 — full attribution registry (seed rail402, x402.org; re-probe
+      `/supported` on an interval), `/facilitators`, `/sellers`, enrichment
+      against our own Bazaar catalog (including verification status —
+      rail402's enrichment has no equivalent)
+- [ ] Phase 4 — Horizon backfill, `/ecosystem` + `/ecosystem/timeseries`,
+      pubnet (RPC provider selection + SAC filtering required at pubnet
+      volume, per rail402's measured `getEvents` load)

--- a/docs/proposal-ecosystem-explorer.md
+++ b/docs/proposal-ecosystem-explorer.md
@@ -1,0 +1,238 @@
+# Proposal — an ecosystem-wide x402 transaction explorer
+
+**Status: PROPOSAL. Not approved, not implemented, no code written.** Drafted
+per request, after studying rail402's live explorer
+(`explorer.rail402.dev`, source `tolgayayci/rail402/apps/explorer`) and
+scoping the equivalent for us. Grounded against this repo's `main` — Fastify
+(`src/server.ts`), `@libsql/client` (`src/store.ts`), the existing
+`/supported` introspection endpoint, and the settle-time hook pattern already
+proven in `src/bazaar.ts`.
+
+**Scope, chosen explicitly.** This is the ecosystem-wide design — visibility
+into x402 traffic across *any* Stellar facilitator, not just ours — because
+that's the more useful product for anyone trying to understand x402 activity
+on Stellar as a whole, not because another implementation happens to cover
+that scope. A smaller version (our own settlements only) is a strict subset
+of everything below (skip §2–§3, keep §1 and §5) if priorities change later;
+nothing here forecloses it.
+
+---
+
+## 0. What rail402 actually built
+
+Their explorer is a separate service (`apps/explorer`, ~15 source files) with
+five layers:
+
+1. **Live tail** (`ingest.ts`) — polls Soroban RPC `getEvents` every ~5s for
+   `transfer` contract events, fetches each candidate transaction
+   (`getTransaction`, `xdrFormat: "json"`), decodes the envelope.
+2. **Classifier** (`classify.ts`) — a pure, structural pattern-match over the
+   decoded XDR, no facilitator cooperation required:
+   - `exact` := an `invoke_host_function` op invoking a SAC `transfer(from,
+     to, amount)`, with a detached, **buyer-signed** address-credentialed
+     auth entry, where the signer is distinct from the op/tx/fee source
+     (proves the fee was sponsored — a hallmark of x402, not ordinary wallet
+     activity).
+   - `upto` := an invocation of a *known* settlement contract's `settle`
+     function (the contract address itself is the marker).
+   - Every row is labeled with a `confidence` tier — `x402-shaped`
+     (structurally matches, attribution unknown), `verified-facilitator`, or
+     the operator's own id — and confidence is never silently upgraded past
+     what was actually observed.
+3. **Attribution registry** (`registry.ts`) — facilitators are seeded
+   (config) or self-announce (`POST /announce`), then periodically re-probed
+   via their **own `/supported` endpoint** to learn their real signer set
+   and any advertised `upto` contracts. A transaction's tx-source or
+   fee-source is matched against this signer index to attribute it. Their
+   own rule, stated in the code: *"an announcement is a lead, never a
+   fact"* — only what's independently re-observed counts.
+4. **Horizon backfill** (`horizon.ts`) — a second tier that walks each known
+   facilitator's full account history via Horizon (which retains the whole
+   chain epoch, unlike RPC's shorter retention window, and indexes fee-bump
+   fee-sources as participants — so one walk covers an entire rotating
+   channel-account pool), decoding `envelope_xdr` directly and running it
+   through the same classifier.
+5. **Enrichment** (`enrich.ts`, `catalog-sync.ts`) — joins `payTo` addresses
+   to Bazaar catalog metadata (serviceName, resource, description).
+   Advisory only; a miss or failure never blocks a payment row.
+
+Storage is SQLite (`payments`, `cursors`, `facilitators`, `sellers`,
+`backfill`, `horizon_cursors`). The API (Hono) is read-only: `/feed`,
+`/tx/:hash`, `/sellers`, `/seller/:payTo`, `/asset/:contract`,
+`/facilitators`, `/facilitator/:id`, `/stats`, `/ecosystem`,
+`/ecosystem/timeseries`, `POST /announce`, `/health`, `/metrics`.
+
+Everything here is **read-only observation of public chain data** — the
+service holds no keys and moves no funds. That property carries over
+directly to our version and is worth keeping as a stated invariant, not an
+accident.
+
+---
+
+## 1. Why this doesn't map onto us 1:1 — and what does
+
+Their hardest problem — the classifier and the attribution registry — exists
+because they're reconstructing facts about *other people's* facilitators
+from the outside, with nothing but public ledger bytes. For **our own**
+settlements, that problem doesn't exist: every fact (buyer, seller, amount,
+resource, scheme, tx hash) is already known with certainty the instant
+`/settle` returns, from data we produced ourselves. So the honest shape of
+the build is two genuinely different pieces bolted together:
+
+- **Our own settlements: zero uncertainty.** A settle-time hook, same shape
+  as the existing fire-and-forget calls in `src/bazaar.ts:88-94`
+  (`tryDisplace`, `reverify`), writes a row directly — no classification,
+  no confidence tier, because there's nothing to infer.
+- **Everyone else's traffic: rail402's actual hard problem.** This is where
+  their ingest/classify/registry/backfill machinery is genuinely needed, and
+  where their engineering (the fee-sponsorship heuristic, the muxed-account
+  normalization, the `source_account`-string auth-entry gotcha, the
+  zero-amount `upto` blind spot) is worth reusing conceptually rather than
+  re-deriving from scratch.
+
+Both pieces write into the same store and serve through the same API — the
+split matters for build order and confidence labeling, not for the final
+product.
+
+---
+
+## 2. Proposed architecture for us
+
+### 2.1 Where it lives
+
+**A new service**, not new routes bolted onto `vellar-facilitator`.
+Reasoning: the ingest loop polls continuously and independently of any
+request; a stuck or slow RPC in the explorer must never be able to touch
+facilitator latency, uptime, or its Fastify event loop. Same isolation
+principle already applied to hosting (`render.yaml`) — the facilitator's
+SLA is the thing that must never regress. Proposed name/path:
+`vellar-explorer` (own repo or an `apps/`-style subdirectory if this repo
+becomes a monorepo — a decision this proposal doesn't make).
+
+It reuses this repo's stack, not rail402's:
+
+| Layer | rail402 | Us |
+|---|---|---|
+| HTTP | Hono | Fastify (`@fastify/cors`, `@fastify/helmet`, `@fastify/rate-limit` already proven here) |
+| Storage | SQLite (better-sqlite3) | `@libsql/client` (Turso) — already the store dependency in `src/store.ts`, same durable/embedded-replica story we already operate |
+| Stellar SDK | `@stellar/stellar-sdk` | Same package, already a dependency (`^16.0.1`) |
+| Config | zod + fail-fast | Same pattern already used in `src/config.ts` |
+
+### 2.2 Ingestion — live tail
+
+Directly analogous to `ingest.ts`: poll `getEvents` for `transfer` topics,
+fetch+classify candidate hashes, persist a resumable cursor. Same resumable,
+contained-failure discipline this repo already applies to `/settle` (a
+single bad transaction, or one RPC hiccup, must never stall the loop) —
+this is the same shape as `withRpcStatusCapture` / `withSkewRetry`
+error-containment, applied to a poll loop instead of a request.
+
+### 2.3 Classification
+
+Reuse rail402's structural rules (§0.2) as the starting spec — they're
+public, verified live (their code claims "5/5 true positives, 0 false
+positives over 18 testnet ledgers, 2026-08-13," worth re-verifying
+ourselves rather than taking on faith, per this session's own verification
+discipline). Our `upto` scheme is still in design (the openx402 draft review
+is a separate open item) — the classifier's `upto` branch should be stubbed
+until that scheme is finalized rather than speculatively built against a
+contract shape that doesn't exist yet.
+
+### 2.4 Attribution registry
+
+We already have the introspection endpoint this depends on:
+`GET /supported` (`src/server.ts:143`, `facilitator.getSupported()`) already
+exists and already reports our signer set — the registry's probe target
+requires **zero new work on the facilitator side**. Seed list starts small
+and honest: ourselves, plus any facilitator whose `/supported` we can
+actually probe (rail402, x402.org — both public). Self-serve `/announce`
+can be deferred to a later phase; a hardcoded seed list is a fine v1.
+
+### 2.5 Horizon backfill
+
+Same tier-2 pattern, deferred to a later phase (§3) — it's the piece that
+recovers history older than the RPC retention window, which matters far
+less on a fresh, low-volume explorer than it does for rail402's
+already-running one.
+
+### 2.6 Enrichment
+
+Joins straight into **our own** Bazaar catalog (`src/catalog.ts`) — this is
+actually a stronger position than rail402's, whose enrichment depends on
+*their* facilitator's catalog. Ours already carries `serviceName`,
+`resource`, and now (per the Phase 5 trust layer) verification state — a
+transaction settled through us can be enriched with **verified ownership
+status**, something rail402's enrichment doesn't have at all. That's a real
+differentiation angle, not just parity.
+
+### 2.7 API surface (v1)
+
+A minimal, honest subset of rail402's: `/feed`, `/tx/:hash`, `/stats`,
+`/sellers`, `/facilitators`. Skip `/ecosystem` and `/ecosystem/timeseries`
+(market-share framing) until there's more than one or two attributed
+facilitators in the data — an "ecosystem" chart with one real data point and
+a wall of "unattributed" is not a good look, and rail402 only earned that
+view by running long enough to accumulate it.
+
+---
+
+## 3. Phased build, not one shot
+
+| Phase | Scope | New uncertainty | Effort |
+|---|---|---|---|
+| **1** | Our own settlements only: settle-time hook → store → `/feed`, `/tx/:hash`, `/stats` | None — same certainty as our own `/settle` response | S–M |
+| **2** | Live-tail ingestion + classifier + our own `/supported` as the sole registry entry, so *our* traffic gets independently corroborated (a check on Phase 1, not a replacement for it) | Classifier false-positive/negative risk, scoped to testnet | M |
+| **3** | Full registry (seed rail402 + x402.org) + attribution + `/facilitators`, `/sellers` directory | Attribution correctness depends on `/supported` staying truthful — same trust-but-verify posture as the rest of this codebase | M |
+| **4** | Horizon backfill, `/ecosystem` views, pubnet | Public RPC rate limits/cost on pubnet (rail402 measured this explicitly — see below) | M–L |
+
+Phase 1 alone answers "people can see transactions done" for our own
+traffic with near-zero risk and is worth shipping on its own regardless of
+how far the later phases go.
+
+---
+
+## 4. Costs and risks, stated honestly
+
+- **New hosting.** A second always-on (or scheduled-poll) service is a new
+  line item — flagging this explicitly and early because of the render.yaml
+  paid-tier incident earlier this session: **nothing here should be
+  interpreted as authorization to provision or pay for anything.** Testnet
+  RPC polling is light enough that a free-tier instance is plausible for
+  Phases 1–3; pubnet (Phase 4) is where rail402 had to actively measure and
+  choose an RPC provider (`gateway.fm` over `mainnet.sorobanrpc.com`, by
+  burst-tolerance) and cap watched assets to avoid saturating `getEvents` —
+  a cost/ops decision to make deliberately when we get there, not default
+  into.
+- **RPC load.** Testnet: rail402 measured ~1.6 transfer events/ledger,
+  trivial. Pubnet: ~250/ledger post-protocol-23 (classic payments emit
+  transfer events too) — unfiltered watching is not viable there; filtering
+  to known SAC contracts (USDC/EURC) is required, same as rail402 does.
+- **Storage growth.** Unbounded by default; `@libsql/client` handles this
+  fine at rail402's observed scale, but no retention/pruning policy is
+  proposed here — worth a decision before Phase 4, not before Phase 1.
+- **Classification risk.** Structural matching can misclassify unusual
+  transactions (rail402's own comments flag several hard-won edge cases:
+  muxed accounts, the `source_account`-string auth form, zero-amount `upto`
+  settles emitting no events at all). Confidence tiers exist precisely so a
+  misclassification reads as "structurally x402-shaped, unattributed"
+  rather than as a false claim about a specific facilitator — carrying that
+  discipline over is non-negotiable, not optional polish.
+- **No settlement-path risk.** Everything above is additive and read-only;
+  nothing in this proposal touches `/verify`, `/settle`, or any code path
+  that moves money. Same boundary this repo already holds for the trust
+  layer and the rotation proposal.
+
+---
+
+## 5. What I'm not doing without sign-off
+
+No code, no new service, no repo, no hosting decision. This is the design
+for review — per this session's standing discipline, and explicitly per
+your instruction to document only for now.
+
+---
+
+*Related: `docs/competitor-study-rail402.md` (source-level rail402 audit,
+this explorer not yet covered there — worth folding this section in if that
+dossier gets revisited), `docs/proposal-voluntary-rotation.md` (the other
+currently-open proposal, same "design first, build later" discipline).*

--- a/docs/proposal-voluntary-rotation.md
+++ b/docs/proposal-voluntary-rotation.md
@@ -1,0 +1,201 @@
+# Proposal — voluntary rotation via a marker settlement (Case 1 of O-17)
+
+**Status: PROPOSAL. Not approved, not implemented, no code written.** Drafted
+per request, grounded directly in the current codebase
+(`src/catalog.ts`, verified against `main` at `afbbb28`). Companion to
+`decision-verified-binding-rotation.md`, which this fleshes option D into a
+concrete, implementable design rather than a paragraph of intent.
+
+**Scope reminder, so this isn't read as more than it is.** This solves
+**voluntary rotation only** — the legitimate merchant still holds the old key.
+The lost-key case has no in-band answer (confirmed twice now, independently —
+our own latch and rail402's SEP-1 approach both hit the identical wall) and is
+handled separately, procedurally, in `proposal-operator-rotation-procedure.md`
+(not yet written — see the closing note).
+
+---
+
+## The key insight that makes this cheap
+
+In the `exact` scheme, **`payTo` never signs anything.** It's a receiving
+address. The party that signs is the *payer*. So "make the old owner prove
+they still hold the key" cannot be done by watching them receive — it can only
+be done by making them **act as a payer, once**, for a transaction whose
+payload says who the successor is.
+
+That reframing means rotation doesn't need a new signature-verification
+primitive, a new Soroban contract, or a new endpoint shape. It needs **one
+more settlement through the exact same `/verify` + `/settle` pipeline that
+already runs today**, carrying a payload extension instead of buying a
+resource. `ExactStellarScheme` already authenticates both classic (`G…`) and
+smart-account (`C…`) payers correctly on the verify side — that machinery is
+proven, in production, right now. Rotation just needs to consume it.
+
+## The design
+
+### 1. A marker settlement, not a new mechanism
+
+The old owner (`oldPayTo`) becomes the payer of one **real, small, real-money
+settlement** — priced identically to how any resource is priced, sent to a
+designated marker `payTo` (the sponsor's own address is the simplest choice;
+it never needs a separate account). The payment payload's `extensions` carries:
+
+```json
+{
+  "rotation": {
+    "resourceKey": "<canonicalResourceKey>",
+    "oldPayTo": "<current bound payTo>",
+    "newPayTo": "<successor payTo>",
+    "nonce": "<random, prevents replay>"
+  }
+}
+```
+
+This settles through the **existing** `/verify` → `/settle` path, unmodified.
+No new client code is needed for a classic old-owner — any x402 buyer library
+already does this. A smart-account old-owner hits the **same** construction
+gap our regular smart-account buyers already hit (#3158) and uses the **same**
+hand-rolled workaround `examples/buyer.mjs` already demonstrates. This is not
+a new problem introduced by rotation — it's the existing, already-worked-
+around problem, reused.
+
+### 2. What the facilitator does with it
+
+A new, small durable record — `RotationAuthorization`:
+
+```
+resourceKey · oldPayTo · newPayTo · settledAt · expiresAt · consumed:boolean
+```
+
+Written when a settlement carrying a `rotation` extension confirms on-chain,
+**and only if `oldPayTo` matches the resource's *current* `entry.ownerPayTo`**
+at settlement time — a rotation claim from an account that doesn't currently
+own the resource is meaningless and is dropped, not stored.
+
+### 3. The one change to `tryDisplace`
+
+`src/catalog.ts:923` currently refuses displacement unconditionally once
+`this.everVerified.has(key)` (the one-way latch — `catalog.ts:895` and
+`:928`). This proposal adds exactly one bypass, checked **before** that
+refusal:
+
+```
+if (everVerified.has(key)) {
+  const auth = lookupRotationAuthorization(key, entry.ownerPayTo, claimant);
+  if (auth && !auth.consumed && auth.expiresAt > now) {
+    consume(auth);           // single-use
+    // fall through — do NOT return "skipped". Proceed to the normal
+    // ownership-verification probe for `claimant`, exactly as an
+    // unverified-binding displacement already does.
+  } else {
+    return outcome("skipped", "binding was PROVEN once and is permanently non-displaceable (one-way latch)");
+  }
+}
+```
+
+**Critically, the marker does not itself grant "verified."** It only opens the
+door that the latch otherwise keeps shut. `claimant` still has to pass the
+*existing* Layer-2 probe (its own 402 must name it) before the binding moves
+and re-latches under the new owner. The marker proves *authorization to
+attempt* the handover; the existing mechanism still proves *actual control of
+the endpoint*. Two independent proofs, neither sufficient alone — which is the
+same shape as every other control in this file (TOFU + Layer 2, never one
+alone).
+
+### 4. Bounds, stated explicitly rather than assumed
+
+- **Expiry:** a marker is valid for a short window (proposed: 72 hours) from
+  settlement. Long enough to complete a real rotation, short enough that a
+  stale, forgotten marker doesn't linger as a dormant capability.
+- **Single-use:** consumed the moment it enables a displacement attempt,
+  successful or not — a used or expired marker cannot be replayed.
+- **Scoped to one resource, one successor:** the nonce plus the
+  `(resourceKey, oldPayTo, newPayTo)` triple means one marker cannot be
+  reinterpreted to authorize a different successor or a different resource.
+- **Cost:** one real settlement, sponsored the same way any settlement is —
+  no new fee-sponsorship logic. Cheap in the failure case: if nobody ever
+  rotates, this path never fires and costs nothing beyond the schema.
+
+### 5. Why this doesn't reopen 2C (the takeover case)
+
+A domain buyer or a compromised endpoint has current *control of the
+endpoint* but never had the *old key*. They cannot produce a valid
+`RotationAuthorization` — there is nothing to forge, because the marker
+requires a real, verified settlement authorized by the specific account the
+latch is bound to. This is exactly the "cryptographic continuity a domain
+buyer does not have" property `decision-verified-binding-rotation.md`'s
+option D asked for; this is that option, made concrete enough to build.
+
+---
+
+## What this costs, honestly
+
+- **New storage:** one small table/record type, mirroring the existing
+  ownership-store shape (`store.ts` already has the pattern for durable,
+  restart-surviving state).
+- **New surface on `tryDisplace`:** one lookup, one consume, before the
+  existing refusal. Small, localized, testable the same way every other guard
+  in that function already is (named mutation, red test).
+- **New surface for sellers:** none required for classic old-owners — any
+  x402 client can build this today. Smart-account old-owners need the same
+  hand-rolled signer `buyer.mjs` already provides; nothing new to write.
+- **Does not touch F (lost-key case).** That's a separate, procedural piece —
+  proposed next, per the earlier agreement to do both, not choose one.
+
+## What I'm not doing without sign-off
+
+No code. This is the design for review.
+
+## Implementation plan, if accepted — grounded against `main` @ `afbbb28`
+
+**1. Schema + store method — S, low risk.** A `rotation_authorization` table
+in `store.ts`, alongside the existing `ownership` table (`store.ts:207`), same
+`CREATE TABLE IF NOT EXISTS` pattern already used for every durable addition:
+`resource_key, old_pay_to, new_pay_to, nonce, settled_at, expires_at,
+consumed_at`, primary key on the first four. Three new store methods —
+record / lookup / consume — same shape as `markVerified` (`store.ts:400`).
+
+**2. `BazaarCatalog` wiring + the `tryDisplace` bypass — S, low risk.** An
+in-memory map mirroring `everVerified`, a private helper mirroring
+`latchVerified` (`catalog.ts:887`). The bypass itself inserts directly ahead
+of the existing unconditional reject at `catalog.ts:895` and `:928`, exactly
+as shown in §3 above.
+
+**3. The settle-time hook — S, but this is the one that carries real weight.**
+`bazaar.ts:62-95` already fires two fire-and-forget checks off every
+settlement (`tryDisplace`, `reverify`), void-called side by side for the same
+documented reason: settlement must never wait on either. This becomes a third
+call in the same shape.
+
+THE TRAP, worth stating precisely because it is the one place a shortcut
+becomes a vulnerability: `result.payer` (already destructured at
+`bazaar.ts:62`, used for `recordSettlement`) is the *cryptographically
+authenticated* payer. `extensions.rotation.oldPayTo` is client-echoed
+content — exactly as forgeable as `resource`/`extensions` already are
+elsewhere in this codebase. The record method MUST require a three-way match
+— `result.payer === extensions.rotation.oldPayTo === entry.ownerPayTo` —
+before writing anything, or anyone could claim to be a different account's
+rotation without ever having paid as them. Own test, own mutation guard.
+
+**4. Tests for the new `tryDisplace` branch — S, mechanical.** Valid marker
+→ proceeds; expired → still skipped; already-consumed → skipped; a claimed
+`oldPayTo` that never actually authenticated as the payer → never recorded in
+the first place (proves the three-way match in step 3).
+
+**5. A demo script — XS.** `examples/rotate-classic.mjs`, near-copy of
+`buyer-classic.mjs` with a different destination and a `rotation` extension
+instead of `bazaar`. Proves a classic account needs zero new client code.
+
+**6. Docs — XS.** A short addition to `operator-runbook.md` distinguishing
+this self-service path from §1, which stays the lost-key/emergency procedure.
+
+**Suggested PR split:** (1)+(2) together — tightly coupled, one reviewable
+unit. (3)+(4) alone — small diff, but the security-bearing one, worth
+reviewing without anything else in the frame. (5)+(6) last, and optional.
+Total new code: a couple hundred lines across three files, roughly matched
+by tests — modest next to everything else built this week.
+
+---
+
+*Companion: `decision-verified-binding-rotation.md` (option D, now concrete),
+`proposal-operator-rotation-procedure.md` (Case 2, F — not yet written).*

--- a/technical-doc.md
+++ b/technical-doc.md
@@ -142,8 +142,16 @@ ground truth rather than self-reported data:
   facilitator then fetches the resource's own 402 challenge over a hardened,
   DNS-pinned, SSRF-guarded prober and confirms the challenge names the bound
   address. A claimant who proves ownership displaces an unverified binding; a
-  once-proven binding is permanently non-displaceable (the takeover guard). The
-  wire reports the full state honestly: `ownerVerified` (currently confirmed),
+  once-proven binding is permanently non-displaceable (the takeover guard).
+  **Planned, not yet built:** a self-service rotation path for a merchant who
+  still holds their old signing key (design: `docs/proposal-voluntary-rotation.md`
+  — a marker settlement through the existing verify/settle path, requiring no
+  new signing code for classic accounts and reusing the same smart-account
+  workaround already used elsewhere in this repo). The permanence above stays
+  absolute for the case where the key is lost — that case has no safe in-band
+  answer, confirmed independently against an alternative design in a
+  competing implementation, and remains an operator procedure. The wire
+  reports the full state honestly: `ownerVerified` (currently confirmed),
   `ownershipState` (`unverified` / `proven-unconfirmed` / `verified`), and
   `statsSource` disclosing whether settlement counts were witnessed by the
   running process or inherited from storage. No other Stellar x402
@@ -266,7 +274,9 @@ launch. Three milestones (final = mainnet, per SCF):
    of funding** (libSQL/Turso, live since 2026-08-11, restart-verified).
    Remaining: operational telemetry + public status dashboard toward the 99%+
    target; load-hardening + sequence-number management under concurrent
-   settlement using the fee-bump path (channel accounts).
+   settlement using the fee-bump path (channel accounts); **voluntary
+   rotation for verified bindings** — proposed design at
+   `docs/proposal-voluntary-rotation.md`, not yet implemented.
 2. **Upstream + provenance.** `scheme_upto_stellar.md` (the "upto" metered
    scheme spec + implementation) contributed upstream; V2 (CAP-0071-02)
    credential support so passkey-signed x402 payments settle; the provenance

--- a/technical-doc.md
+++ b/technical-doc.md
@@ -276,7 +276,11 @@ launch. Three milestones (final = mainnet, per SCF):
    target; load-hardening + sequence-number management under concurrent
    settlement using the fee-bump path (channel accounts); **voluntary
    rotation for verified bindings** — proposed design at
-   `docs/proposal-voluntary-rotation.md`, not yet implemented.
+   `docs/proposal-voluntary-rotation.md`, not yet implemented; **a public
+   transaction explorer** — proposed design at
+   `docs/proposal-ecosystem-explorer.md` (own settlements first, then
+   ecosystem-wide attribution across any Stellar facilitator), not yet
+   implemented.
 2. **Upstream + provenance.** `scheme_upto_stellar.md` (the "upto" metered
    scheme spec + implementation) contributed upstream; V2 (CAP-0071-02)
    credential support so passkey-signed x402 payments settle; the provenance


### PR DESCRIPTION
Docs only — no code. Referenced the proposal (`docs/proposal-voluntary-rotation.md`, already on `main`) from the two places forward-looking work is supposed to live:

- **`BUILD-PLAN.md`** — new Phase 6, added *after* the HISTORICAL freeze banner rather than editing archived content. Checklist mirrors the proposal's implementation-plan section exactly.
- **`technical-doc.md`** §6 (Trust Layer) — a 'planned, not yet built' note sitting beside the current permanent-latch description, so the doc doesn't imply this exists yet. §9 (Milestone 1) — listed as a concrete deliverable alongside the other trust/catalog hardening items already there.

Both call out explicitly that this covers only the voluntary-rotation half of O-17. The lost-key half has no in-band answer — confirmed independently by auditing a competing implementation's alternative approach — and stays a separate, not-yet-written operator procedure.