### PR TITLE
feat(seller): 7 new paid endpoints, Bazaar-discoverable

### DIFF
--- a/docs/bond-escrow-deployment.md
+++ b/docs/bond-escrow-deployment.md
@@ -1,0 +1,128 @@
+# `bond-escrow` contract — deployment record
+
+Published so anyone can verify this deployed contract against its source without
+trusting this file. Every value below is checkable.
+
+| | |
+| --- | --- |
+| Contract ID (testnet) | `CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4` |
+| Wasm hash | `21e4a128423f8d4246951812a4fd6cb3811ba30b100c73e912b4febc7ffd949c` |
+| Source | `contracts/bond-escrow/` in this repo — **original work**, not vendored (contrast with `contracts/upto-stellar/`, which is rail402's, taken verbatim). Built across four incremental passes plus two review-driven fixes, all folded into a single commit on `main` via [PR #74](https://github.com/Vellar-Wallet/vellar-facilitator/pull/74). |
+| Built with | rustc/cargo 1.96.0, `stellar` CLI 26.1.0, target `wasm32v1-none`, `soroban-sdk` resolved to `23.5.3` (`Cargo.lock`), `overflow-checks = true` in the release profile |
+| Deployed | 2026-08-21, from a dedicated testnet admin key (not the facilitator's `SPONSOR_SECRET_KEY` — see "Admin key" below), deploy tx [`e0bec89f…`](https://stellar.expert/explorer/testnet/tx/e0bec89fdcefaf9f7eaa601aedf8962a74f162b5ccca0161f912e87faa611bcd) |
+| Full sequence exercised | Yes — every one of the seven entry points, on this exact deployed instance, in one continuous run. See below. |
+
+## Verify the build yourself
+
+The on-chain wasm hash IS the sha256 of the wasm, so the whole chain is three commands:
+
+```sh
+cd contracts/bond-escrow
+stellar contract build          # rustc 1.96.0 / stellar-cli 26.1.0 / wasm32v1-none
+shasum -a 256 target/wasm32v1-none/release/x402_bond_escrow.wasm
+# → 21e4a128423f8d4246951812a4fd6cb3811ba30b100c73e912b4febc7ffd949c
+```
+
+And fetch what the chain is actually running:
+
+```sh
+stellar contract fetch \
+  --id CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4 \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  --out-file fetched.wasm
+shasum -a 256 fetched.wasm      # → the same hash
+```
+
+This was done three independent ways, all producing the identical hash, before treating
+it as trustworthy:
+
+1. A clean local build.
+2. A second clean local build (`rm -rf target` between runs), to confirm the build is
+   reproducible and not an artifact of incremental compilation state.
+3. `stellar contract fetch` against the live deployed instance above, independently
+   re-hashed.
+
+All three: `21e4a128423f8d4246951812a4fd6cb3811ba30b100c73e912b4febc7ffd949c`.
+
+## The response window is 5 minutes on this deployment, not 24 hours — and that is a real, documented decision, not an oversight
+
+`PLACEHOLDER_RESPONSE_WINDOW_SECONDS` in `contracts/bond-escrow/src/lib.rs:235` is
+currently `5 * 60`, not `24 * 60 * 60`. Full reasoning lives in that constant's own
+doc-comment (`lib.rs`, immediately above line 235), not just here — read it directly
+rather than trusting this summary. In short: neither 24 hours nor 5 minutes is validated
+by real data; both are guesses. 24 hours was the original placeholder, reasoned from
+giving a seller's real receipt-posting process — potentially under real operational load
+during a griefing burst — enough time to respond, without letting a slash-avoidance
+seller stall indefinitely. 5 minutes abandons the first half of that reasoning on
+purpose, specifically so the full lifecycle below could be exercised against real ledger
+time in minutes rather than a day, for a testnet-only proof of mechanism. **This value
+must move back toward something like the original 24-hour reasoning, informed by real
+receipt-posting latency data, before any pubnet deployment** — the source comment says
+this explicitly and this file repeats it so the caveat travels with the deployment
+record, not just the code.
+
+A separate, throwaway deployment (never recorded here, its wasm hash never cited as
+evidence for this or any other build) used this same 5-minute value first, purely to
+sanity-check the CLI mechanics before committing to this real run.
+
+## Admin key
+
+`initialize` was called with a dedicated testnet key generated specifically for this
+deployment, not the facilitator's `SPONSOR_SECRET_KEY` and not reused from any other
+purpose. This matches the reasoning recorded in `initialize`'s own doc-comment
+(`lib.rs`, "Which key: a dedicated admin key, not the facilitator's payment sponsor
+key"): compromising the admin key lets an attacker forge dispute standing and drain
+bonded funds, a materially different blast radius than compromising the payment-sponsor
+key, and the two should not be rotatable only in lockstep. This testnet admin key is
+scratch and disposable; it is not a template for how the mainnet admin key would be
+provisioned or held.
+
+## The full sequence — every entry point, real ledger time, Horizon-confirmed
+
+Run start-to-finish against the deployed instance above. Each transaction was
+independently confirmed successful on Horizon (`successful: true`, with its own ledger
+number and timestamp), not just trusted from the CLI's own "submitted successfully"
+output.
+
+| # | Entry point | Tx hash | Ledger | Horizon timestamp (UTC) | What happened |
+| --- | --- | --- | --- | --- | --- |
+| 1 | `initialize` | [`9d5959c6…`](https://stellar.expert/explorer/testnet/tx/9d5959c6f3a9c8ace42c5c8bf2868c77a5a7e11e926eab20c80bb225e8ab6674) | 4264791 | 2026-08-21T21:09:17Z | Admin set |
+| 2 | `deposit` | [`83841175…`](https://stellar.expert/explorer/testnet/tx/8384117524622650103263b70eefdea24e16c24ca81a53cfdf37523da8b17a6f) | 4264793 | 2026-08-21T21:09:27Z | 400,000 atomic USDC (0.04 USDC) — real SEP-41 transfer, Horizon effects confirm `account_debited` the seller and `contract_credited` the same amount |
+| 3 | `set_delivery_key` | [`325ee05c…`](https://stellar.expert/explorer/testnet/tx/325ee05c349b55f7a98623a8cd57cd2046547107dfff1439834ac37178bf9c72) | 4264795 | 2026-08-21T21:09:37Z | Seller's Ed25519 delivery-signing pubkey registered |
+| 4 | `register_settlement` | [`972d1379…`](https://stellar.expert/explorer/testnet/tx/972d1379aca6b461efa7004cdeeb6aaef6ee4debbd9fd919c46ff61b3790ed8a) | 4264797 | 2026-08-21T21:09:47Z | Settlement of 250,000 atomic (0.025 USDC) registered, giving the payer standing |
+| 5 | `file_dispute` | [`ecf12e79…`](https://stellar.expert/explorer/testnet/tx/ecf12e792d8eee7b65cdeb656ba1dac27087a4ebb5602c53866b9eb0fcc54749) | 4264799 | 2026-08-21T21:09:57Z | Dispute opened by the real payer, `filed_at: 1787346598` |
+| — | *(real wait — no transaction)* | — | — | ~5m30s elapsed on the actual network clock | No receipt was posted; the response window elapsed for real |
+| 6 | `finalize` | [`f6b516bd…`](https://stellar.expert/explorer/testnet/tx/f6b516bd0cc7cfcf208e7d25676797aa43d651db81abdeb24ee0b84c7317cfae) | 4264867 | 2026-08-21T21:15:37Z | Slash executed — real SEP-41 transfer, Horizon effects confirm `contract_debited` 0.0250000 USDC and `account_credited` the same amount to the payer |
+
+Post-state, read directly from the contract after step 6: `get_dispute` → `null`
+(closed), `get_listing.bond_amount` → `150,000` (400,000 − 250,000, exactly
+`min(settlement.amount, bond_amount)`), `open_dispute_count` → `0`.
+
+**`set_delivery_key` ordering note.** `set_delivery_key` requires an existing `Listing`
+record and fails with `ListingNotFound` (`Error` code 8) if called before any `deposit`
+has happened against that resource key — this is a real, deliberate requirement of the
+contract, not a testnet quirk. It was discovered by getting the order wrong on the first
+(throwaway) run: calling `set_delivery_key` before `deposit` failed exactly as designed.
+The sequence above reflects the correct order — `deposit` before `set_delivery_key` —
+and is the order any real integration needs to follow.
+
+## Not yet independently verified by a third party
+
+Unlike `upto-stellar`, which `explorer.vellar.xyz` independently confirms by classifying
+real chain data with its own logic, `bond-escrow` has no independent-party verification
+path today. The explorer has no concept of a bonded listing, a dispute, or a settlement
+registration — this is explicitly out of scope per `docs/proposal-provider-bond.md`
+Section 6. Everything in this document is self-reported by this repo, verified by the
+methods stated above, not corroborated by a separate operator. Worth deciding explicitly
+whether that gap needs closing before this is treated as equivalent evidence to
+`upto-stellar`'s deployment record.
+
+## Facilitator wiring
+
+None exists yet. Nothing in `src/` calls `register_settlement` or any other entry point
+of this contract — see `docs/proposal-provider-bond.md` Section 6 for the full,
+unbuilt scope (the synchronous `/settle`-path registration call, HTTP relay routes,
+catalog and trust-block integration, and everything in `vellar-sdk`). This contract is
+reachable today only by direct Soroban CLI or SDK calls, exactly as exercised above —
+not through any real payment made via this facilitator.

--- a/docs/bond-integration-status.md
+++ b/docs/bond-integration-status.md
@@ -1,0 +1,203 @@
+# Provider bond system — where it stands, and how to finish it
+
+**Status:** the contract is complete and proven on testnet. The facilitator is wired for
+exactly one of its seven entry points. This document is the guide for picking the rest
+back up — what's done, what isn't, what needs a real decision before more code gets
+written, and the concrete order to do it in. Written at a deliberate pause point, not a
+stopping point: the design and the first real connection are solid enough to stand on
+their own for now (see "Why we're pausing here" at the end).
+
+---
+
+## 1. What's actually done, with evidence
+
+**The design.** `docs/proposal-provider-bond.md` — every decision locked, every trade-off
+argued through, not just concluded. Merged to `main` in
+[PR #74](https://github.com/Vellar-Wallet/vellar-facilitator/pull/74).
+
+**The contract.** `contracts/bond-escrow/` — original work, not vendored. All seven entry
+points from the design document exist and are tested: `register_settlement`, `deposit`,
+`withdraw`, `file_dispute`, `set_delivery_key`, `post_receipt`, `finalize`. **89 tests
+passing** (`cargo test`, verified directly, not from memory, while writing this doc).
+Merged in the same PR #74, commit `7d91620` (amended once for the claim-filing-window fix
+and the dedicated-admin-key decision — see `docs/proposal-provider-bond.md`'s own history
+if the exact diff matters later).
+
+**Two real testnet deployments**, not simulated:
+
+1. A 24-hour-response-window instance, `CAJKUV7LHB7HLLUBRSFCET44ZTDRL4XCWOSKKQA2E2CMITJEDFTD3CLP`.
+   Steps 1-5 of the full lifecycle were run for real against it before the response window
+   was changed (see item 2 below) — this instance is now **abandoned**, not because
+   anything failed, but because its source no longer matches what's committed. It still
+   holds a small amount of real testnet USDC and an open dispute that will never resolve
+   through any code path that still exists. Harmless, just stale. Do not use it.
+2. A 5-minute-response-window instance, `CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4`
+   — **this is the one that matters**. Wasm hash `21e4a128423f8d4246951812a4fd6cb3811ba30b100c73e912b4febc7ffd949c`,
+   confirmed three independent ways (two clean local builds, one `stellar contract fetch`
+   against the live instance). Every one of the seven entry points was exercised for real
+   against it, with real ledger time (not the test harness's synthetic clock) and every
+   transaction independently confirmed on Horizon. Full record —
+   contract ID, wasm hash, every tx hash, the `set_delivery_key`-after-`deposit` ordering
+   requirement, the 5-minute-vs-24-hour caveat — is written up in
+   `docs/bond-escrow-deployment.md`.
+
+   **That file is currently local-only, not pushed, not merged, not on `main`** — confirmed
+   directly while writing this doc (`git show main:docs/bond-escrow-deployment.md` fails).
+   It exists as a real, complete, accurate commit (`282ebee` on the local branch
+   `docs/bond-escrow-deployment-record`) — pushing and opening a PR for it is a small,
+   safe, low-effort first step whenever this work resumes, and probably the very first
+   thing to do (see the roadmap below).
+
+**The facilitator connection — one entry point, wired and proven.**
+[PR #75](https://github.com/Vellar-Wallet/vellar-facilitator/pull/75), merged to `main`
+(`025bfa5`), three commits:
+
+- `src/config.ts` — `BOND_ESCROW_CONTRACT_ID` / `BOND_ESCROW_ADMIN_SECRET_KEY`, same
+  validation convention as `UPTO_CONTRACT_ID`, both-or-neither enforced at boot.
+- `src/bond.ts` — `registerSettlement()`, the Soroban invocation wiring. Admin-key-signs
+  (never the sponsor key), and a `rejected`/`infrastructure_error` split that mirrors how
+  Soroban actually reports the two cases, not a guess.
+- `src/server.ts` — `register_settlement` called synchronously inside `/settle`, before
+  success is reported. Unconfigured, `/settle` is byte-for-byte unchanged.
+
+**436 TypeScript tests passing** (verified directly while writing this doc:
+`npm test` on current `main`). CI green before merge on both PRs.
+
+**Confirmed end-to-end, for real** — the actual proof this whole thing works together, not
+just in isolation: a real facilitator process, pointed at the 5-minute contract above,
+settled a real payment through the demo seller. `/settle` returned `200`. The resulting
+`SettlementRecord` was independently confirmed on-chain:
+
+```
+settlement tx      5f20dcfd96c083fedebb7d9ff5d6761b32d4fb39de864c41d0b16c3bda3683d5
+contract            CAWQ2FJDPWHOFLYQIPKBU4M6IE4GUROKUKVVZERWQVD2DHP7S2CULTI4
+SettlementRecord    { amount: 200000, payer: <real buyer G-address>, seller: <real PAYTO> }
+```
+
+That is a real payer with real, on-chain standing to dispute a real settlement. It is the
+one thing in this whole system that has been proven to work end to end, not just at each
+layer independently.
+
+---
+
+## 2. What's explicitly not done — precisely, not vaguely
+
+The contract has all seven entry points. The facilitator only calls one of them
+(`register_settlement`), and only calls it on the facilitator's own behalf, using the
+facilitator's own admin key. Everything else requires a **buyer or seller** to act, and
+nothing in this codebase lets them do that through the facilitator yet:
+
+| Entry point | Contract status | Facilitator status |
+| --- | --- | --- |
+| `register_settlement` | done, tested, proven live | **wired** — `/settle` calls it |
+| `deposit` | done, tested, proven live | not callable through the facilitator at all |
+| `set_delivery_key` | done, tested, proven live | not callable through the facilitator at all |
+| `withdraw` | done, tested, proven live | not callable through the facilitator at all |
+| `file_dispute` | done, tested, proven live | not callable through the facilitator at all |
+| `post_receipt` | done, tested, proven live | not callable through the facilitator at all |
+| `finalize` | done, tested, proven live (permissionless) | not callable through the facilitator at all |
+
+Also not built, per `docs/proposal-provider-bond.md` Section 6, unchanged since that
+document was written:
+
+- No `bonded_only` filter in `catalog.ts`, `server.ts`'s discovery routes, or `mcp.ts`.
+- No bond resolver in `trust.ts` — the discovery response's `trust` block carries nothing
+  about bonds today.
+- No caching of bond/dispute state in `store.ts`, and no polling process for the
+  time-based state changes (a dispute window elapsing) that have no triggering
+  transaction.
+- Nothing in `vellar-sdk` (a separate repo) — it remains payer-only, no seller-side
+  receipt-signing helper, no new MCP tools for filing a dispute or verifying a receipt.
+- No independent third-party verification path — `vellar-explorer` has zero bond-escrow
+  awareness, unlike `upto-stellar`'s explorer confirmation.
+
+---
+
+## 3. Real decisions needed before more code gets written — not just tasks
+
+These aren't implementation work, they're calls that shape the implementation work, and
+skipping them means building the wrong thing first.
+
+**a. Does the facilitator relay `deposit`/`withdraw`/`file_dispute`/`post_receipt` as
+sponsored HTTP routes, or stay purely direct-to-contract?** `register_settlement` didn't
+need this call — it's entirely facilitator-signed. Every remaining entry point is signed
+by a *seller* or a *payer*, which is a materially different integration shape:
+
+- **Relay (recommended, matching the existing `/verify`+`/settle` value proposition)**: the
+  facilitator accepts a signed request, builds and submits the Soroban transaction,
+  sponsors the fee — buyers and sellers never need to hold XLM or run a Soroban SDK
+  themselves. This is real new surface: new routes, new request/response shapes, new
+  error handling, and the SDK-side counterpart (`vellar-sdk`) needs a way to produce
+  whatever signed payload the relay expects.
+- **Direct-to-contract**: sellers and buyers call the contract themselves via CLI or a
+  hand-rolled client, exactly like the confirmation test in `docs/bond-escrow-deployment.md`
+  did. Zero new facilitator routes, but it means real users need Soroban tooling and
+  testnet/pubnet XLM of their own — a much higher bar than this product has asked of
+  anyone so far, and a real UX regression from what `/settle` already provides for
+  payments.
+
+This should be decided once, explicitly, before touching any of the remaining entry
+points — not re-litigated per entry point.
+
+**b. What should the real response window actually be?** The only currently-live,
+fully-proven contract instance uses 5 minutes, deliberately compressed for a same-day
+demo and explicitly marked in its own source comment as not shippable toward mainnet as
+is. Before any further real-facilitator work happens against a bond contract, this needs
+either a fresh deployment with a genuinely defensible value (the original 24-hour
+reasoning, or something informed by real data if any exists by then) or an explicit,
+conscious decision to keep testing against the 5-minute instance a while longer with that
+tradeoff understood. Don't let "the contract we happen to have deployed" quietly become
+"the value we ship" by default.
+
+**c. Who holds the real admin key for whatever gets deployed next?** The admin key
+currently in use (`GAGSR7PBRCU2JC6FOEHIVQKNTBWIDOIEHONB43YYWAC6SMYGAIKWT7BI`) was generated
+ad hoc for this session's testing. Fine for continued manual/local work; not something
+that should become the facilitator's live bond-admin key by default just because it's the
+one that already exists. A real deployment — even testnet-only, even before this goes to
+any real users — should get its own deliberately-provisioned, tracked key, matching the
+same discipline this whole feature is built around (a dedicated key, not a reused one).
+
+---
+
+## 4. The completion roadmap, in order
+
+1. **Push and open a PR for `docs/bond-escrow-deployment.md`.** It's finished, accurate,
+   and already committed locally (`282ebee`) — this is nearly free and makes the testnet
+   proof-of-life a matter of public record instead of a local file.
+2. **Decide 3a and 3b above** (relay vs. direct-to-contract; the real response-window
+   value). Both are cheap to decide and expensive to build around incorrectly.
+3. **If relaying**: design and build the HTTP routes for `deposit`, `set_delivery_key`,
+   `file_dispute`, `post_receipt`, and `withdraw` — matching `/settle`'s existing pattern
+   of accepting a signed payload and sponsoring the fee, one route at a time, same
+   discipline as the `register_settlement` build (tests before moving to the next,
+   confirmation against a real deployed instance before calling any one of them done).
+   `finalize` needs no route at all — it's permissionless by design; anyone (including a
+   simple cron-style job the facilitator could run, or just documentation telling
+   claimants they can call it themselves) can trigger it once a window elapses.
+4. **`trust.ts`'s bond resolver and the `bonded_only` filter**, once there's something
+   real for a buyer to filter on — building this before step 3 exists would mean
+   surfacing bond data nobody can act on yet.
+5. **`store.ts` caching plus a poller**, once discovery is actually reading bond state
+   on every request and the live-query cost becomes real rather than theoretical.
+6. **`vellar-sdk`** — the seller-side receipt-signing helper and payer-side MCP tools,
+   once there's a real relay API for them to call against.
+7. **`vellar-explorer` independent verification**, last — it's explicitly a follow-on per
+   the design document, not blocking anything else, and is most useful once real bonded
+   listings with real dispute history exist to show.
+
+Each step should get the same treatment `register_settlement` got: real tests, a real
+confirmation against a real deployed contract before calling it done, and an honest
+accounting — in the PR, not just in chat — of what was decided versus what was
+specified.
+
+---
+
+## 5. Why we're pausing here
+
+Not because anything is blocked — because what exists right now is a complete, honest,
+independently-verifiable story on its own: a contract proven end to end on testnet, a
+design document that argues every decision rather than just asserting it, and one real
+payment that created real, on-chain, checkable dispute standing. That's a genuine
+milestone, not a partial one pretending to be further along than it is. The remaining
+work is real, substantial, and better done deliberately — after the decisions in section 3
+are actually made — than rushed to make the story sound more finished than it is.

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -28,6 +28,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
+import { createHash, randomUUID } from "node:crypto";
 
 // Auto-load examples/.env.recording so you never have to `source` it. Existing
 // shell env vars still win (loadEnvFile does not override). No-op if absent.
@@ -89,10 +90,52 @@ const PAYTO = process.env.PAYTO || "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI
 const ASSET = process.env.ASSET || "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA";
 const PRICE_ATOMIC = process.env.PRICE_ATOMIC || "1000000";
 
+// USDC on Stellar has 7 decimal places (confirmed by this repo's own
+// atomic/decimal convention — see provision-testnet.mjs and the sibling
+// vellar-playground's lib/usdc.ts `USDC_DECIMALS = 7`), so 1 USDC = 10,000,000
+// atomic. `/quote`'s PRICE_ATOMIC default of "1000000" is therefore 0.1 USDC,
+// NOT 0.01 — a decimal place off the naive reading. The seven new endpoints
+// below are priced independently of PRICE_ATOMIC (which stays /quote's own
+// knob): 0.01 USDC = 100,000 atomic for six of them, and 0.02 USDC = 200,000
+// atomic for /inspect, which does real Horizon work three calls deep.
+const PRICE_ATOMIC_001_USDC = "100000";
+const PRICE_ATOMIC_002_USDC = "200000";
+
 // Used only by the boot-time merchant preflight below — never on the payment
 // path, which goes through the facilitator.
 const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
 const PASSPHRASE = Networks.TESTNET;
+
+// Horizon testnet — used by /inspect (balances + recent txs) and /timestamp
+// (ledger sequence number only). These are the only two of the seven new
+// routes below that touch an external API; the other five (/stroops, /hash,
+// /base64, /word-count, /uuid) are pure local computation. Both Horizon calls
+// carry an explicit 10s timeout and fail with a clear JSON error rather than
+// hanging or crashing — see fetchHorizon().
+const HORIZON_URL = "https://horizon-testnet.stellar.org";
+const HORIZON_TIMEOUT_MS = 10_000;
+
+/**
+ * GET a Horizon testnet path with an explicit timeout, returning a
+ * discriminated result rather than throwing — every caller needs to turn a
+ * timeout/network failure into a clean 4xx/502 JSON body, never a crash or an
+ * unbounded hang.
+ */
+async function fetchHorizon(path) {
+  try {
+    const res = await fetch(`${HORIZON_URL}${path}`, { signal: AbortSignal.timeout(HORIZON_TIMEOUT_MS) });
+    let body;
+    try {
+      body = await res.json();
+    } catch {
+      body = undefined;
+    }
+    return { ok: res.ok, status: res.status, body };
+  } catch (err) {
+    const timedOut = err?.name === "TimeoutError" || err?.name === "AbortError";
+    return { ok: false, status: 0, timedOut, error: String(err?.message || err) };
+  }
+}
 
 /**
  * Where a value came from — shell, the env file, or the built-in default.
@@ -178,6 +221,47 @@ const coreServer = new x402ResourceServer(new HTTPFacilitatorClient({ url: FACIL
   .register("stellar:testnet", new ExactStellarScheme())
   .registerExtension(bazaarResourceServerExtension);
 
+// USDC/Stellar atomic scale: 10,000,000 (7 decimal places) — same constant
+// documented above and in the sibling vellar-playground's lib/usdc.ts.
+const USDC_DECIMALS = 7;
+const ATOMIC_SCALE = 10n ** BigInt(USDC_DECIMALS);
+
+/**
+ * Parse a USDC decimal-amount string (e.g. "1.5", "0.0000001", "12") into its
+ * exact stroop value, as a BigInt — no floating point anywhere, since a
+ * float64 cannot represent every 7-decimal value exactly (0.1 + 0.2 territory)
+ * and this is money math. Mirrors the *inverse* of vellar-playground's
+ * lib/usdc.ts `atomicToDecimalString` (decimal string -> atomic there;
+ * atomic -> decimal string here), reimplemented from scratch in this repo.
+ *
+ * Splits the decimal string into whole and fractional parts, scales each by
+ * hand with BigInt arithmetic, and combines them:
+ *   whole part  * 10_000_000
+ * + fractional part, right-padded/truncated to 7 digits
+ *
+ * Returns `null` (never throws) for anything that isn't a plain non-negative
+ * decimal number, so the route can turn that into a clean 400 rather than a
+ * crash or a silently wrong answer.
+ */
+function usdcToStroops(input) {
+  if (typeof input !== "string" || input.length === 0) return null;
+  // Whole, or whole.fraction — no sign, no exponent, no thousands separators.
+  // Signed/scientific input is exactly the "malformed" case the spec calls
+  // out to reject with a 400, not coerce.
+  const match = /^(\d+)(?:\.(\d+))?$/.exec(input);
+  if (!match) return null;
+  const [, wholeStr, fracStr = ""] = match;
+  if (fracStr.length > USDC_DECIMALS) {
+    // More precision than USDC supports (7 decimals) — reject rather than
+    // silently truncating a value the caller thought they specified exactly.
+    return null;
+  }
+  const whole = BigInt(wholeStr);
+  const fracPadded = fracStr.padEnd(USDC_DECIMALS, "0");
+  const frac = fracPadded.length > 0 ? BigInt(fracPadded) : 0n;
+  return whole * ATOMIC_SCALE + frac;
+}
+
 const routes = {
   "GET /quote": {
     accepts: {
@@ -197,6 +281,186 @@ const routes = {
       input: { topic: "perseverance" },
       inputSchema: { properties: { topic: { type: "string" } } },
       output: { example: { quote: "Ships are safe in harbor, but that's not what ships are for." } },
+    }),
+  },
+
+  // ── SEVEN NEW PAID ROUTES ────────────────────────────────────────────────
+  // Same conventions as /quote above: `accepts` names the price, `description`
+  // + `serviceName` (a dedicated RouteConfig field — see @x402/core's
+  // RouteConfig type — used here rather than folding a name into
+  // `description`, since it exists for exactly this and flows into the
+  // catalog's resourceInfo/discovery metadata) name the resource for Bazaar
+  // discovery, and `extensions: declareDiscoveryExtension(...)` describes the
+  // real input/output shape so a discovering agent knows how to call it.
+  "GET /inspect/:address": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_002_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "Stellar Address Inspector",
+    description:
+      "Give it any Stellar testnet address, get back its XLM balance, USDC balance, and recent transactions.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      pathParams: { address: "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC" },
+      pathParamsSchema: {
+        properties: { address: { type: "string", description: "A Stellar G... account address" } },
+        required: ["address"],
+      },
+      output: {
+        example: {
+          address: "GAATVGLRHZXFC66GEN5QNKD56HC5JJZVHQ3P7ZJNVCCI4WKLN44FICSC",
+          xlmBalance: "9999.9999900",
+          usdcBalance: "10.5664000",
+          recentTransactionHashes: ["ef3f8e67...", "4dfbdff5...", "a35959b5..."],
+        },
+      },
+    }),
+  },
+
+  "GET /stroops": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_001_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "Stroop Converter",
+    description: "Give it a USDC amount, get back the exact stroop value. Useful for building x402 payment payloads.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      input: { usdc: "1.5" },
+      inputSchema: {
+        properties: { usdc: { type: "string", description: "A USDC decimal amount, e.g. \"1.5\"" } },
+        required: ["usdc"],
+      },
+      output: { example: { usdc: "1.5", stroops: "15000000" } },
+    }),
+  },
+
+  "GET /hash": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_001_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "Text Hasher",
+    description: "Give it any text, get back SHA-256 and MD5 hashes. Results are independently verifiable.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      input: { input: "hello world" },
+      inputSchema: {
+        properties: { input: { type: "string", description: "Text to hash, max 500 characters" } },
+        required: ["input"],
+      },
+      output: {
+        example: {
+          input: "hello world",
+          sha256: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde",
+          md5: "5eb63bbbe01eeed093cb22bb8f5acdc3",
+        },
+      },
+    }),
+  },
+
+  "GET /timestamp": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_001_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "Trusted Timestamp",
+    description:
+      "Returns the current time anchored to the Stellar ledger sequence number — a verifiable timestamp from the chain.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      input: {},
+      inputSchema: { properties: {} },
+      output: {
+        example: {
+          iso8601: "2026-08-23T06:54:51.000Z",
+          unixSeconds: 1787036091,
+          stellarLedgerSequence: 4289052,
+        },
+      },
+    }),
+  },
+
+  "GET /base64": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_001_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "Base64 Encoder/Decoder",
+    description: "Encode or decode base64. Useful for reading raw x402 payment headers.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      input: { input: "hello world", mode: "encode" },
+      inputSchema: {
+        properties: {
+          input: { type: "string", description: "Text to encode, or base64 to decode. Max 1000 characters" },
+          mode: { type: "string", enum: ["encode", "decode"] },
+        },
+        required: ["input", "mode"],
+      },
+      output: { example: { mode: "encode", input: "hello world", output: "aGVsbG8gd29ybGQ=" } },
+    }),
+  },
+
+  "GET /word-count": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_001_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "Text Analyzer",
+    description: "Give it any text, get back word count, character count, sentence count, and reading time.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      input: { text: "Ships are safe in harbor. But that's not what ships are for!" },
+      inputSchema: {
+        properties: { text: { type: "string", description: "Text to analyze, max 2000 characters" } },
+        required: ["text"],
+      },
+      output: {
+        example: { words: 11, characters: 62, sentences: 2, estimatedReadingTimeSeconds: 3 },
+      },
+    }),
+  },
+
+  "GET /uuid": {
+    accepts: {
+      scheme: "exact",
+      payTo: PAYTO,
+      network: "stellar:testnet",
+      price: { asset: ASSET, amount: PRICE_ATOMIC_001_USDC },
+      maxTimeoutSeconds: 120,
+    },
+    serviceName: "UUID Generator",
+    description: "Returns a fresh UUID v4 with a SHA-256 fingerprint. Each call is unique and independently verifiable.",
+    mimeType: "application/json",
+    extensions: declareDiscoveryExtension({
+      input: {},
+      inputSchema: { properties: {} },
+      output: {
+        example: {
+          uuid: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          fingerprint: "1155d132ea7a2addad9a75277e...",
+        },
+      },
     }),
   },
 };
