### PR TITLE
feat(bond): wire register_settlement into the settle path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,25 @@ STELLAR_NETWORK=testnet
 # record + wasm hash verification: docs/upto-deployment.md.
 # UPTO_CONTRACT_ID=CDHPA64M73TUTEM4MMHIWIXINBQXH7JJXFGZMGH22VJWFJFROMR6QV2S
 
+# ── Bond escrow ───────────────────────────────────────────────────────────
+# Our deployed `bond-escrow` contract. Set (together with the admin key
+# below — both or neither, boot fails otherwise) ⇒ every settlement is
+# registered with it as part of /settle, giving the payer standing to
+# dispute. Unset ⇒ bonding is entirely inactive, settlement behaves exactly
+# as it does today. Original work, not vendored. Deployment record + wasm
+# hash verification: docs/bond-escrow-deployment.md (currently a testnet
+# proof-of-life only — response window compiled to 5 minutes for that
+# demo, not the 24 hours its own reasoning argues for; see
+# contracts/bond-escrow/src/lib.rs, PLACEHOLDER_RESPONSE_WINDOW_SECONDS).
+# BOND_ESCROW_CONTRACT_ID=CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4
+#
+# The dedicated Stellar secret that signs register_settlement calls.
+# Deliberately NOT SPONSOR_SECRET_KEY — see contracts/bond-escrow/src/lib.rs,
+# initialize's doc-comment, for why the two must stay independently
+# rotatable. Never a testnet demo key in production; generate and fund one
+# specifically for this role.
+# BOND_ESCROW_ADMIN_SECRET_KEY=
+
 # CATALOG_FILE is RETIRED — catalog persistence moved to libSQL/Turso (see
 # "Catalog persistence" below). Setting it now does nothing but warn loudly at
 # boot (config.ts). Left here, commented out, only so anyone who still has it

--- a/src/bond.test.ts
+++ b/src/bond.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from "vitest";
+import { Account, Keypair } from "@stellar/stellar-sdk";
+import { registerSettlement, type BondEscrowOptions, type BondEscrowRpcLike } from "./bond.js";
+
+// register_settlement's live path (simulate → sign → submit → confirm) is proven by the
+// deployment record (docs/bond-escrow-deployment.md — a full register_settlement →
+// deposit → file_dispute → wait → finalize sequence, every transaction independently
+// confirmed on Horizon). These tests pin what this TS wiring layer does BEFORE and AROUND
+// that network round-trip: caller-bug validation, which key actually signs, and the
+// rejected/infrastructure_error split — mirroring upto.test.ts's own philosophy of testing
+// the gate rather than re-proving the network path a real deployment already proved.
+
+const CONTRACT = "CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4"; // the real deployed instance
+const adminKp = Keypair.random();
+const sponsorKp = Keypair.random(); // NEVER passed to registerSettlement — see "which key signs" below
+const PAYER = Keypair.random().publicKey();
+const SELLER = Keypair.random().publicKey();
+const VALID_PAYMENT_ID = "a".repeat(64); // 32 bytes, hex
+
+function options(overrides: Partial<BondEscrowOptions> = {}): BondEscrowOptions {
+  return {
+    contractId: CONTRACT,
+    adminSecretKey: adminKp.secret(),
+    network: "stellar:testnet",
+    maxTransactionFeeStroops: 500_000,
+    ...overrides,
+  };
+}
+
+function validParams() {
+  return {
+    paymentId: VALID_PAYMENT_ID,
+    payer: PAYER,
+    seller: SELLER,
+    resourceKey: "https://example.com/quote",
+    amount: "500000",
+  };
+}
+
+const unreachableServer: BondEscrowRpcLike = {
+  getAccount: async () => {
+    throw new Error("must never be reached in caller-bug-validation tests");
+  },
+  simulateTransaction: async () => {
+    throw new Error("must never be reached");
+  },
+  sendTransaction: async () => {
+    throw new Error("must never be reached");
+  },
+  getTransaction: async () => {
+    throw new Error("must never be reached");
+  },
+};
+
+describe("registerSettlement — caller-bug validation, thrown before any network call", () => {
+  it("rejects a paymentId that is not 32 bytes", async () => {
+    await expect(
+      registerSettlement(options(), { ...validParams(), paymentId: "abcd" }, { server: unreachableServer }),
+    ).rejects.toThrow(/paymentId must be 32 bytes/);
+  });
+
+  it("rejects a paymentId that is not valid hex", async () => {
+    await expect(
+      registerSettlement(
+        options(),
+        { ...validParams(), paymentId: "z".repeat(64) },
+        { server: unreachableServer },
+      ),
+    ).rejects.toThrow(/paymentId must be 32 bytes/); // Buffer.from(..., "hex") silently drops invalid chars, shrinking length
+  });
+
+  it("rejects a malformed payer address", async () => {
+    await expect(
+      registerSettlement(options(), { ...validParams(), payer: "not-an-address" }, { server: unreachableServer }),
+    ).rejects.toThrow(/not a valid Stellar address/);
+  });
+
+  it("rejects a malformed seller address", async () => {
+    await expect(
+      registerSettlement(options(), { ...validParams(), seller: "not-an-address" }, { server: unreachableServer }),
+    ).rejects.toThrow(/not a valid Stellar address/);
+  });
+
+  it("rejects a zero or negative amount", async () => {
+    await expect(
+      registerSettlement(options(), { ...validParams(), amount: "0" }, { server: unreachableServer }),
+    ).rejects.toThrow(/amount must be a positive integer/);
+    await expect(
+      registerSettlement(options(), { ...validParams(), amount: "-1" }, { server: unreachableServer }),
+    ).rejects.toThrow(/amount must be a positive integer/);
+  });
+
+  it("rejects an empty resourceKey", async () => {
+    await expect(
+      registerSettlement(options(), { ...validParams(), resourceKey: "" }, { server: unreachableServer }),
+    ).rejects.toThrow(/resourceKey must not be empty/);
+  });
+});
+
+describe("registerSettlement — which key signs", () => {
+  it("derives the signing/source identity from adminSecretKey, never a sponsor key", async () => {
+    // getAccount(admin.publicKey()) is the first network call registerSettlement makes,
+    // reached even when simulation subsequently fails — genuinely exercising the code path
+    // that decides whose account this call is built from and who will sign it, not just
+    // asserting the two keypairs happen to differ.
+    let accountRequestedFor: string | undefined;
+    const server: BondEscrowRpcLike = {
+      getAccount: async (address) => {
+        accountRequestedFor = address;
+        return new Account(address, "0");
+      },
+      simulateTransaction: async () =>
+        ({ error: "HostError: Error(Auth, InvalidAction)", events: [], id: "1", latestLedger: 1 }) as never,
+      sendTransaction: async () => {
+        throw new Error("must not be reached — simulation already failed");
+      },
+      getTransaction: async () => {
+        throw new Error("must not be reached");
+      },
+    };
+    await registerSettlement(options(), validParams(), { server });
+    expect(accountRequestedFor).toBe(adminKp.publicKey());
+    expect(accountRequestedFor).not.toBe(sponsorKp.publicKey());
+  });
+
+  it("a config built with the sponsor key in adminSecretKey's slot would sign with the sponsor — proving the field is what's read, not a hidden default", async () => {
+    // Not an endorsement of doing this — the opposite: it shows registerSettlement has no
+    // independent notion of "the real admin," it trusts whatever secret is in
+    // opts.adminSecretKey completely. The separation this codebase relies on is enforced by
+    // src/config.ts validating two distinct env vars into two distinct fields (see
+    // config.test.ts's bond-escrow describe block), not by anything in this file refusing a
+    // wrong key — worth being honest that the guarantee lives one layer up.
+    let accountRequestedFor: string | undefined;
+    const server: BondEscrowRpcLike = {
+      getAccount: async (address) => {
+        accountRequestedFor = address;
+        return new Account(address, "0");
+      },
+      simulateTransaction: async () =>
+        ({ error: "HostError: Error(Auth, InvalidAction)", events: [], id: "1", latestLedger: 1 }) as never,
+      sendTransaction: async () => {
+        throw new Error("must not be reached");
+      },
+      getTransaction: async () => {
+        throw new Error("must not be reached");
+      },
+    };
+    await registerSettlement(options({ adminSecretKey: sponsorKp.secret() }), validParams(), { server });
+    expect(accountRequestedFor).toBe(sponsorKp.publicKey());
+  });
+
+  it("BondEscrowOptions has no field a sponsor key could be passed through — structural guarantee", () => {
+    // TypeScript-level proof: this compiles only because `sponsorSecretKey` is not a key of
+    // BondEscrowOptions at all. If someone ever adds one, this line stops compiling and the
+    // test suite catches the regression at typecheck time, not just at review time.
+    const opts = options();
+    // @ts-expect-error — BondEscrowOptions has no sponsorSecretKey field, by design.
+    opts.sponsorSecretKey = sponsorKp.secret();
+    expect(opts.adminSecretKey).toBe(adminKp.secret());
+  });
+});
+
+describe("registerSettlement — rejected vs infrastructure_error", () => {
+  function serverWithSimError(errorMessage: string): BondEscrowRpcLike {
+    return {
+      getAccount: async (address) => new Account(address, "0"),
+      simulateTransaction: async () =>
+        ({ error: errorMessage, events: [], id: "1", latestLedger: 1 }) as never,
+      sendTransaction: async () => {
+        throw new Error("must not be reached — simulation already failed");
+      },
+      getTransaction: async () => {
+        throw new Error("must not be reached");
+      },
+    };
+  }
+
+  it("maps a recognized Error(Contract, #N) to a named rejection with its code", async () => {
+    const result = await registerSettlement(options(), validParams(), {
+      server: serverWithSimError("HostError: Error(Contract, #3)"),
+    });
+    expect(result).toEqual({
+      outcome: "rejected",
+      detail: "SettlementAlreadyRegistered",
+      contractErrorCode: 3,
+    });
+  });
+
+  it("maps NotInitialized (#2) and InvalidAmount (#4) too", async () => {
+    const notInit = await registerSettlement(options(), validParams(), {
+      server: serverWithSimError("HostError: Error(Contract, #2)"),
+    });
+    expect(notInit).toEqual({ outcome: "rejected", detail: "NotInitialized", contractErrorCode: 2 });
+
+    const invalidAmount = await registerSettlement(options(), validParams(), {
+      server: serverWithSimError("HostError: Error(Contract, #4)"),
+    });
+    expect(invalidAmount).toEqual({
+      outcome: "rejected",
+      detail: "InvalidAmount",
+      contractErrorCode: 4,
+    });
+  });
+
+  it("falls back to a generic 'unknown contract error' for an unrecognized code, not a crash", async () => {
+    const result = await registerSettlement(options(), validParams(), {
+      server: serverWithSimError("HostError: Error(Contract, #99)"),
+    });
+    expect(result).toEqual({
+      outcome: "rejected",
+      detail: "unknown contract error #99",
+      contractErrorCode: 99,
+    });
+  });
+
+  it("treats an auth-shaped trap (no Error(Contract,...) match) as rejected with the raw detail", async () => {
+    const result = await registerSettlement(options(), validParams(), {
+      server: serverWithSimError("HostError: Error(Auth, InvalidAction)"),
+    });
+    expect(result.outcome).toBe("rejected");
+    if (result.outcome === "rejected") {
+      expect(result.contractErrorCode).toBeUndefined();
+      expect(result.detail).toContain("Error(Auth, InvalidAction)");
+    }
+  });
+
+  it("reports a thrown network exception as infrastructure_error, not rejected", async () => {
+    const server: BondEscrowRpcLike = {
+      getAccount: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+      simulateTransaction: unreachableServer.simulateTransaction,
+      sendTransaction: unreachableServer.sendTransaction,
+      getTransaction: unreachableServer.getTransaction,
+    };
+    const result = await registerSettlement(options(), validParams(), { server });
+    expect(result.outcome).toBe("infrastructure_error");
+    if (result.outcome === "infrastructure_error") {
+      expect(result.detail).toContain("ECONNREFUSED");
+    }
+  });
+
+  // NOT independently unit-tested here, and deliberately not faked with a placeholder
+  // assertion: everything past a successful simulation — assembleTransaction's fee/resource
+  // handling, a real submission, polling to confirmation, and the true happy path — needs a
+  // genuinely SDK-shaped SimulateTransactionSuccessResponse (real transactionData XDR, a
+  // real footprint) to exercise honestly. Hand-building that XDR just to satisfy a mock
+  // would be effort spent reproducing what a real RPC already does, for a test that still
+  // wouldn't prove anything a hand-crafted mock couldn't be made to say. upto.test.ts made
+  // the same call for the same reason (see this file's header comment) and instead points at
+  // a real deployment record as the proof. This file does the same:
+  // docs/bond-escrow-deployment.md's full register_settlement → deposit → file_dispute →
+  // wait → finalize sequence, every transaction independently confirmed on Horizon, is that
+  // proof for the submission/confirmation/happy-path behavior this describe block would
+  // otherwise need to fake.
+});