@@ -545,75 +809,401 @@ function relayFailure(res, stage, status, headers, body, extra = {}) {
   return res.status(status).json(payload);
 }
 
-app.get("/quote", async (req, res) => {
-  const paymentHeader = req.get("PAYMENT-SIGNATURE") || req.get("X-PAYMENT") || undefined;
-  const presentedPayment = Boolean(paymentHeader);
-  let result;
-  try {
-    result = await httpServer.processHTTPRequest({
-      adapter: adapter(req),
-      path: req.path,
-      method: req.method,
-      paymentHeader,
-      routePattern: "GET /quote",
-    });
-  } catch (err) {
-    return res.status(500).json({ error: "resource server error", detail: String(err?.message || err) });
+/**
+ * Thrown by a route's `validate(req)` to reject malformed/missing/out-of-range
+ * input with a specific status (always a 4xx) and a human-readable message.
+ * Caught by `handlePaidRoute` BEFORE the payment gate runs, so a request that
+ * was never going to produce a valid result never makes it as far as a 402
+ * challenge or a real charge — an agent shouldn't have to pay to learn its
+ * input was malformed.
+ */
+class InputError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
   }
+}
 
-  if (result.type === "payment-error") {
-    const { status, headers, body } = result.response;
-    // NOT every payment-error is a failure. A request that presented NO payment
-    // gets the 402 CHALLENGE, and that is the protocol working — its body is
-    // empty by design because the requirements travel in the `payment-required`
-    // HEADER. Logging it as a failure (and filling the empty body) would make
-    // every unpaid first request look broken, which is the same class of
-    // misleading diagnostic this block exists to remove.
-    if (!presentedPayment) {
-      for (const [k, v] of Object.entries(headers || {})) res.setHeader(k, v);
-      return res.status(status).json(body ?? {});
+/**
+ * Shared payment-gating flow for every paid GET route in this file: validate
+ * input up front, run the request through `processHTTPRequest`, forward a 402
+ * challenge or a verify failure exactly as `/quote` already did, settle
+ * through the facilitator on success, and only then call `buildResult(req)`
+ * for the route's own payload.
+ *
+ * Factored out of `/quote`'s original inline handler (this is the ONLY place
+ * that pattern is now written) so the seven new routes below reuse the exact
+ * same gating instead of eight near-identical copies drifting apart. `/quote`
+ * itself now calls this too — its behavior is unchanged, byte-for-byte, from
+ * before this refactor (it passes no `validate`, so that step is a no-op).
+ *
+ * `validate(req)` runs FIRST, before any payment processing, and must throw
+ * `InputError` (never anything else) to reject a request — this keeps a
+ * malformed/unpaid request from ever reaching the 402 challenge, so nobody is
+ * asked to pay for a request that could never succeed.
+ *
+ * `buildResult(req)` runs AFTER settlement and must be synchronous-or-async;
+ * if it throws (a bug, or an external dependency like Horizon failing in a
+ * way `validate` couldn't have caught up front — e.g. Horizon timing out on a
+ * well-formed address), that is a 502, logged, with payment already settled —
+ * same tradeoff `/quote`'s original handler body always had.
+ */
+function handlePaidRoute(routePattern, buildResult, validate) {
+  return async (req, res) => {
+    if (validate) {
+      try {
+        await validate(req);
+      } catch (err) {
+        if (err instanceof InputError) {
+          return res.status(err.status).json({ error: "invalid_input", detail: err.message });
+        }
+        console.error(`[seller] ${routePattern} validate() threw a non-InputError: ${String(err?.message || err)}`);
+        return res.status(400).json({ error: "invalid_input", detail: String(err?.message || err) });
+      }
     }
-    return relayFailure(res, "verify", status, headers, body, {
-      detail: result.errorReason ?? result.error ?? undefined,
-    });
-  }
-  if (result.type === "no-payment-required") {
-    return res.json({ ok: true, note: "no payment required for this route" });
-  }
 
-  // payment-verified: drive settlement through the facilitator.
-  try {
-    const settle = await httpServer.processSettlement(
-      result.paymentPayload,
-      result.paymentRequirements,
-      result.declaredExtensions,
-    );
+    const paymentHeader = req.get("PAYMENT-SIGNATURE") || req.get("X-PAYMENT") || undefined;
+    const presentedPayment = Boolean(paymentHeader);
+    let result;
+    try {
+      result = await httpServer.processHTTPRequest({
+        adapter: adapter(req),
+        path: req.path,
+        method: req.method,
+        paymentHeader,
+        routePattern,
+      });
+    } catch (err) {
+      return res.status(500).json({ error: "resource server error", detail: String(err?.message || err) });
+    }
+
+    if (result.type === "payment-error") {
+      const { status, headers, body } = result.response;
+      // NOT every payment-error is a failure. A request that presented NO
+      // payment gets the 402 CHALLENGE, and that is the protocol working — its
+      // body is empty by design because the requirements travel in the
+      // payment-required HEADER. Logging it as a failure (and filling the
+      // empty body) would make every unpaid first request look broken, which
+      // is the same class of misleading diagnostic this block exists to
+      // remove.
+      if (!presentedPayment) {
+        for (const [k, v] of Object.entries(headers || {})) res.setHeader(k, v);
+        return res.status(status).json(body ?? {});
+      }
+      return relayFailure(res, "verify", status, headers, body, {
+        detail: result.errorReason ?? result.error ?? undefined,
+      });
+    }
+    if (result.type === "no-payment-required") {
+      return res.json({ ok: true, note: "no payment required for this route" });
+    }
+
+    // payment-verified: drive settlement through the facilitator.
+    let settle;
+    try {
+      settle = await httpServer.processSettlement(
+        result.paymentPayload,
+        result.paymentRequirements,
+        result.declaredExtensions,
+      );
+    } catch (err) {
+      // A throw from processSettlement never had a body to lose, but it was
+      // also never logged — so a crash-shaped failure and a refusal looked
+      // the same from outside.
+      return relayFailure(res, "settle-threw", 502, {}, undefined, {
+        detail: String(err?.message || err),
+      });
+    }
     for (const [k, v] of Object.entries(settle.headers || {})) res.setHeader(k, v);
     if (settle.success === false) {
       const { status, headers, body } = settle.response || {};
-      // `settle.errorReason` carries the facilitator's status and body verbatim
-      // when the client library could not parse a structured error — which is
-      // exactly the case for our own 503s. It is the most informative field
-      // available, and it was being dropped.
+      // `settle.errorReason` carries the facilitator's status and body
+      // verbatim when the client library could not parse a structured error
+      // — which is exactly the case for our own 503s. It is the most
+      // informative field available, and it was being dropped.
       return relayFailure(res, "settle", status || 502, headers, body, {
         detail: settle.errorReason,
         errorMessage: settle.errorMessage,
       });
     }
-    res.json({
-      quote: "Ships are safe in harbor, but that's not what ships are for.",
-      topic: req.query.topic ?? "perseverance",
-      settlement: { transaction: settle.transaction, payer: settle.payer, network: settle.network },
-    });
-  } catch (err) {
-    // A throw from processSettlement never had a body to lose, but it was also
-    // never logged — so a crash-shaped failure and a refusal looked the same
-    // from outside.
-    return relayFailure(res, "settle-threw", 502, {}, undefined, {
-      detail: String(err?.message || err),
-    });
-  }
-});
+
+    // Payment settled. Build this route's own payload; errors here are ours,
+    // not the facilitator's, so they get their own clear status/body rather
+    // than being folded into relayFailure's x402-shaped envelope.
+    try {
+      const payload = await buildResult(req);
+      res.json({
+        ...payload,
+        settlement: { transaction: settle.transaction, payer: settle.payer, network: settle.network },
+      });
+    } catch (err) {
+      console.error(`[seller] ${routePattern} handler failed after settlement: ${String(err?.message || err)}`);
+      res.status(502).json({ error: "handler_failed", detail: String(err?.message || err) });
+    }
+  };
+}
+
+app.get(
+  "/quote",
+  handlePaidRoute("GET /quote", (req) => ({
+    quote: "Ships are safe in harbor, but that's not what ships are for.",
+    topic: req.query.topic ?? "perseverance",
+  })),
+);
+
+// ---------------------------------------------------------------------------
+// SEVEN NEW PAID ROUTES.
+//
+// Each follows the same shape: a `validate` step (runs before any payment
+// processing, throws InputError for a clean 4xx) and a `buildResult` step
+// (runs after settlement, returns the JSON payload merged with `settlement`).
+// Response shape matches /quote's own established convention — flat fields
+// plus a `settlement` block, NOT wrapped in a `result` envelope.
+// ---------------------------------------------------------------------------
+
+app.get(
+  "/inspect/:address",
+  handlePaidRoute(
+    "GET /inspect/:address",
+    async (req) => {
+      const address = req.params.address;
+
+      const [accountRes, txRes] = await Promise.all([
+        fetchHorizon(`/accounts/${encodeURIComponent(address)}`),
+        fetchHorizon(`/accounts/${encodeURIComponent(address)}/transactions?order=desc&limit=3`),
+      ]);
+
+      if (!accountRes.ok) {
+        if (accountRes.status === 404) {
+          throw new InputError(404, `no account found on Stellar testnet for address ${address}`);
+        }
+        const reason = accountRes.timedOut
+          ? "Horizon did not respond within 10s"
+          : accountRes.error || `Horizon returned HTTP ${accountRes.status}`;
+        throw new Error(`horizon_unavailable: ${reason}`);
+      }
+
+      // Horizon's classic /accounts balances array reports both the native
+      // XLM line (asset_type: "native", no asset_code) and any classic
+      // trustline the account holds — including USDC, since the SAC this
+      // seller prices in (CBIELTK6…) wraps a classic Circle-issued asset that
+      // shows up here the same way any other trustline balance does. No
+      // separate Soroban RPC call needed; "all from Horizon testnet" per
+      // spec.
+      const balances = accountRes.body?.balances || [];
+      const xlmLine = balances.find((b) => b.asset_type === "native");
+      const usdcLine = balances.find((b) => b.asset_code === "USDC");
+
+      const hashes = (txRes.ok ? txRes.body?._embedded?.records || [] : []).map((t) => t.hash);
+
+      return {
+        address,
+        xlmBalance: xlmLine?.balance ?? "0",
+        usdcBalance: usdcLine?.balance ?? "0",
+        recentTransactionHashes: hashes,
+      };
+    },
+    async (req) => {
+      const address = req.params.address;
+      if (!address || typeof address !== "string") {
+        throw new InputError(400, "missing address path parameter");
+      }
+      if (!StrKey.isValidEd25519PublicKey(address)) {
+        throw new InputError(400, `"${address}" is not a valid Stellar G... address`);
+      }
+    },
+  ),
+);
+
+app.get(
+  "/stroops",
+  handlePaidRoute(
+    "GET /stroops",
+    (req) => {
+      const usdc = req.query.usdc;
+      const stroops = usdcToStroops(usdc);
+      return { usdc, stroops: stroops.toString() };
+    },
+    (req) => {
+      const usdc = req.query.usdc;
+      if (usdc === undefined || usdc === "") {
+        throw new InputError(400, "missing required query param: usdc");
+      }
+      if (typeof usdc !== "string" || usdcToStroops(usdc) === null) {
+        throw new InputError(
+          400,
+          `"${usdc}" is not a valid USDC decimal amount (expected e.g. "1.5", up to 7 decimal places, no sign/exponent)`,
+        );
+      }
+    },
+  ),
+);
+
+const HASH_INPUT_MAX_LEN = 500;
+
+app.get(
+  "/hash",
+  handlePaidRoute(
+    "GET /hash",
+    (req) => {
+      const input = req.query.input;
+      return {
+        input,
+        sha256: createHash("sha256").update(input, "utf8").digest("hex"),
+        md5: createHash("md5").update(input, "utf8").digest("hex"),
+      };
+    },
+    (req) => {
+      const input = req.query.input;
+      if (input === undefined || input === "") {
+        throw new InputError(400, "missing required query param: input");
+      }
+      if (typeof input !== "string") {
+        throw new InputError(400, "input must be a single string query param");
+      }
+      if (input.length > HASH_INPUT_MAX_LEN) {
+        throw new InputError(400, `input too long (${input.length} chars) — max ${HASH_INPUT_MAX_LEN}`);
+      }
+    },
+  ),
+);
+
+app.get(
+  "/timestamp",
+  handlePaidRoute("GET /timestamp", async () => {
+    const now = new Date();
+    const ledgerRes = await fetchHorizon("/ledgers?order=desc&limit=1");
+    if (!ledgerRes.ok) {
+      const reason = ledgerRes.timedOut
+        ? "Horizon did not respond within 10s"
+        : ledgerRes.error || `Horizon returned HTTP ${ledgerRes.status}`;
+      throw new Error(`horizon_unavailable: ${reason}`);
+    }
+    const ledger = ledgerRes.body?._embedded?.records?.[0];
+    if (!ledger || typeof ledger.sequence !== "number") {
+      throw new Error("horizon_unavailable: unexpected /ledgers response shape (no sequence found)");
+    }
+    return {
+      iso8601: now.toISOString(),
+      unixSeconds: Math.floor(now.getTime() / 1000),
+      stellarLedgerSequence: ledger.sequence,
+    };
+  }),
+);
+
+const BASE64_INPUT_MAX_LEN = 1000;
+// Plausible-base64 check: standard alphabet, correctly padded to a multiple
+// of 4. Used both to reject obviously-invalid `mode=decode` input up front
+// AND, after decoding, to catch Buffer.from's lenient decoding (it silently
+// ignores non-base64 characters rather than throwing) by re-encoding the
+// decoded bytes and comparing against the (whitespace-stripped) original —
+// a round-trip mismatch means the input wasn't really valid base64.
+const BASE64_SHAPE_REGEX = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+app.get(
+  "/base64",
+  handlePaidRoute(
+    "GET /base64",
+    (req) => {
+      const { input, mode } = req.query;
+      if (mode === "encode") {
+        return { mode, input, output: Buffer.from(input, "utf8").toString("base64") };
+      }
+      // mode === "decode", already validated round-trips cleanly.
+      return { mode, input, output: Buffer.from(input, "base64").toString("utf8") };
+    },
+    (req) => {
+      const { input, mode } = req.query;
+      if (mode === undefined || mode === "") {
+        throw new InputError(400, "missing required query param: mode (must be \"encode\" or \"decode\")");
+      }
+      if (mode !== "encode" && mode !== "decode") {
+        throw new InputError(400, `mode must be "encode" or "decode", got "${mode}"`);
+      }
+      if (input === undefined || input === "") {
+        throw new InputError(400, "missing required query param: input");
+      }
+      if (typeof input !== "string") {
+        throw new InputError(400, "input must be a single string query param");
+      }
+      if (input.length > BASE64_INPUT_MAX_LEN) {
+        throw new InputError(400, `input too long (${input.length} chars) — max ${BASE64_INPUT_MAX_LEN}`);
+      }
+      if (mode === "decode") {
+        const stripped = input.replace(/\s+/g, "");
+        if (!BASE64_SHAPE_REGEX.test(stripped)) {
+          throw new InputError(400, `"${input}" is not valid base64`);
+        }
+        // Round-trip check: Buffer.from(x, 'base64') silently ignores
+        // characters outside the alphabet rather than throwing, so the shape
+        // regex above is necessary but re-encoding and comparing is what
+        // actually catches lenient-decode garbage.
+        const roundTripped = Buffer.from(stripped, "base64").toString("base64");
+        if (roundTripped.replace(/=+$/, "") !== stripped.replace(/=+$/, "")) {
+          throw new InputError(400, `"${input}" is not valid base64 (failed round-trip check)`);
+        }
+      }
+    },
+  ),
+);
+
+const WORD_COUNT_INPUT_MAX_LEN = 2000;
+// Reading speed assumption: 200 words per minute. This sits inside the
+// commonly-cited 200-238 wpm average adult silent-reading range; 200 is used
+// specifically because it is the more conservative (slower) end, which is
+// the safer bias for an estimate nobody can verify against the reader. This
+// is a documented heuristic, not a precise measurement.
+const READING_WPM = 200;
+// Sentence-boundary heuristic: count runs of `.`/`!`/`?` as one terminator
+// each (so "..." or "?!" count once). This is not linguistically precise
+// (misses abbreviations like "Mr." as false positives, etc.) — it's a
+// reasonable, documented approximation, not a claim of exactness.
+const SENTENCE_TERMINATOR_REGEX = /[.!?]+/g;
+
+app.get(
+  "/word-count",
+  handlePaidRoute(
+    "GET /word-count",
+    (req) => {
+      const text = req.query.text;
+      const trimmed = text.trim();
+      const words = trimmed.length === 0 ? 0 : trimmed.split(/\s+/).length;
+      const sentenceMatches = text.match(SENTENCE_TERMINATOR_REGEX);
+      const sentences = sentenceMatches ? sentenceMatches.length : 0;
+      const estimatedReadingTimeSeconds = Math.ceil((words / READING_WPM) * 60);
+      return {
+        text,
+        words,
+        characters: text.length,
+        sentences,
+        estimatedReadingTimeSeconds,
+      };
+    },
+    (req) => {
+      const text = req.query.text;
+      if (text === undefined || text === "") {
+        throw new InputError(400, "missing required query param: text");
+      }
+      if (typeof text !== "string") {
+        throw new InputError(400, "text must be a single string query param");
+      }
+      if (text.length > WORD_COUNT_INPUT_MAX_LEN) {
+        throw new InputError(400, `text too long (${text.length} chars) — max ${WORD_COUNT_INPUT_MAX_LEN}`);
+      }
+    },
+  ),
+);
+
+app.get(
+  "/uuid",
+  handlePaidRoute("GET /uuid", () => {
+    // randomUUID() is called fresh on every request — nothing here is cached
+    // or memoized, so distinct calls always produce distinct UUIDs.
+    const uuid = randomUUID();
+    const fingerprint = createHash("sha256").update(uuid, "utf8").digest("hex");
+    return { uuid, fingerprint };
+  }),
+);
 
 app.listen(PORT, () => {
   console.error(`[seller] paid API on ${publicBase()}/quote  (bound to port ${PORT})`);
@@ -627,4 +1217,8 @@ app.listen(PORT, () => {
   }
   console.error(`[seller] facilitator: ${FACILITATOR_URL}`);
   console.error(`[seller] price: ${PRICE_ATOMIC} atomic of ${ASSET} -> ${PAYTO}`);
+  console.error(
+    `[seller] also serving: /inspect/:address (${PRICE_ATOMIC_002_USDC} atomic), ` +
+      `/stroops /hash /timestamp /base64 /word-count /uuid (${PRICE_ATOMIC_001_USDC} atomic each)`,
+  );
 });


### PR DESCRIPTION
## What

Adds 7 new paid GET endpoints to the demo seller (`examples/seller.mjs`, deployed as `vellar-seller-demo` per `render.yaml`), each declaring itself via the Bazaar discovery extension so it auto-catalogs on first payment, same mechanism `/quote` already uses.

| Endpoint | Price | What it does |
|---|---|---|
| `GET /inspect/:address` | 0.02 USDC | XLM balance, USDC balance, last 3 tx hashes for a Stellar address, from Horizon testnet |
| `GET /stroops?usdc=<amount>` | 0.01 USDC | Exact stroop conversion (BigInt, no floating point) |
| `GET /hash?input=<text>` | 0.01 USDC | SHA-256 + MD5 of text, max 500 chars |
| `GET /timestamp` | 0.01 USDC | UTC time (ISO 8601 + epoch) anchored to the current Stellar ledger sequence, from Horizon |
| `GET /base64?input=<text>&mode=encode\|decode` | 0.01 USDC | Base64 encode/decode, max 1000 chars, validated round-trip on decode |
| `GET /word-count?text=<text>` | 0.01 USDC | Word/char/sentence count + reading time, max 2000 chars |
| `GET /uuid` | 0.01 USDC | Fresh UUID v4 + its SHA-256 fingerprint |

`/quote` and `/whoami` are unchanged — confirmed via a byte-identical decoded 402 challenge before/after.

## Verification

- All 7 endpoints hit directly with unauthenticated curl: each returns a well-formed 402 with a correct, useful Bazaar discovery schema (spot-checked the decoded challenges for `/stroops` and `/inspect` — correct price, correct schema, realistic worked examples).
- Input validation runs before the payment gate on every endpoint — malformed/missing input never triggers a 402, so a caller can never be charged for a request that was obviously wrong. Verified: `/stroops?usdc=abc`, `/hash` with no `input`, `/inspect/notanaddress`, `/base64?mode=xyz` all return clean 400s with no crash.
- `/inspect` and `/timestamp` are the only two endpoints that call an external API (Horizon testnet) — both have an explicit 10s timeout and fail gracefully rather than hang or 500.
- Pricing double-checked against USDC's real 7-decimal convention: 200,000 atomic = 0.02 USDC, 100,000 atomic = 0.01 USDC.

Full local verification transcript available on request — not pasted here to keep this readable.

## Not yet proven

Cataloging on the *hosted* facilitator (real settlements → real catalog entries on `/discovery/resources`) requires this seller to be reachable from the internet, which only happens once this merges and Render redeploys. That's the next step after this PR lands, run separately.