--- a/src/bond.ts
+++ b/src/bond.ts
@@ -1,0 +1,277 @@
+// Provider bond escrow wiring for Stellar — calls OUR deployed bond-escrow contract, built
+// from original source (contracts/bond-escrow/, deployment record in
+// docs/bond-escrow-deployment.md), unlike upto.ts's vendored settlement contract.
+//
+// This file wires ONE entry point so far: register_settlement. The design document
+// (docs/proposal-provider-bond.md, Section 6) locks that registration must be synchronous,
+// awaited, and admin-gated — the only thing that ever gives a payer standing to dispute a
+// bond, so a forged registration is a direct path to fabricated slashes. Every other entry
+// point (deposit, withdraw, file_dispute, set_delivery_key, post_receipt, finalize) is
+// deliberately out of scope here; they're independently callable by sellers/payers per the
+// design doc's own reasoning and don't need this facilitator to mediate them.
+//
+// ## The admin key signs this, never the sponsor key — structurally, not just by convention
+//
+// registerSettlement takes `adminSecretKey`, not `sponsorSecretKey`. There is no code path in
+// this file that reads config.sponsorSecretKey at all — the two keys are different fields on
+// FacilitatorConfig (src/config.ts), validated independently, and this function's options type
+// only has a slot for one of them. A caller cannot pass the sponsor key in by accident the way
+// a same-named or same-typed parameter might invite; the field is literally called
+// `adminSecretKey` and there is nothing named `sponsorSecretKey` anywhere in this module for a
+// slip to reach for. See contracts/bond-escrow/src/lib.rs, initialize's doc-comment ("Which
+// key: a dedicated admin key, not the facilitator's payment sponsor key") for the full
+// reasoning: compromising this key lets an attacker forge dispute standing and drain bonded
+// funds — a different blast radius than compromising the payment-sponsor key — and the two
+// must be rotatable independently, which means never being the same secret to begin with.
+//
+// ## Why this call is simpler than upto.ts's settle flow
+//
+// upto's settle relays a BUYER's pre-signed SorobanAuthorizationEntry while the SPONSOR pays
+// the fee as a separate party — two different identities, so the auth entry has to be
+// extracted from the buyer's transaction and forwarded explicitly. register_settlement has
+// only one party: the admin authorizes AND pays its own fee, as the transaction's source
+// account. Soroban's own rule for `require_auth()` on the transaction's source account is
+// satisfied by the classic transaction signature alone — no separate SorobanAuthorizationEntry
+// needs to be constructed or attached, confirmed empirically: this is exactly how
+// `stellar contract invoke --source <admin> -- register_settlement ...` worked without any
+// manual auth-entry handling during this contract's live testnet exercises
+// (docs/bond-escrow-deployment.md). One consequence worth being explicit about: the admin key
+// needs its own small XLM balance to pay register_settlement's fees — it is not fee-sponsored
+// by the payment sponsor. That is a deliberate cost of keeping the two identities genuinely
+// independent, not an oversight.
+//
+// ## Distinguishing "couldn't complete the call" from "the contract said no"
+//
+// A caller (src/bazaar.ts, wired in a later pass) needs to know which happened, because the
+// recovery path differs: an infrastructure failure is plausibly transient and retry-worthy; a
+// contract-level rejection means something is genuinely wrong (a payment_id collision, a
+// negative amount slipping through upstream validation, the contract not yet initialized) and
+// an operator needs to see it, not have it silently retried. The split follows directly from
+// how Soroban actually reports these two cases to the SDK:
+//   - A THROWN exception anywhere in the RPC round-trip (network unreachable, malformed
+//     response, submission failure, confirmation timeout) — the RPC never gave us a considered
+//     answer about the contract's logic. Reported as `infrastructure_error`.
+//   - `rpc.Api.isSimulationError(sim)` returning true — the RPC successfully ran the actual
+//     contract code and it trapped (a `Result::Err` from register_settlement, or an auth
+//     failure). This is caught at SIMULATION time, before anything is ever submitted, so a
+//     rejection here costs nothing on-ledger. Reported as `rejected`, with the contract's own
+//     error code parsed out of the message when it matches Soroban's stable
+//     `Error(Contract, #N)` formatting (the same format observed directly, repeatedly, via the
+//     `stellar` CLI against this exact contract during its live testnet exercises).
+//   - A transaction that simulates successfully but then fails on submission/confirmation is
+//     treated as `infrastructure_error` too, not `rejected` — by the time simulation already
+//     succeeded, a subsequent on-ledger failure means something changed between simulate and
+//     submit (a race, a transient node issue), which is a different, less certain situation
+//     than a deterministic business-rule rejection. This is a deliberate simplification, stated
+//     here rather than left implicit: it will occasionally misclassify a genuine late-breaking
+//     rejection (e.g. a race against a second registration for the same payment_id) as
+//     infrastructure. If that turns out to matter in practice, it needs its own pass to parse
+//     `getTransaction`'s FAILED result for a contract error the same way simulation errors are
+//     parsed below — not attempted here to keep this file's first version bounded.
+
+import {
+  Address,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  xdr,
+} from "@stellar/stellar-sdk";
+
+const PASSPHRASES: Record<string, string> = {
+  "stellar:testnet": "Test SDF Network ; September 2015",
+  "stellar:pubnet": "Public Global Stellar Network ; September 2015",
+};
+
+const DEFAULT_RPC: Record<string, string> = {
+  "stellar:testnet": "https://soroban-testnet.stellar.org",
+  "stellar:pubnet": "https://mainnet.sorobanrpc.com",
+};
+
+/** Only the codes register_settlement can actually return, per
+ *  contracts/bond-escrow/src/lib.rs's Error enum (AlreadyInitialized=1,
+ *  NotInitialized=2, SettlementAlreadyRegistered=3, InvalidAmount=4 — the rest of the
+ *  21-variant enum belongs to other entry points this file doesn't call). Deliberately NOT
+ *  a full duplicate of the Rust enum: keeping this list scoped to what this one call can
+ *  reach avoids two enums that need to stay in lockstep for codes this function can never
+ *  see. An unrecognized code (wrong contract deployed, a future contract version) falls
+ *  back to a generic "unknown contract error #N" rather than silently mislabeling it. */
+const REGISTER_SETTLEMENT_CONTRACT_ERRORS: Record<number, string> = {
+  2: "NotInitialized",
+  3: "SettlementAlreadyRegistered",
+  4: "InvalidAmount",
+};
+
+export interface BondEscrowOptions {
+  /** Our deployed bond-escrow contract (C…). See docs/bond-escrow-deployment.md. */
+  contractId: string;
+  /** The dedicated admin key — NEVER config.sponsorSecretKey. See the header comment. */
+  adminSecretKey: string;
+  network: "stellar:testnet" | "stellar:pubnet";
+  rpcUrl?: string | undefined;
+  /** Reused from config.maxTransactionFeeStroops rather than a new dedicated ceiling — a
+   *  deliberate choice, not an oversight: register_settlement's resource cost (storage
+   *  writes only, no token transfer) is a strict subset of what that ceiling was already
+   *  sized to clear, so a second knob for a smaller number would be complexity without a
+   *  need it currently serves. Revisit if that stops being true. */
+  maxTransactionFeeStroops: number;
+}
+
+export interface RegisterSettlementParams {
+  /** 32 bytes, hex-encoded (64 hex chars). A Stellar transaction hash is already exactly
+   *  32 bytes and already unique per settlement, making it a natural, ready-made source —
+   *  the specific derivation is the calling site's decision (a later pass), not this
+   *  function's; it only requires the shape. */
+  paymentId: string;
+  /** The verified payer's G… address. */
+  payer: string;
+  /** The listing's seller G… address. */
+  seller: string;
+  /** The canonical resource key as a plain string (e.g.
+   *  BazaarCatalog.canonicalResourceKey's output) — UTF-8 encoded here, NOT pre-hashed.
+   *  The contract hashes it on-ledger itself; see contracts/bond-escrow/src/lib.rs's
+   *  "Resource-key encoding" section for why. */
+  resourceKey: string;
+  /** Settled amount, atomic units. Must be a positive integer as a string or bigint —
+   *  the contract itself rejects <= 0 (InvalidAmount), but malformed input (not an
+   *  integer at all) is this function's own caller's bug and throws synchronously rather
+   *  than being reported as a `rejected` outcome, which is reserved for the contract
+   *  actually running and saying no. */
+  amount: string | bigint;
+}
+
+export type RegisterSettlementResult =
+  | { outcome: "registered"; transaction: string }
+  | {
+      outcome: "rejected";
+      /** Human-readable detail — either a recognized contract error name or the raw
+       *  (truncated) simulation error string when the code isn't one of the three above. */
+      detail: string;
+      /** The numeric Soroban contract error code, when the failure was parseable as
+       *  `Error(Contract, #N)`. Absent for an auth-shaped trap or an unparseable message. */
+      contractErrorCode?: number;
+    }
+  | { outcome: "infrastructure_error"; detail: string };
+
+/** TEST SEAM — same shape and purpose as upto.ts's UptoRpcLike: the network touchpoints,
+ *  injectable so this function is testable without a real RPC. */
+export interface BondEscrowRpcLike {
+  getAccount(address: string): Promise<ConstructorParameters<typeof TransactionBuilder>[0]>;
+  simulateTransaction(tx: unknown): Promise<rpc.Api.SimulateTransactionResponse>;
+  sendTransaction(tx: unknown): Promise<{ status: string; hash: string }>;
+  getTransaction(hash: string): Promise<{ status: string }>;
+}
+
+/** Soroban's own stable error-message formatting for a contract-level trap, observed
+ *  directly and repeatedly against this exact contract via the `stellar` CLI during its
+ *  live testnet exercises (docs/bond-escrow-deployment.md) — e.g. "Error(Contract, #8)". */
+const CONTRACT_ERROR_PATTERN = /Error\(Contract, #(\d+)\)/;
+
+function parseContractError(rawMessage: string): { code: number; name: string } | undefined {
+  const match = CONTRACT_ERROR_PATTERN.exec(rawMessage);
+  if (!match || !match[1]) return undefined;
+  const code = Number(match[1]);
+  return { code, name: REGISTER_SETTLEMENT_CONTRACT_ERRORS[code] ?? `unknown contract error #${code}` };
+}
+
+/** Register a settlement with the bond-escrow contract, giving its payer standing to later
+ *  file a dispute. Synchronous by design — the caller (src/bazaar.ts, a later pass) awaits
+ *  this before treating a settlement as fully complete. See the header comment for the full
+ *  reasoning on the admin/sponsor key split and the rejected/infrastructure_error split. */
+export async function registerSettlement(
+  opts: BondEscrowOptions,
+  params: RegisterSettlementParams,
+  deps?: { server?: BondEscrowRpcLike },
+): Promise<RegisterSettlementResult> {
+  // Caller-bug validation — thrown synchronously, not reported as `rejected` or
+  // `infrastructure_error`, both of which are reserved for the call actually reaching the
+  // network. A malformed paymentId or address here means src/bazaar.ts's wiring is broken,
+  // not that anything happened on-chain.
+  const paymentIdBytes = Buffer.from(params.paymentId, "hex");
+  if (paymentIdBytes.length !== 32) {
+    throw new Error(
+      `[bond] paymentId must be 32 bytes (64 hex chars), got ${paymentIdBytes.length} bytes: ${params.paymentId}`,
+    );
+  }
+  let payerAddress: Address, sellerAddress: Address, contractAddress: Address;
+  try {
+    payerAddress = Address.fromString(params.payer);
+    sellerAddress = Address.fromString(params.seller);
+    contractAddress = Address.fromString(opts.contractId);
+  } catch (err) {
+    throw new Error(`[bond] payer, seller, or contractId is not a valid Stellar address: ${err}`);
+  }
+  const amount = BigInt(params.amount);
+  if (amount <= 0n) {
+    throw new Error(`[bond] amount must be a positive integer, got ${params.amount}`);
+  }
+  if (params.resourceKey.length === 0) {
+    throw new Error("[bond] resourceKey must not be empty");
+  }
+
+  const admin = Keypair.fromSecret(opts.adminSecretKey);
+  const passphrase = PASSPHRASES[opts.network]!;
+  const server =
+    deps?.server ?? (new rpc.Server(opts.rpcUrl ?? DEFAULT_RPC[opts.network]!) as unknown as BondEscrowRpcLike);
+
+  const args = [
+    nativeToScVal(paymentIdBytes, { type: "bytes" }),
+    nativeToScVal(payerAddress.toString(), { type: "address" }),
+    nativeToScVal(sellerAddress.toString(), { type: "address" }),
+    nativeToScVal(Buffer.from(params.resourceKey, "utf8"), { type: "bytes" }),
+    nativeToScVal(amount, { type: "i128" }),
+  ];
+  const ic = new xdr.InvokeContractArgs({
+    contractAddress: contractAddress.toScAddress(),
+    functionName: "register_settlement",
+    args,
+  });
+
+  try {
+    // Admin is the source account, so its require_auth() is satisfied by the transaction's
+    // own signature — no separate SorobanAuthorizationEntry to construct. See the header
+    // comment.
+    const account = await server.getAccount(admin.publicKey());
+    const tx = new TransactionBuilder(account, { fee: "1000", networkPassphrase: passphrase })
+      .addOperation(
+        Operation.invokeHostFunction({
+          func: xdr.HostFunction.hostFunctionTypeInvokeContract(ic),
+          auth: [],
+        }),
+      )
+      .setTimeout(60)
+      .build();
+
+    const sim = await server.simulateTransaction(tx);
+    if (rpc.Api.isSimulationError(sim)) {
+      const parsed = parseContractError(sim.error);
+      return parsed
+        ? { outcome: "rejected", detail: parsed.name, contractErrorCode: parsed.code }
+        : { outcome: "rejected", detail: sim.error.slice(0, 200) };
+    }
+
+    const assembled = rpc
+      .assembleTransaction(tx, sim as rpc.Api.SimulateTransactionSuccessResponse)
+      .build();
+    if (Number(assembled.fee) > opts.maxTransactionFeeStroops) {
+      return { outcome: "infrastructure_error", detail: "fee_exceeds_maximum" };
+    }
+
+    assembled.sign(admin);
+    const sent = await server.sendTransaction(assembled);
+    if (sent.status !== "PENDING") {
+      return { outcome: "infrastructure_error", detail: `submission_failed: status ${sent.status}` };
+    }
+    for (let i = 0; i < 20; i++) {
+      await new Promise((r) => setTimeout(r, 1500));
+      const got = await server.getTransaction(sent.hash);
+      if (got.status === "SUCCESS") return { outcome: "registered", transaction: sent.hash };
+      if (got.status === "FAILED")
+        return { outcome: "infrastructure_error", detail: `transaction_failed_post_simulation: ${sent.hash}` };
+    }
+    return { outcome: "infrastructure_error", detail: `confirmation_timeout: ${sent.hash}` };
+  } catch (err) {
+    return { outcome: "infrastructure_error", detail: `${err instanceof Error ? err.message : err}` };
+  }
+}

--- a/src/catalog.restart-verification.test.ts
+++ b/src/catalog.restart-verification.test.ts
@@ -78,6 +78,8 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined,
   verificationApiUrl: undefined,
   spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,7 +1,11 @@
+import { Keypair } from "@stellar/stellar-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { loadConfig } from "./config.js";
 
 const SECRET = "SBJP6HHFTABK2GXVVFAKY6C4B7DDNB5PIEQXKUNL2ZAOBPWFOUOSTLVNMA";
+// A real, publicly-documented testnet contract address (docs/upto-deployment.md) — used
+// here only as a syntactically valid C… value, not to imply this config points at it.
+const VALID_CONTRACT_ID = "CDHPA64M73TUTEM4MMHIWIXINBQXH7JJXFGZMGH22VJWFJFROMR6QV2S";
 
 describe("loadConfig", () => {
   it("throws without SPONSOR_SECRET_KEY", async () => {
@@ -125,5 +129,90 @@ describe("loadConfig", () => {
     expect(() => loadConfig({ SPONSOR_SECRET_KEY: SECRET, MAX_TX_FEE_STROOPS: "-5" })).toThrow(
       /MAX_TX_FEE_STROOPS/,
     );
+  });
+
+  describe("bond-escrow", () => {
+    const ADMIN_SECRET = Keypair.random().secret();
+
+    it("defaults both to undefined when unset — bonding entirely inactive", async () => {
+      const config = loadConfig({ SPONSOR_SECRET_KEY: SECRET });
+      expect(config.bondEscrowContractId).toBeUndefined();
+      expect(config.bondEscrowAdminSecretKey).toBeUndefined();
+    });
+
+    it("accepts both set together", async () => {
+      const config = loadConfig({
+        SPONSOR_SECRET_KEY: SECRET,
+        BOND_ESCROW_CONTRACT_ID: VALID_CONTRACT_ID,
+        BOND_ESCROW_ADMIN_SECRET_KEY: ADMIN_SECRET,
+      });
+      expect(config.bondEscrowContractId).toBe(VALID_CONTRACT_ID);
+      expect(config.bondEscrowAdminSecretKey).toBe(ADMIN_SECRET);
+    });
+
+    it("rejects a malformed contract ID — wrong prefix, wrong length, and garbage", async () => {
+      expect(() =>
+        loadConfig({
+          SPONSOR_SECRET_KEY: SECRET,
+          BOND_ESCROW_CONTRACT_ID: "not-a-contract-id",
+          BOND_ESCROW_ADMIN_SECRET_KEY: ADMIN_SECRET,
+        }),
+      ).toThrow(/BOND_ESCROW_CONTRACT_ID/);
+      expect(() =>
+        loadConfig({
+          SPONSOR_SECRET_KEY: SECRET,
+          // A valid-looking secret key in the contract-ID slot — wrong prefix (S, not C).
+          BOND_ESCROW_CONTRACT_ID: ADMIN_SECRET,
+          BOND_ESCROW_ADMIN_SECRET_KEY: ADMIN_SECRET,
+        }),
+      ).toThrow(/BOND_ESCROW_CONTRACT_ID/);
+      expect(() =>
+        loadConfig({
+          SPONSOR_SECRET_KEY: SECRET,
+          BOND_ESCROW_CONTRACT_ID: VALID_CONTRACT_ID.slice(0, -1), // one char short
+          BOND_ESCROW_ADMIN_SECRET_KEY: ADMIN_SECRET,
+        }),
+      ).toThrow(/BOND_ESCROW_CONTRACT_ID/);
+    });
+
+    it("rejects a malformed admin secret key — wrong prefix and wrong length", async () => {
+      expect(() =>
+        loadConfig({
+          SPONSOR_SECRET_KEY: SECRET,
+          BOND_ESCROW_CONTRACT_ID: VALID_CONTRACT_ID,
+          BOND_ESCROW_ADMIN_SECRET_KEY: "not-a-secret-key",
+        }),
+      ).toThrow(/BOND_ESCROW_ADMIN_SECRET_KEY/);
+      expect(() =>
+        loadConfig({
+          SPONSOR_SECRET_KEY: SECRET,
+          BOND_ESCROW_CONTRACT_ID: VALID_CONTRACT_ID,
+          // A valid-looking contract ID in the secret-key slot — wrong prefix (C, not S).
+          BOND_ESCROW_ADMIN_SECRET_KEY: VALID_CONTRACT_ID,
+        }),
+      ).toThrow(/BOND_ESCROW_ADMIN_SECRET_KEY/);
+    });
+
+    it("rejects the contract ID set without the admin key", async () => {
+      expect(() =>
+        loadConfig({ SPONSOR_SECRET_KEY: SECRET, BOND_ESCROW_CONTRACT_ID: VALID_CONTRACT_ID }),
+      ).toThrow(/BOND_ESCROW_CONTRACT_ID.*BOND_ESCROW_ADMIN_SECRET_KEY|must be set together/);
+    });
+
+    it("rejects the admin key set without the contract ID", async () => {
+      expect(() =>
+        loadConfig({ SPONSOR_SECRET_KEY: SECRET, BOND_ESCROW_ADMIN_SECRET_KEY: ADMIN_SECRET }),
+      ).toThrow(/BOND_ESCROW_CONTRACT_ID.*BOND_ESCROW_ADMIN_SECRET_KEY|must be set together/);
+    });
+
+    it("treats an empty string the same as unset for both", async () => {
+      const config = loadConfig({
+        SPONSOR_SECRET_KEY: SECRET,
+        BOND_ESCROW_CONTRACT_ID: "",
+        BOND_ESCROW_ADMIN_SECRET_KEY: "",
+      });
+      expect(config.bondEscrowContractId).toBeUndefined();
+      expect(config.bondEscrowAdminSecretKey).toBeUndefined();
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,22 @@ export interface FacilitatorConfig {
    *  pinned source — contracts/upto-stellar/PROVENANCE.md; deployment record
    *  and wasm hash in docs/upto-deployment.md. */
   uptoContractId: string | undefined;
+  /** Our deployed `bond-escrow` contract (C…). Set ⇒ a settled payment is
+   *  registered with it (giving the payer standing to dispute) as part of
+   *  /settle. Unset ⇒ bonding is entirely inactive; settlement behaves
+   *  exactly as it does today. Original work, not vendored — deployment
+   *  record and wasm hash in docs/bond-escrow-deployment.md. Must be set
+   *  together with bondEscrowAdminSecretKey or not at all — see loadConfig. */
+  bondEscrowContractId: string | undefined;
+  /** The dedicated Stellar secret (S…) that signs `register_settlement`
+   *  calls against bondEscrowContractId — deliberately NOT sponsorSecretKey.
+   *  See contracts/bond-escrow/src/lib.rs, initialize's doc-comment ("Which
+   *  key: a dedicated admin key, not the facilitator's payment sponsor
+   *  key") for why: compromising this key lets an attacker forge dispute
+   *  standing and drain bonded funds, a different blast radius than
+   *  compromising the payment-sponsor key, and the two must be rotatable
+   *  independently. */
+  bondEscrowAdminSecretKey: string | undefined;
   /** Optional JSON file path for Bazaar catalog persistence across restarts. */
   /** libSQL/Turso URL. `file:…` locally, `libsql://…` in production. Unset means
    *  in-memory only: the catalog works but nothing survives a restart. */
@@ -215,6 +231,22 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
     );
   }
 
+  const bondEscrowContractId = parseBondEscrowContractId(env.BOND_ESCROW_CONTRACT_ID);
+  const bondEscrowAdminSecretKey = parseBondEscrowAdminSecretKey(env.BOND_ESCROW_ADMIN_SECRET_KEY);
+  // Half-configured bonding is a broken state, not a partial feature: register_settlement
+  // cannot be called without both the contract to call and the key to sign with. Catching
+  // this at boot, loudly, is cheaper than discovering it the first time a settlement tries
+  // to register and silently can't — same "the operator set it on purpose, fail don't
+  // degrade" posture as parseUptoContractId's own comment below.
+  if ((bondEscrowContractId === undefined) !== (bondEscrowAdminSecretKey === undefined)) {
+    throw new Error(
+      "[config] BOND_ESCROW_CONTRACT_ID and BOND_ESCROW_ADMIN_SECRET_KEY must be set together or not " +
+        "at all — one is set without the other, which would leave bonding half-enabled: a contract to " +
+        "register settlements against with no key to sign the call, or a signing key with nothing to " +
+        "call. Set both to enable bonding, or unset both to leave it off.",
+    );
+  }
+
   return {
     port: Number(env.PORT ?? 4100),
     host: env.HOST ?? "0.0.0.0",
@@ -223,6 +255,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
     sponsorSecretKey,
     maxTransactionFeeStroops,
     uptoContractId: parseUptoContractId(env.UPTO_CONTRACT_ID),
+    bondEscrowContractId,
+    bondEscrowAdminSecretKey,
     catalogDbUrl: env.CATALOG_DB_URL,
     catalogDbAuthToken: env.CATALOG_DB_AUTH_TOKEN,
     verificationApiUrl: env.VERIFICATION_API_URL,
@@ -238,6 +272,33 @@ function parseUptoContractId(raw: string | undefined): string | undefined {
   if (!/^C[A-Z2-7]{55}$/.test(raw)) {
     throw new Error(
       `[config] UPTO_CONTRACT_ID is set but is not a valid contract address (C…, 56 chars): ${raw}`,
+    );
+  }
+  return raw;
+}
+
+/** Same shape as parseUptoContractId, same reasoning: fail the boot rather than silently
+ *  leave bonding disabled when the operator plainly meant to turn it on. */
+function parseBondEscrowContractId(raw: string | undefined): string | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  if (!/^C[A-Z2-7]{55}$/.test(raw)) {
+    throw new Error(
+      `[config] BOND_ESCROW_CONTRACT_ID is set but is not a valid contract address (C…, 56 chars): ${raw}`,
+    );
+  }
+  return raw;
+}
+
+/** A Stellar classic secret key (S…, 56 chars). Deliberately validated by shape here,
+ *  at config-parse time, rather than deferred to whenever bond.ts first calls
+ *  Keypair.fromSecret on it — a malformed value should fail the boot immediately, the
+ *  same standard the contract ID above is held to, not surface later as a confusing
+ *  failure the first time a settlement tries to register. */
+function parseBondEscrowAdminSecretKey(raw: string | undefined): string | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  if (!/^S[A-Z2-7]{55}$/.test(raw)) {
+    throw new Error(
+      "[config] BOND_ESCROW_ADMIN_SECRET_KEY is set but is not a valid Stellar secret key (S…, 56 chars)",
     );
   }
   return raw;

--- a/src/hardening.test.ts
+++ b/src/hardening.test.ts
@@ -19,6 +19,8 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined,
   verificationApiUrl: undefined,
   spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },

--- a/src/server.bondregistration.test.ts
+++ b/src/server.bondregistration.test.ts
@@ -1,0 +1,323 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import type { PaymentRequirements } from "@x402/core/types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+import type { RegisterSettlementResult } from "./bond.js";
+
+// The full live sequence (register_settlement's real network path) is proven by
+// docs/bond-escrow-deployment.md — every entry point, real ledger time, every transaction
+// independently confirmed on Horizon. This file tests the layer around that call: does
+// /settle actually invoke registration when configured, does it stay silent when not, and
+// does each of registerSettlement's possible outcomes produce the exact /settle response
+// this was specified to produce. registerSettlement itself is mocked — a separate file
+// (src/bond.test.ts) covers its own internal behavior.
+//
+// Isolated in its own file, matching the existing server.pagination.test.ts /
+// server.policykey.test.ts / server.health.test.ts convention, specifically so the
+// module-level mock of ./bond.js below only ever applies to these tests, never to the much
+// larger, already-passing server.test.ts.
+
+vi.mock("./bond.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./bond.js")>();
+  return { ...actual, registerSettlement: vi.fn() };
+});
+const { registerSettlement } = await import("./bond.js");
+const registerSettlementMock = vi.mocked(registerSettlement);
+
+const testConfig = {
+  port: 0,
+  host: "127.0.0.1",
+  network: "stellar:testnet" as const,
+  rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(),
+  maxTransactionFeeStroops: 2_000_000,
+  catalogDbUrl: undefined,
+  uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
+  catalogDbAuthToken: undefined,
+  verificationApiUrl: undefined,
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
+};
+
+const BOND_ESCROW_OPTIONS = {
+  contractId: "CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4", // the real deployed instance
+  adminSecretKey: Keypair.random().secret(),
+  network: "stellar:testnet" as const,
+  rpcUrl: undefined,
+  maxTransactionFeeStroops: 500_000,
+};
+
+const PAYER = Keypair.random().publicKey();
+const SETTLED_TX_HASH = "b".repeat(64); // 32 bytes hex — the paymentId registerSettlement would receive
+
+function requirements(): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND",
+    amount: "1000000",
+    payTo: "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A",
+    maxTimeoutSeconds: 60,
+    extra: {},
+  } as PaymentRequirements;
+}
+
+// A structurally VALID transaction envelope (same one server.test.ts uses) — /settle
+// shreds unparseable XDR at the route before ever reaching facilitator.settle.
+const VALID_TX_XDR =
+  "AAAAAgAAAAARUqIOOVQYwBn0s32MhGQwyoTHPy7SzjfXdweAw6b/4gAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABqdyAuAAAAAAAAAAEAAAAAAAAAAQAAAADrmp8rY1JU7CL78HNaROud45MqVmrrbxOCVuWSEz0eRwAAAAAAAAAAAJiWgAAAAAAAAAAA";
+
+const RESOURCE_URL = "https://api.example.com/quote";
+
+function settleBody() {
+  return {
+    x402Version: 2,
+    paymentPayload: {
+      x402Version: 2,
+      scheme: "exact",
+      network: "stellar:testnet",
+      payload: { transaction: VALID_TX_XDR },
+      resource: { url: RESOURCE_URL },
+    },
+    paymentRequirements: requirements(),
+  };
+}
+
+/** A successful settle result — the ONE condition under which bond registration runs at
+ *  all. Real facilitator.settle is stubbed rather than actually reaching Soroban RPC,
+ *  matching how a genuine success is otherwise unreachable in a unit test (no existing test
+ *  in server.test.ts achieves success:true either, for the same reason). */
+async function appWithStubbedSuccess(bondEscrow?: typeof BOND_ESCROW_OPTIONS) {
+  const facilitator = buildFacilitator(testConfig);
+  vi.spyOn(facilitator, "settle").mockResolvedValue({
+    success: true,
+    transaction: SETTLED_TX_HASH,
+    payer: PAYER,
+    network: "stellar:testnet",
+  } as never);
+  const app = await buildServer(
+    facilitator,
+    await BazaarCatalog.create(),
+    undefined,
+    undefined,
+    {},
+    undefined,
+    "stellar:testnet",
+    bondEscrow,
+  );
+  await app.ready();
+  return app;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  registerSettlementMock.mockReset();
+});
+
+describe("/settle — bond registration is entirely inactive when unconfigured", () => {
+  it("never calls registerSettlement when bondEscrow is undefined, even on a real success", async () => {
+    const app = await appWithStubbedSuccess(undefined);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.body).success).toBe(true);
+      expect(registerSettlementMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/settle — bond registration outcomes, each producing the specified response", () => {
+  it("outcome 'registered' — settle reports success normally", async () => {
+    registerSettlementMock.mockResolvedValue({
+      outcome: "registered",
+      transaction: "c".repeat(64),
+    } satisfies RegisterSettlementResult);
+    const app = await appWithStubbedSuccess(BOND_ESCROW_OPTIONS);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(true);
+      expect(body.transaction).toBe(SETTLED_TX_HASH);
+      expect(registerSettlementMock).toHaveBeenCalledWith(BOND_ESCROW_OPTIONS, {
+        paymentId: SETTLED_TX_HASH,
+        payer: PAYER,
+        seller: requirements().payTo,
+        // Canonicalized per BazaarCatalog.canonicalResourceKey — origin + normalized path,
+        // proving the real canonicalization ran, not just a raw passthrough of RESOURCE_URL.
+        resourceKey: "https://api.example.com/quote",
+        amount: requirements().amount,
+      });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("outcome 'infrastructure_error' — 503, names bond registration, keeps the real transaction hash", async () => {
+    registerSettlementMock.mockResolvedValue({
+      outcome: "infrastructure_error",
+      detail: "ECONNREFUSED",
+    } satisfies RegisterSettlementResult);
+    const app = await appWithStubbedSuccess(BOND_ESCROW_OPTIONS);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe("bond_registration_failed");
+      expect(body.reason).toBe("ECONNREFUSED");
+      // The real settlement outcome is not hidden behind the 503 — money moved.
+      expect(body.transaction).toBe(SETTLED_TX_HASH);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("outcome 'rejected' with SettlementAlreadyRegistered — NOT fatal, settle still succeeds", async () => {
+    registerSettlementMock.mockResolvedValue({
+      outcome: "rejected",
+      detail: "SettlementAlreadyRegistered",
+      contractErrorCode: 3,
+    } satisfies RegisterSettlementResult);
+    const app = await appWithStubbedSuccess(BOND_ESCROW_OPTIONS);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(true);
+      expect(body.transaction).toBe(SETTLED_TX_HASH);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("outcome 'rejected' with any other code — 500, carries the parsed error code", async () => {
+    registerSettlementMock.mockResolvedValue({
+      outcome: "rejected",
+      detail: "InvalidAmount",
+      contractErrorCode: 4,
+    } satisfies RegisterSettlementResult);
+    const app = await appWithStubbedSuccess(BOND_ESCROW_OPTIONS);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(500);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe("bond_registration_failed");
+      expect(body.reason).toBe("InvalidAmount");
+      expect(body.contractErrorCode).toBe(4);
+      expect(body.transaction).toBe(SETTLED_TX_HASH);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("a rejected result with NO contractErrorCode (an auth-shaped trap) is treated as 'any other' — 500, not silently swallowed", async () => {
+    registerSettlementMock.mockResolvedValue({
+      outcome: "rejected",
+      detail: "HostError: Error(Auth, InvalidAction)",
+    } satisfies RegisterSettlementResult);
+    const app = await appWithStubbedSuccess(BOND_ESCROW_OPTIONS);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body).contractErrorCode).toBeUndefined();
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("registerSettlement throwing is caught and reported as 503, never crashes the request", async () => {
+    registerSettlementMock.mockRejectedValue(new Error("[bond] paymentId must be 32 bytes"));
+    const app = await appWithStubbedSuccess(BOND_ESCROW_OPTIONS);
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.reason).toContain("paymentId must be 32 bytes");
+      expect(body.transaction).toBe(SETTLED_TX_HASH);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/settle — the missing_payer_or_seller guard", () => {
+  it("returns 503 with reason missing_payer_or_seller when result.payer is undefined on a stubbed success", async () => {
+    // "Should be impossible on a successful settlement" per the code's own comment — this
+    // forces the branch anyway, since "should be impossible" earned an explicit guard
+    // rather than being assumed, and an explicit guard is worth an explicit test.
+    //
+    // A dedicated inline stub, not the shared appWithStubbedSuccess helper: a default
+    // parameter there can't distinguish "omitted" from "explicitly undefined" (JS applies
+    // the default either way), so this needs its own setup rather than a payer-override
+    // argument that would silently do nothing.
+    const facilitator = buildFacilitator(testConfig);
+    vi.spyOn(facilitator, "settle").mockResolvedValue({
+      success: true,
+      transaction: SETTLED_TX_HASH,
+      payer: undefined,
+      network: "stellar:testnet",
+    } as never);
+    const app = await buildServer(
+      facilitator,
+      await BazaarCatalog.create(),
+      undefined,
+      undefined,
+      {},
+      undefined,
+      "stellar:testnet",
+      BOND_ESCROW_OPTIONS,
+    );
+    await app.ready();
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(503);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(false);
+      expect(body.error).toBe("bond_registration_failed");
+      expect(body.reason).toBe("missing_payer_or_seller");
+      expect(body.transaction).toBe(SETTLED_TX_HASH);
+      expect(registerSettlementMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/settle — bond registration is skipped on a failed settlement", () => {
+  it("does not call registerSettlement when the settlement itself did not succeed", async () => {
+    const facilitator = buildFacilitator(testConfig);
+    vi.spyOn(facilitator, "settle").mockResolvedValue({
+      success: false,
+      transaction: "",
+      network: "stellar:testnet",
+      errorReason: "settle_exact_stellar_transaction_failed",
+    } as never);
+    const app = await buildServer(
+      facilitator,
+      await BazaarCatalog.create(),
+      undefined,
+      undefined,
+      {},
+      undefined,
+      "stellar:testnet",
+      BOND_ESCROW_OPTIONS,
+    );
+    await app.ready();
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(200); // failed settle is still a conformant 200 x402 response
+      expect(JSON.parse(res.body).success).toBe(false);
+      expect(registerSettlementMock).not.toHaveBeenCalled();
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/server.health.test.ts
+++ b/src/server.health.test.ts
@@ -14,6 +14,8 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(), maxTransactionFeeStroops: 500_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined, verificationApiUrl: undefined,
   spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 50, unboundPoolMax: 10 },
   balance: { softFloorStroops: 250_000_000, hardFloorStroops: 100_000_000, intervalMs: 60_000 },

--- a/src/server.pagination.test.ts
+++ b/src/server.pagination.test.ts
@@ -19,6 +19,7 @@ const testConfig = {
   port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
   sponsorSecretKey: Keypair.random().secret(), maxTransactionFeeStroops: 500_000,
   catalogDbUrl: undefined, uptoContractId: undefined,
+  bondEscrowContractId: undefined, bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined, verificationApiUrl: undefined,
   spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 50, unboundPoolMax: 10 },
   balance: { softFloorStroops: 250_000_000, hardFloorStroops: 100_000_000, intervalMs: 60_000 },

--- a/src/server.policykey.test.ts
+++ b/src/server.policykey.test.ts
@@ -29,6 +29,8 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined,
   verificationApiUrl: undefined,
   spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -18,6 +18,8 @@ const testConfig = {
   maxTransactionFeeStroops: 2_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined,
   verificationApiUrl: undefined,
   spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
 } from "./trust.js";
 import { createSpendPolicy, type SpendPolicy } from "./policy.js";
 import { BalanceGuard } from "./balance.js";
+import { registerSettlement, type BondEscrowOptions } from "./bond.js";
 
 interface FacilitatorRequestBody {
   x402Version?: number;
@@ -75,6 +76,10 @@ export async function buildServer(
    *  marks it Required). The production call site passes config.network; the
    *  default keeps the many test call sites terse and is asserted to match. */
   network: string = "stellar:testnet",
+  /** Set only when config.bondEscrowContractId is configured — undefined means
+   *  bonding is entirely inactive and /settle behaves exactly as it did before this
+   *  existed. See the bond-registration block in /settle for the full behavior. */
+  bondEscrow?: BondEscrowOptions,
 ) {
   const bodyLimit = hardening.bodyLimitBytes ?? DEFAULT_BODY_LIMIT;
   // Fix 2: a body-limit floor for /verify and /settle (well under Fastify's 1 MiB
@@ -211,6 +216,14 @@ export async function buildServer(
         }),
       );
     }
+    // Canonical resource URL — hoisted above the spend-policy block so bond
+    // registration (below) can reuse the same derivation rather than recomputing
+    // it independently, which is exactly how a resource-key canonicalization bug
+    // gets a second, silently-drifting copy. Cheap and pure (URL parsing only),
+    // so computing it unconditionally costs nothing when neither consumer needs it.
+    const rawResourceUrl =
+      (paymentPayload as unknown as { resource?: { url?: string } }).resource?.url ?? "";
+    const resourceUrl = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
     // Fix 1: consult the spend policy before spending sponsor XLM. On pubnet a
     // tripped per-payTo rate limit or global spend ceiling refuses with 503; on
     // testnet it logs what would have tripped and proceeds (fail-open).
@@ -230,9 +243,6 @@ export async function buildServer(
       // `/quote?symbol=AAPL` reads as unbound on every settle and lands in the
       // shared unbound pool — and the per-URL budget could be multiplied by
       // simply varying the query string.
-      const rawResourceUrl =
-        (paymentPayload as unknown as { resource?: { url?: string } }).resource?.url ?? "";
-      const resourceUrl = BazaarCatalog.canonicalResourceKey(rawResourceUrl);
       const verdict = policy.checkSettle({
         resourceUrl,
         payTo: payToKey,
@@ -298,6 +308,112 @@ export async function buildServer(
     if (result.success === false && rpcStatus) {
       request.log.warn({ rpcStatus }, "[settle] submission refused by the RPC");
       return { ...result, rpcStatus };
+    }
+    // Bond registration — synchronous, awaited, BEFORE /settle reports success.
+    // docs/proposal-provider-bond.md, Section 6: this is the one call that gives a
+    // payer standing to dispute a bond, so a settlement that succeeds without it
+    // is a settlement no buyer can ever get recourse for — exactly the gap this
+    // whole system exists to close. Only reached when bondEscrow is configured
+    // (both-or-neither with the admin key, enforced in config.ts) and the
+    // settlement itself actually succeeded — nothing to register standing
+    // against for a failed settle.
+    if (bondEscrow && result.success === true) {
+      try {
+        const seller = BazaarCatalog.canonicalPayTo(paymentRequirements.payTo);
+        // Both of these SHOULD be impossible on a successful settlement — a real
+        // payment cannot have settled without a real payer and a real payTo — but
+        // "should be impossible" is exactly the case this system's own posture
+        // (name it, don't hide it) says to handle explicitly rather than assume.
+        if (!seller || !result.payer) {
+          request.log.error(
+            { transaction: result.transaction, payer: result.payer, payTo: paymentRequirements.payTo },
+            "[bond] settlement succeeded but is missing a payer or seller address — cannot register",
+          );
+          return reply.status(503).send(
+            settleError(network, "bond_registration_unavailable", {
+              error: "bond_registration_failed",
+              reason: "missing_payer_or_seller",
+              // The real settlement outcome, not hidden behind the 503 — money
+              // moved even though this response reports failure.
+              transaction: result.transaction,
+            }),
+          );
+        }
+        const registration = await registerSettlement(bondEscrow, {
+          // A Stellar transaction hash is already exactly 32 bytes and already
+          // unique per settlement — a ready-made payment_id, per bond.ts's own
+          // doc-comment on the field.
+          paymentId: result.transaction,
+          // Not run through canonicalPayTo, unlike seller below: SDK-derived from parsed
+          // transaction XDR, not a merchant-typed string, so it shouldn't carry the
+          // whitespace/casing exposure that canonicalization exists for. If that
+          // assumption ever breaks, bond.ts's own address validation throws -> 503, a
+          // loud failure, not a silent wrong-value bug.
+          payer: result.payer,
+          seller,
+          resourceKey: resourceUrl,
+          amount: result.amount ?? paymentRequirements.amount,
+        });
+
+        if (registration.outcome === "infrastructure_error") {
+          request.log.error(
+            { transaction: result.transaction, detail: registration.detail },
+            "[bond] registration failed (infrastructure) — refusing to report settle success without it",
+          );
+          return reply.status(503).send(
+            settleError(network, "bond_registration_unavailable", {
+              error: "bond_registration_failed",
+              reason: registration.detail,
+              transaction: result.transaction,
+            }),
+          );
+        }
+        if (registration.outcome === "rejected") {
+          if (registration.contractErrorCode === 3 /* SettlementAlreadyRegistered */) {
+            // Unexpected, but not fatal: dispute standing already exists for this
+            // paymentId (a prior registration attempt must have succeeded even
+            // though this request didn't observe it — e.g. a retried settle, or a
+            // submission that landed after we'd already stopped waiting on a prior
+            // attempt). The outcome this call cares about — standing exists — is
+            // already true. Logged loudly because it is still worth an operator's
+            // attention, not because the settle needs to fail over it.
+            request.log.warn(
+              { transaction: result.transaction },
+              "[bond] SettlementAlreadyRegistered — standing already exists for this paymentId, letting settle succeed",
+            );
+          } else {
+            request.log.error(
+              { transaction: result.transaction, detail: registration.detail, code: registration.contractErrorCode },
+              "[bond] registration rejected by the contract — unexpected, refusing to report settle success",
+            );
+            return reply.status(500).send(
+              settleError(network, "bond_registration_rejected", {
+                error: "bond_registration_failed",
+                reason: registration.detail,
+                contractErrorCode: registration.contractErrorCode,
+                transaction: result.transaction,
+              }),
+            );
+          }
+        }
+      } catch (err) {
+        // Anything thrown here (including bond.ts's own caller-bug validation,
+        // which should be unreachable given the guards above, but "should be
+        // unreachable" is not a substitute for handling it) is treated the same
+        // as an infrastructure failure: fail loud, never let it crash the
+        // request uncaught, never silently report success without registration.
+        request.log.error(
+          { transaction: result.transaction, err: err instanceof Error ? err.message : err },
+          "[bond] registration threw — refusing to report settle success without it",
+        );
+        return reply.status(503).send(
+          settleError(network, "bond_registration_unavailable", {
+            error: "bond_registration_failed",
+            reason: err instanceof Error ? err.message : String(err),
+            transaction: result.transaction,
+          }),
+        );
+      }
     }
     return result;
   });
@@ -517,6 +633,27 @@ if (isDirectRun) {
   });
   balanceGuard.start();
 
+  // Bond registration is opt-in by contract ID, same convention as uptoContractId
+  // above — unset means bonding is entirely inactive, /settle unchanged. The
+  // both-or-neither invariant already enforced in config.ts guarantees the admin
+  // key is present whenever the contract ID is.
+  const bondEscrow: BondEscrowOptions | undefined = config.bondEscrowContractId
+    ? {
+        contractId: config.bondEscrowContractId,
+        adminSecretKey: config.bondEscrowAdminSecretKey!,
+        network: config.network,
+        rpcUrl: config.rpcUrl,
+        maxTransactionFeeStroops: config.maxTransactionFeeStroops,
+      }
+    : undefined;
+  if (!bondEscrow) {
+    console.warn(
+      "[bond] BOND_ESCROW_CONTRACT_ID is not set — settlements will NOT be registered with the bond " +
+        "contract. No payer gets dispute standing for any settlement. This is expected until the bond " +
+        "system is deployed and configured; see docs/bond-escrow-deployment.md.",
+    );
+  }
+
   const app = await buildServer(
     buildFacilitator(config),
     catalog,
@@ -525,6 +662,7 @@ if (isDirectRun) {
     {},
     balanceGuard,
     config.network,
+    bondEscrow,
   );
   // P3 — sponsor funding asserted AT BOOT, with the fix in the error. The
   // polling balance guard exists for drain DURING operation; this exists for


### PR DESCRIPTION
Three commits: `BOND_ESCROW_CONTRACT_ID`/admin-key config, the `bond.ts` invocation wiring, and the actual `/settle`-path integration.

## Confirmation test — real, not simulated

Ran a real facilitator process locally, pointed at the real deployed bond contract, settled a real payment through the demo seller:

- Settlement tx: `5f20dcfd96c083fedebb7d9ff5d6761b32d4fb39de864c41d0b16c3bda3683d5`
- `/settle` returned `200`, seller unlocked the resource
- `stellar contract invoke -- get_settlement --payment_id 5f20dcfd...` against `CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4` returned a genuine on-chain `SettlementRecord`: correct amount (`200000`), correct payer, correct seller.

That's the first real payment through this facilitator whose payer now has actual, on-chain standing to dispute.

## Error behavior

- `infrastructure_error` → `503`, `error: "bond_registration_failed"`, reason named — same pattern as the sponsor balance guard's existing 503. **The response still carries the real settlement transaction hash.** The underlying Stellar payment genuinely succeeded and moved real money even though this API call reports failure — a caller or operator reading a 503 here needs to see that a transaction happened, not assume nothing did.
- `rejected` + `SettlementAlreadyRegistered` → logged loudly, `/settle` still returns `200`. Not fatal: dispute standing already exists for this `paymentId`, which is the outcome that actually matters.
- `rejected` + anything else → `500`, with the parsed `contractErrorCode` in the response body.
- Any thrown exception during the attempt is caught and treated the same as `infrastructure_error` — never crashes the request uncaught.

Only reached when `BOND_ESCROW_CONTRACT_ID` is configured and the settlement itself succeeded. Unset → `/settle` is byte-for-byte unchanged.

## What this does NOT yet do

- No HTTP relay routes for dispute-filing, receipt-posting, or withdrawal
- No `trust.ts` bond resolver
- No `bonded_only` catalog/MCP filtering
- No `store.ts` caching or polling
- Nothing in `vellar-sdk` (a separate repo, still payer-only)

This PR connects the payment path to the bond contract — the one call that gives a payer real standing to dispute. Everything else in `docs/proposal-provider-bond.md` Section 6 is a separate pass.

## Testing

435/435 passing, typecheck clean. New coverage: `config.test.ts`'s bond-escrow describe block, `bond.test.ts` (14 tests — caller-bug validation, which key signs, the rejected/infrastructure_error split), `server.bondregistration.test.ts` (8 tests — every response shape `/settle` can now produce), plus six existing test fixtures updated for the two new required config fields.