### PR TITLE
Tranche 1 — 1.2: Operational telemetry (11 named Prometheus metrics)

### DIFF
--- a/BUILD-PLAN.md
+++ b/BUILD-PLAN.md
@@ -86,6 +86,13 @@ See docs/decisions.md._
       rotation the way docs/channel-pool-design.md §5 describes; it stays
       `available` and keeps getting acquired until a settlement using it
       fails on-chain.
+- [ ] Migrate src/metrics.ts off `prom-client` (deprecated by its own
+      maintainers as of the version pinned for Tranche 1's telemetry
+      deliverable, 1.2) to `@prometheus-io/client`, the maintainer-named
+      successor — deliberately NOT done for Tranche 1 itself: that package
+      was pre-1.0 (v0.16.1, only 4 published versions) at decision time,
+      too immature to build a grant deliverable on with confidence.
+      Post-Tranche-1 item once it has matured.
 - [x] Hosting DEPLOYED 2026-07-31: `https://vellar-facilitator.onrender.com`
       (render.yaml blueprint, dedicated funded sponsor `GBUCR6H2…`).
       Live-proven: settlement tx `1da6f9e6…` through the hosted instance,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@x402/extensions": "^2.20.0",
         "@x402/stellar": "^2.20.0",
         "fastify": "^5.2.0",
+        "prom-client": "^15.1.3",
         "undici": "^8.10.0",
         "zod": "^4.4.3"
       },
@@ -962,6 +963,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -1919,6 +1929,12 @@
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-11.1.5.tgz",
       "integrity": "sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==",
+      "license": "MIT"
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -3505,6 +3521,20 @@
       ],
       "license": "MIT"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "deprecated": "prom-client has been replaced by @prometheus-io/client",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
@@ -4017,6 +4047,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.3.tgz",
+      "integrity": "sha512-zbRt+lT+/H4fRItHshczHErVCQnitJk8MfMT24MqFJf3YL7SJJPqGIGeuOdvxXxM/AHFzKBl7WoyaYwqO9s3Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/thread-stream": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@libsql/client": "^0.17.4",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@stellar/stellar-sdk": "^16.0.1",
+    "prom-client": "^15.1.3",
     "@x402/core": "^2.20.0",
     "@x402/extensions": "^2.20.0",
     "@x402/stellar": "^2.20.0",

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,199 @@
+// Operational telemetry — Tranche 1 deliverable 1.2
+// (scf-form-response.md: "metrics + structured logging, 10+ named metrics",
+// success criterion "10+ metrics live-verified"). Design: this is the
+// registry + metric-definition module; src/server.ts's own /metrics route
+// (a later step) is the only thing that reads from it, via the exported
+// functions below — server.ts never imports prom-client directly, so every
+// place a metric is touched is a readable, named function call, not a raw
+// prom-client method call scattered through route handlers.
+//
+// EXPLICIT REGISTRY, NOT prom-client's GLOBAL DEFAULT: prom-client ships a
+// module-level singleton (`client.register`) that every metric registers
+// into unless told otherwise. Using it here would mean any test that
+// imports this module — even indirectly, even just to typecheck a type —
+// registers real metrics into a process-wide singleton that outlives the
+// test and collides with the next test's own metric registration attempt
+// (prom-client throws on a duplicate metric name in the same registry).
+// A `new Registry()` instance owned entirely by this module is a page from
+// src/rpcstatus.ts and src/channelPool.ts's own book: state that a test can
+// construct fresh and throw away, never a shared global two unrelated test
+// files could stomp on.
+//
+// prom-client@15.1.3 IS DEPRECATED BY ITS OWN MAINTAINERS in favor of
+// @prometheus-io/client — a deliberate, reviewed decision to still build on
+// it for Tranche 1 (see BUILD-PLAN.md's own follow-up item): the
+// replacement was pre-1.0 (v0.16.1, 4 published versions) at the time this
+// was written, too immature to build a grant deliverable on with
+// confidence, while prom-client itself has 0 known vulnerabilities and
+// remains the de facto standard in production Node.js code. Migration is a
+// tracked post-Tranche-1 item, not forgotten.
+
+import { Registry, Counter, Gauge, Histogram, collectDefaultMetrics } from "prom-client";
+
+/** Owned entirely by this module — see the file-level comment above for why
+ *  this is a fresh instance, never prom-client's own global default
+ *  registry. Exported so src/server.ts's /metrics route can call
+ *  `registry.metrics()` to render the Prometheus text-format response —
+ *  the one place outside this file that legitimately needs the registry
+ *  object itself, everything else uses the named functions below. */
+export const registry = new Registry();
+
+// Node.js process metrics (event loop lag, heap, GC pauses, CPU, file
+// descriptors, etc.) — a near-zero-effort addition once the registry
+// exists, and the convention every Prometheus-consuming tool (Grafana
+// Cloud included) expects a real Node.js service to expose. Confirmed
+// deliberate, not incidental: named separately from the 11 metrics below,
+// which are what the grant's "10+ named metrics" criterion is actually
+// counted against.
+collectDefaultMetrics({ register: registry });
+
+// ---------------------------------------------------------------------------
+// 1. vellar_settle_total — counter, label: outcome (success|failure)
+// ---------------------------------------------------------------------------
+const settleTotal = new Counter({
+  name: "vellar_settle_total",
+  help: "Total /settle requests, by outcome.",
+  labelNames: ["outcome"] as const,
+  registers: [registry],
+});
+
+export function incrementSettleTotal(outcome: "success" | "failure"): void {
+  settleTotal.inc({ outcome });
+}
+
+// ---------------------------------------------------------------------------
+// 2. vellar_settle_errors_total — counter, label: reason
+// ---------------------------------------------------------------------------
+const settleErrorsTotal = new Counter({
+  name: "vellar_settle_errors_total",
+  help: "Total /settle failures, by real error classification.",
+  labelNames: ["reason"] as const,
+  registers: [registry],
+});
+
+export function incrementSettleErrorsTotal(
+  reason: "txBadSeq" | "TRY_AGAIN_LATER" | "pool_exhausted" | "other",
+): void {
+  settleErrorsTotal.inc({ reason });
+}
+
+// ---------------------------------------------------------------------------
+// 3. vellar_verify_total — counter, label: outcome (success|failure)
+// ---------------------------------------------------------------------------
+const verifyTotal = new Counter({
+  name: "vellar_verify_total",
+  help: "Total /verify requests, by outcome.",
+  labelNames: ["outcome"] as const,
+  registers: [registry],
+});
+
+export function incrementVerifyTotal(outcome: "success" | "failure"): void {
+  verifyTotal.inc({ outcome });
+}
+
+// ---------------------------------------------------------------------------
+// 4. vellar_settle_duration_seconds — histogram
+// Buckets: observed p50 ~11s, p95 ~12s from the channel-pool load test
+// (docs/channel-pool-design.md's own Run 2 result). A bucket boundary at 15
+// makes the grant's own "p95 <= 15s" success criterion directly readable
+// off the histogram's cumulative counts, without computing a percentile by
+// hand.
+// ---------------------------------------------------------------------------
+const settleDurationSeconds = new Histogram({
+  name: "vellar_settle_duration_seconds",
+  help: "Wall-clock duration of a /settle request, in seconds.",
+  buckets: [0.5, 1, 2, 3, 5, 7, 10, 12, 15, 20, 30],
+  registers: [registry],
+});
+
+export function observeSettleDurationSeconds(seconds: number): void {
+  settleDurationSeconds.observe(seconds);
+}
+
+// ---------------------------------------------------------------------------
+// 5-7. Channel-account pool gauges — mirror /health's own channelPool
+// field (src/server.ts, docs/channel-pool-design.md §5). Set at SCRAPE TIME
+// from pool.status(), not incremented — see setPoolGauges' own doc comment.
+// ---------------------------------------------------------------------------
+const poolAvailable = new Gauge({
+  name: "vellar_pool_available",
+  help: "Channel accounts currently available for acquisition.",
+  registers: [registry],
+});
+const poolInUse = new Gauge({
+  name: "vellar_pool_in_use",
+  help: "Channel accounts currently acquired by an in-flight settlement.",
+  registers: [registry],
+});
+const poolDisabled = new Gauge({
+  name: "vellar_pool_disabled",
+  help: "Channel accounts currently disabled (e.g. low balance) and excluded from acquisition.",
+  registers: [registry],
+});
+
+/**
+ * Sets all three pool gauges at once from a single ChannelPool.status()
+ * read. Deliberately one function, not three — the three counts are only
+ * ever meaningful read together (this mirrors /health's own channelPool
+ * field, which always reports all three from one status() call), and a
+ * caller reaching for "just set poolInUse" independently of the other two
+ * would produce a scrape whose three pool gauges came from two different
+ * moments in time.
+ */
+export function setPoolGauges(status: { available: number; inUse: number; disabled: number }): void {
+  poolAvailable.set(status.available);
+  poolInUse.set(status.inUse);
+  poolDisabled.set(status.disabled);
+}
+
+// ---------------------------------------------------------------------------
+// 8. vellar_catalog_size — gauge, set at scrape time
+// ---------------------------------------------------------------------------
+const catalogSize = new Gauge({
+  name: "vellar_catalog_size",
+  help: "Number of resources currently in the Bazaar catalog.",
+  registers: [registry],
+});
+
+export function setCatalogSize(size: number): void {
+  catalogSize.set(size);
+}
+
+// ---------------------------------------------------------------------------
+// 9. vellar_rate_limit_rejections_total — counter
+// ---------------------------------------------------------------------------
+const rateLimitRejectionsTotal = new Counter({
+  name: "vellar_rate_limit_rejections_total",
+  help: "Total requests rejected for exceeding the per-IP rate limit.",
+  registers: [registry],
+});
+
+export function incrementRateLimitRejectionsTotal(): void {
+  rateLimitRejectionsTotal.inc();
+}
+
+// ---------------------------------------------------------------------------
+// 10. vellar_uptime_seconds — gauge, set at scrape time
+// ---------------------------------------------------------------------------
+const uptimeSeconds = new Gauge({
+  name: "vellar_uptime_seconds",
+  help: "Process uptime in seconds (matches /health's own uptimeSeconds field).",
+  registers: [registry],
+});
+
+export function setUptimeSeconds(seconds: number): void {
+  uptimeSeconds.set(seconds);
+}
+
+// ---------------------------------------------------------------------------
+// 11. vellar_reverify_pending — gauge, set at scrape time
+// ---------------------------------------------------------------------------
+const reverifyPending = new Gauge({
+  name: "vellar_reverify_pending",
+  help: "Boot-time re-proof probes still in flight (matches /health's own reverifyPending field).",
+  registers: [registry],
+});
+
+export function setReverifyPending(count: number): void {
+  reverifyPending.set(count);
+}

--- a/src/server.metrics.test.ts
+++ b/src/server.metrics.test.ts
@@ -1,0 +1,320 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import type { PaymentRequirements } from "@x402/core/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+import { fakeChannelAccountSecretKeys } from "./testChannelPoolKeys.js";
+import { registry } from "./metrics.js";
+
+// Tranche 1 deliverable 1.2 (scf-form-response.md: "metrics + structured
+// logging, 10+ named metrics") — this file tests the METRICS
+// instrumentation specifically: that the right counters/histogram move on
+// the right paths, and that /metrics itself returns valid, complete
+// Prometheus text. The underlying /settle and /verify HANDLER LOGIC (spend
+// policy, balance guard, bond registration, malformed-payload handling) is
+// already covered by server.test.ts and server.bondregistration.test.ts —
+// not duplicated here. Isolated in its own file, matching the existing
+// server.pagination.test.ts / server.policykey.test.ts /
+// server.health.test.ts / server.bondregistration.test.ts convention.
+//
+// RESET MECHANISM (confirmed from prom-client's own type definitions,
+// node_modules/prom-client/index.d.ts): Registry has both `clear()` (REMOVES
+// all metrics, which would desync src/metrics.ts's own long-lived
+// Counter/Gauge/Histogram objects from the registry — they'd still exist as
+// JS objects but no longer be attached to it) and `resetMetrics()` (resets
+// VALUES, keeps every metric definition registered). resetMetrics() is the
+// correct one here: src/metrics.ts registers all 11 metrics plus
+// collectDefaultMetrics() exactly once, at module import time, into ONE
+// module-level `registry` — the same singleton every test in this file (and
+// every real request in the actual app) shares, so counters would otherwise
+// accumulate across tests within this one run.
+
+const testConfig = {
+  port: 0,
+  host: "127.0.0.1",
+  network: "stellar:testnet" as const,
+  rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(),
+  channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
+  maxTransactionFeeStroops: 2_000_000,
+  catalogDbUrl: undefined,
+  uptoContractId: undefined,
+  bondEscrowContractId: undefined,
+  bondEscrowAdminSecretKey: undefined,
+  catalogDbAuthToken: undefined,
+  verificationApiUrl: undefined,
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 100, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 100_000_000, hardFloorStroops: 20_000_000, intervalMs: 60_000 },
+};
+
+// Same structurally-valid envelope server.test.ts / server.bondregistration.test.ts
+// already use — /settle shreds unparseable XDR at the route before ever
+// reaching facilitator.settle, so a real test needs real (if fake-signed) XDR.
+const VALID_TX_XDR =
+  "AAAAAgAAAAARUqIOOVQYwBn0s32MhGQwyoTHPy7SzjfXdweAw6b/4gAAAGQAAAAAAAAAAgAAAAEAAAAAAAAAAAAAAABqdyAuAAAAAAAAAAEAAAAAAAAAAQAAAADrmp8rY1JU7CL78HNaROud45MqVmrrbxOCVuWSEz0eRwAAAAAAAAAAAJiWgAAAAAAAAAAA";
+
+function requirements(): PaymentRequirements {
+  return {
+    scheme: "exact",
+    network: "stellar:testnet",
+    asset: "CBIN4HTPJM2QLJ32DTRO6OCLIMM7TR7D74JDIPVQYLNYGL7SBWOXH5ND",
+    amount: "1000000",
+    payTo: "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A",
+    maxTimeoutSeconds: 60,
+    extra: {},
+  } as PaymentRequirements;
+}
+
+function settleBody() {
+  return {
+    x402Version: 2,
+    paymentPayload: {
+      x402Version: 2,
+      scheme: "exact",
+      network: "stellar:testnet",
+      payload: { transaction: VALID_TX_XDR },
+    },
+    paymentRequirements: requirements(),
+  };
+}
+
+function verifyBody() {
+  return settleBody();
+}
+
+const METRIC_LINE = /^[a-zA-Z_:][a-zA-Z0-9_:]*(\{[^}]*\})?\s+-?[0-9.eE+-]+(\s+[0-9]+)?$/m;
+
+describe("/metrics", () => {
+  beforeEach(() => {
+    registry.resetMetrics();
+  });
+
+  it("returns HTTP 200 with Content-Type matching registry.contentType", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      const res = await app.inject({ method: "GET", url: "/metrics" });
+      expect(res.statusCode).toBe(200);
+      expect(res.headers["content-type"]).toBe(registry.contentType);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("response body is valid Prometheus text (contains at least one correctly-formatted metric line)", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      const res = await app.inject({ method: "GET", url: "/metrics" });
+      expect(res.body).toMatch(METRIC_LINE);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("all 11 named vellar_* metrics are present in the response body", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      const res = await app.inject({ method: "GET", url: "/metrics" });
+      const body = res.body;
+      // Names only — not asserting specific values here, that's covered by
+      // the /settle and /verify instrumentation tests below. This test's
+      // job is completeness: every one of the grant's "10+ named metrics"
+      // actually shows up on a real scrape, not just that it compiles.
+      const expectedNames = [
+        "vellar_settle_total",
+        "vellar_settle_errors_total",
+        "vellar_verify_total",
+        "vellar_settle_duration_seconds",
+        "vellar_pool_available",
+        "vellar_pool_in_use",
+        "vellar_pool_disabled",
+        "vellar_catalog_size",
+        "vellar_rate_limit_rejections_total",
+        "vellar_uptime_seconds",
+        "vellar_reverify_pending",
+      ];
+      expect(expectedNames).toHaveLength(11);
+      for (const name of expectedNames) {
+        expect(body, `expected ${name} to appear in /metrics output`).toContain(name);
+      }
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("rate limit is active: the 61st request in a minute is rejected, not served", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      let lastStatus = 0;
+      for (let i = 0; i < 61; i++) {
+        const res = await app.inject({ method: "GET", url: "/metrics" });
+        lastStatus = res.statusCode;
+      }
+      // @fastify/rate-limit's own documented behavior on exceeding the
+      // configured max: 429 Too Many Requests (confirmed against its
+      // README/source — the same status code the GLOBAL limiter already
+      // relies on elsewhere in this codebase, src/hardening.test.ts).
+      expect(lastStatus).toBe(429);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/settle metrics instrumentation", () => {
+  beforeEach(() => {
+    registry.resetMetrics();
+  });
+
+  async function scrapeVellarMetric(app: Awaited<ReturnType<typeof buildServer>>, name: string): Promise<string> {
+    const res = await app.inject({ method: "GET", url: "/metrics" });
+    const lines = res.body.split("\n").filter((l) => l.startsWith(name));
+    return lines.join("\n");
+  }
+
+  it("a successful settle increments vellar_settle_total{outcome=\"success\"}", async () => {
+    // Real facilitator.settle() cannot return success:true offline (no live
+    // Soroban RPC in this test suite) — same constraint
+    // server.bondregistration.test.ts's own appWithStubbedSuccess helper
+    // documents ("no existing test in server.test.ts achieves success:true
+    // either"). Stubbing facilitator.settle directly is the established,
+    // correct way to reach this path.
+    const built = buildFacilitator(testConfig);
+    vi.spyOn(built.facilitator, "settle").mockResolvedValue({
+      success: true,
+      transaction: "a".repeat(64),
+      payer: Keypair.random().publicKey(),
+      network: "stellar:testnet",
+    } as never);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: settleBody() });
+      expect(res.statusCode).toBe(200);
+      const metric = await scrapeVellarMetric(app, "vellar_settle_total");
+      expect(metric).toContain('vellar_settle_total{outcome="success"} 1');
+      expect(metric).not.toContain('outcome="failure"');
+    } finally {
+      vi.restoreAllMocks();
+      await app.close();
+    }
+  });
+
+  it("a failed settle increments vellar_settle_total{outcome=\"failure\"} and vellar_settle_errors_total with the correct reason", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      // The 400 invalid_body path — a real, reachable failure with no
+      // mocking needed at all.
+      const res = await app.inject({ method: "POST", url: "/settle", payload: {} });
+      expect(res.statusCode).toBe(400);
+      const settleTotal = await scrapeVellarMetric(app, "vellar_settle_total");
+      expect(settleTotal).toContain('vellar_settle_total{outcome="failure"} 1');
+      const errors = await scrapeVellarMetric(app, "vellar_settle_errors_total");
+      // invalid_body is not one of the three named reasons (pool_exhausted /
+      // txBadSeq / TRY_AGAIN_LATER) — confirmed by reading src/server.ts:
+      // errorReason is only ever set inside those three specific branches,
+      // so anything else defaults to "other" in the finally block.
+      expect(errors).toContain('vellar_settle_errors_total{reason="other"} 1');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("the duration histogram is observed on /settle even on the early-return 400 path", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      const res = await app.inject({ method: "POST", url: "/settle", payload: {} });
+      expect(res.statusCode).toBe(400);
+      const histogram = await scrapeVellarMetric(app, "vellar_settle_duration_seconds_count");
+      // Exactly one observation — the 400 never reached facilitator.settle()
+      // at all, confirming the histogram covers the WHOLE handler, not just
+      // the path that calls the facilitator.
+      expect(histogram).toContain("vellar_settle_duration_seconds_count 1");
+    } finally {
+      await app.close();
+    }
+  });
+
+  // NOT UNIT-TESTABLE OFFLINE — investigated, not assumed. Draining the real
+  // pool (via built.pool.acquire() in a loop) and firing a real /settle
+  // request was tried first; it reaches ExactStellarScheme._verify() and
+  // throws there (TypeError, Cannot read properties of undefined), because
+  // _verify() genuinely simulates the transaction against live Soroban RPC
+  // before settle() ever calls selectSigner — the same reason no other test
+  // in this codebase reaches a genuine facilitator.settle() success either
+  // (see server.bondregistration.test.ts's own appWithStubbedSuccess
+  // comment). Mocking facilitator.settle to skip that step also skips
+  // selectSigner entirely — poolExhausted is a flag set INSIDE
+  // facilitator.ts's own selectSigner closure
+  // (channelAcquisitionStore.getStore().poolExhausted = true, private to
+  // that module, never exported), reachable only through a real,
+  // unmocked settle() call. A mocked settle() cannot exercise it no matter
+  // what the mock returns or throws.
+  //
+  // Exporting a test-only seam into facilitator.ts (e.g. the
+  // AsyncLocalStorage itself, or a helper to set the flag directly) to make
+  // this one case reachable offline was explicitly considered and
+  // rejected — production-code surface area added solely to satisfy one
+  // test is exactly the kind of thing that outlives its own justification.
+  //
+  // REAL EVIDENCE THIS PATH WORKS, instead: the channel-pool load test run
+  // on 2026-08-31 (load-test-results-2026-08-31T11-15-47-630Z.json) — during
+  // that run's FIRST attempt, before the double-acquisition bug
+  // (src/facilitator.ts's own withChannelAcquisitionCapture doc comment)
+  // was found and fixed, the real pool genuinely exhausted under real load
+  // and produced real 503 pool_exhausted responses from server.ts's own
+  // classification logic — the exact code path this test would otherwise
+  // exercise, proven correct end-to-end against a real running instance,
+  // not simulated.
+});
+
+describe("/verify metrics instrumentation", () => {
+  beforeEach(() => {
+    registry.resetMetrics();
+  });
+
+  async function scrapeVellarMetric(app: Awaited<ReturnType<typeof buildServer>>, name: string): Promise<string> {
+    const res = await app.inject({ method: "GET", url: "/metrics" });
+    const lines = res.body.split("\n").filter((l) => l.startsWith(name));
+    return lines.join("\n");
+  }
+
+  it("a successful verify increments vellar_verify_total{outcome=\"success\"}", async () => {
+    const built = buildFacilitator(testConfig);
+    vi.spyOn(built.facilitator, "verify").mockResolvedValue({
+      isValid: true,
+      payer: Keypair.random().publicKey(),
+    } as never);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      const res = await app.inject({ method: "POST", url: "/verify", payload: verifyBody() });
+      expect(res.statusCode).toBe(200);
+      expect(res.json().isValid).toBe(true);
+      const metric = await scrapeVellarMetric(app, "vellar_verify_total");
+      expect(metric).toContain('vellar_verify_total{outcome="success"} 1');
+      expect(metric).not.toContain('outcome="failure"');
+    } finally {
+      vi.restoreAllMocks();
+      await app.close();
+    }
+  });
+
+  it("a failed verify increments vellar_verify_total{outcome=\"failure\"}", async () => {
+    const built = buildFacilitator(testConfig);
+    const app = await buildServer(built, await BazaarCatalog.create());
+    try {
+      // The 400 invalid_body path — real, no mocking needed.
+      const res = await app.inject({ method: "POST", url: "/verify", payload: {} });
+      expect(res.statusCode).toBe(400);
+      const metric = await scrapeVellarMetric(app, "vellar_verify_total");
+      expect(metric).toContain('vellar_verify_total{outcome="failure"} 1');
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,18 @@ import {
 import { createSpendPolicy, type SpendPolicy } from "./policy.js";
 import { BalanceGuard } from "./balance.js";
 import { registerSettlement, type BondEscrowOptions } from "./bond.js";
+import {
+  registry as metricsRegistry,
+  setPoolGauges,
+  setCatalogSize,
+  setUptimeSeconds,
+  setReverifyPending,
+  incrementRateLimitRejectionsTotal,
+  incrementSettleTotal,
+  incrementSettleErrorsTotal,
+  observeSettleDurationSeconds,
+  incrementVerifyTotal,
+} from "./metrics.js";
 
 interface FacilitatorRequestBody {
   x402Version?: number;
@@ -119,7 +131,31 @@ export async function buildServer(
     global: true,
     max: hardening.rateMaxPerMinute ?? DEFAULT_RATE_MAX,
     timeWindow: "1 minute",
+    // Only /health is fully exempt — unthrottled by design, since Render's
+    // own health checker must never be blocked (a throttled health check
+    // reads as a dead instance and could trigger a restart loop). /metrics
+    // (Tranche 1 deliverable 1.2) deliberately does NOT get the same
+    // exemption: allowList is a COMPLETE bypass in @fastify/rate-limit's
+    // own implementation (confirmed by reading its source — an allow-listed
+    // request returns { isAllowed: true } immediately, with no fallback
+    // ceiling of any kind still applying underneath it), so putting
+    // /metrics here would mean truly unbounded public access. It has its
+    // own real, generous per-route ceiling instead (see the /metrics route
+    // itself) — a scraper polling every 15s has 15x headroom before ever
+    // being affected, while a real ceiling still exists for anything else
+    // that finds the public URL. Nothing on /metrics is secret (confirmed
+    // by reading every metric definition in src/metrics.ts — counts,
+    // gauges, a duration histogram, never an address or a key), so this is
+    // about compute-cost/abuse posture, not confidentiality.
     allowList: (req) => req.url === "/health",
+    // vellar_rate_limit_rejections_total (src/metrics.ts) — onExceeded is
+    // the correct hook (confirmed against @fastify/rate-limit's own type
+    // definitions): it fires exactly when a request is ACTUALLY rejected
+    // for exceeding the limit, unlike onExceeding, which fires earlier, as
+    // the count approaches the limit but before it's actually tripped —
+    // using that one instead would count requests that were still allowed
+    // through.
+    onExceeded: () => incrementRateLimitRejectionsTotal(),
   });
 
   app.get("/health", async () => ({
@@ -180,11 +216,65 @@ export async function buildServer(
       : {}),
   }));
 
+  // Tranche 1 deliverable 1.2 (scf-form-response.md: "metrics + structured
+  // logging, 10+ named metrics") — Prometheus text-format scrape endpoint,
+  // src/metrics.ts owns the registry and all 11 metric definitions; this
+  // route only sets the gauges that reflect CURRENT state (mirroring
+  // /health's own catalog.size/catalog.reverifyPending/pool.status() reads
+  // immediately above) and renders the registry.
+  //
+  // Gauges are set here, at scrape time, not on every underlying event —
+  // same reasoning as /health's own channelPool field: a gauge should
+  // always reflect "what is true right now", and setting it only when
+  // scraped (rather than, say, on every catalog mutation) means it can
+  // never go stale between scrapes the way an incrementally-maintained
+  // gauge could if an update were ever missed.
+  //
+  // RATE LIMIT, deliberately NOT the same treatment as /health: /health is
+  // fully allow-listed (unthrottled) because Render's own health checker
+  // must never be blocked. /metrics is a public, unauthenticated endpoint
+  // by necessity (Grafana Cloud's scraper needs to reach it with no
+  // credentials) — but "public" and "unthrottled" are different questions,
+  // and allow-listing it would have meant genuinely unbounded access, since
+  // @fastify/rate-limit's allowList is a complete bypass with no fallback
+  // ceiling underneath it (confirmed by reading its source). This route
+  // gets its own real per-route ceiling instead: 60 req/min is 15x the ~4
+  // req/min a 15s-interval scraper actually generates, so the intended
+  // scraper is never affected, while the endpoint is not literally
+  // unlimited to anything else that finds the URL. Not because the content
+  // is sensitive (it isn't — confirmed by reading every metric definition
+  // in src/metrics.ts: counts, gauges, a duration histogram, never an
+  // address or a key) but because unbounded public compute is its own
+  // exposure regardless of what the response contains.
+  app.get(
+    "/metrics",
+    { config: { rateLimit: { max: 60, timeWindow: 60_000 } } },
+    async (_request, reply) => {
+      setPoolGauges(pool.status());
+      setCatalogSize(catalog.size);
+      setUptimeSeconds(process.uptime());
+      setReverifyPending(catalog.reverifyPending);
+      reply.header("content-type", metricsRegistry.contentType);
+      return metricsRegistry.metrics();
+    },
+  );
+
   app.get("/supported", async () => facilitator.getSupported());
 
   app.post<{ Body: FacilitatorRequestBody }>("/verify", async (request, reply) => {
+    // Tranche 1 deliverable 1.2 telemetry (src/metrics.ts). Explicit calls
+    // at each return, NOT try/finally: unlike /settle, this handler has
+    // exactly 3 exit points, no try/catch of its own, no async side effects
+    // beyond the one facilitator.verify() call, and every path's outcome is
+    // already known at the point of its own return statement — wrapping it
+    // would add a layer of indirection this handler's actual shape doesn't
+    // need. (Contrast with /settle's ~10 return points across nested
+    // try/catch/finally blocks and bond-registration branches, where
+    // try/finally is what keeps every path covered without having to
+    // enumerate them all by hand.)
     const { paymentPayload, paymentRequirements } = request.body ?? {};
     if (!paymentPayload || !paymentRequirements) {
+      incrementVerifyTotal("failure");
       return reply.status(400).send(
         verifyError("invalid_body", {
           error: "invalid_body",
@@ -197,6 +287,7 @@ export async function buildServer(
     // still costs one simulation upstream), so reject anything whose transaction
     // isn't parseable XDR without a network round-trip.
     if (!isParseableTransactionXdr(paymentPayload)) {
+      incrementVerifyTotal("failure");
       return reply.status(400).send(
         verifyError("invalid_payload", {
           error: "invalid_payload",
@@ -204,23 +295,53 @@ export async function buildServer(
         }),
       );
     }
-    return withSkewRetry(
+    const result = await withSkewRetry(
       () => facilitator.verify(paymentPayload, paymentRequirements),
       (r) => (r as { invalidReason?: string }).invalidReason,
       (m) => request.log.warn(m),
     );
+    incrementVerifyTotal((result as { isValid?: boolean }).isValid === true ? "success" : "failure");
+    return result;
   });
 
   app.post<{ Body: FacilitatorRequestBody }>("/settle", async (request, reply) => {
-    const { paymentPayload, paymentRequirements } = request.body ?? {};
-    if (!paymentPayload || !paymentRequirements) {
-      return reply.status(400).send(
-        settleError(network, "invalid_body", {
-          error: "invalid_body",
-          detail: "paymentPayload and paymentRequirements are required",
-        }),
-      );
-    }
+    // Tranche 1 deliverable 1.2 telemetry (src/metrics.ts). startTime is
+    // recorded before the try block, ahead of every early return this
+    // handler has — a pool_exhausted refusal or a balance/policy rejection
+    // is still a real /settle request that took real wall-clock time and
+    // belongs in vellar_settle_duration_seconds, not just the requests that
+    // reach facilitator.settle() itself.
+    //
+    // outcome defaults to "failure" and is ONLY overwritten to "success" at
+    // the one genuine success return path (the final `return result;` at
+    // the end of this handler, reached exclusively when result.success ===
+    // true and — if bond registration is configured — it also succeeded).
+    // This default-to-failure posture is deliberate: if this handler ever
+    // grows an 11th return path that forgets to set outcome, it silently
+    // counts as a failure rather than a silent, wrong "success" — the
+    // safer failure mode for a metric a grant reviewer will read.
+    //
+    // errorReason is set at each point the REAL cause is already known in
+    // the existing code (pool_exhausted's own branch; rpcStatus's
+    // txBadSeq/TRY_AGAIN_LATER classification once rpcStatus exists) —
+    // confirmed by reading the actual server.ts source rather than assumed:
+    // neither "txBadSeq" nor "TRY_AGAIN_LATER" appears anywhere in this
+    // file as a literal errorReason string; both only ever arrive via
+    // rpcStatus.errorCode / rpcStatus.status, a separate object from
+    // result.errorReason.
+    const startTime = performance.now();
+    let outcome: "success" | "failure" = "failure";
+    let errorReason: "txBadSeq" | "TRY_AGAIN_LATER" | "pool_exhausted" | "other" | undefined;
+    try {
+      const { paymentPayload, paymentRequirements } = request.body ?? {};
+      if (!paymentPayload || !paymentRequirements) {
+        return reply.status(400).send(
+          settleError(network, "invalid_body", {
+            error: "invalid_body",
+            detail: "paymentPayload and paymentRequirements are required",
+          }),
+        );
+      }
     // Re-audit: shed unsubmittable payloads BEFORE reserving spend budget,
     // symmetric with /verify. Junk costs the sponsor no XLM, so it must not be
     // able to consume the global ceiling and refuse real settlement.
@@ -341,6 +462,7 @@ export async function buildServer(
         // (docs/channel-pool-design.md §4) — nothing was spent, nothing
         // about this request was invalid, the pool was simply, transiently,
         // fully checked out.
+        errorReason = "pool_exhausted";
         request.log.warn({ status: pool.status() }, "[channel-pool] settle refused: pool exhausted");
         return reply.status(503).send(
           settleError(network, "pool_exhausted", {
@@ -382,6 +504,21 @@ export async function buildServer(
     // (do not retry, the payload is stale). Additive: the x402-required fields
     // are untouched.
     if (result.success === false && rpcStatus) {
+      // vellar_settle_errors_total (src/metrics.ts) classification — the
+      // ONLY two places these two specific reasons ever originate, per the
+      // real rpcStatus shape (src/rpcstatus.ts's CapturedRpcStatus):
+      // rpcStatus.errorCode carries "txBadSeq" when the RPC's own
+      // errorResult XDR decodes to that name; rpcStatus.status carries
+      // "TRY_AGAIN_LATER" when the RPC declined to forward the transaction
+      // at all (no errorResult in that case). Anything else reaching this
+      // branch is a real rpcStatus the caller should still see, just not
+      // one of these two named metric reasons — falls through to "other".
+      errorReason =
+        rpcStatus.errorCode === "txBadSeq"
+          ? "txBadSeq"
+          : rpcStatus.status === "TRY_AGAIN_LATER"
+            ? "TRY_AGAIN_LATER"
+            : "other";
       request.log.warn({ rpcStatus }, "[settle] submission refused by the RPC");
       return { ...result, rpcStatus };
     }
@@ -491,7 +628,20 @@ export async function buildServer(
         );
       }
     }
-    return result;
+      // The one genuine success path — reached only when result.success ===
+      // true survived every intermediate guard above, including bond
+      // registration (every bond-registration failure branch returns
+      // early with its own response before control ever reaches here).
+      outcome = "success";
+      return result;
+    } finally {
+      const durationSeconds = (performance.now() - startTime) / 1000;
+      observeSettleDurationSeconds(durationSeconds);
+      incrementSettleTotal(outcome);
+      if (outcome === "failure") {
+        incrementSettleErrorsTotal(errorReason ?? "other");
+      }
+    }
   });
 
   /**


### PR DESCRIPTION
## Scope

This PR currently covers **1.2 only** — operational telemetry. It is a **draft** and not ready to merge: per the plan for this branch, nothing merges to `main` until all remaining Tranche 1 deliverables (1.1, 1.2, 1.3, 1.5) are complete and reviewed together. Opening now for early visibility into 1.2's diff.

## What's in this PR

- `/metrics` endpoint (Prometheus text format) via `prom-client`
- 11 named metrics: `vellar_settle_total`, `vellar_settle_errors_total`, `vellar_verify_total`, `vellar_settle_duration_seconds`, `vellar_pool_available`, `vellar_pool_in_use`, `vellar_pool_disabled`, `vellar_catalog_size`, `vellar_rate_limit_rejections_total`, `vellar_uptime_seconds`, `vellar_reverify_pending` — plus `collectDefaultMetrics()` for Node.js process internals
- `/settle` instrumented via `try/finally` wrapping the full handler (covers all ~10 exit paths structurally); `/verify` instrumented with explicit calls (3 exit paths)
- `/metrics` is route-scoped rate-limited (60 req/min per IP) — not on the global allow-list; `/health` remains the only fully unthrottled route
- 9 new tests in `src/server.metrics.test.ts`
- `prom-client@15.1.3` chosen deliberately over the pre-1.0 `@prometheus-io/client` successor for a grant deliverable — migration tracked as a follow-up in `BUILD-PLAN.md`

## Still pending on this branch (not in this diff yet)

- **1.1** — Postgres decision (current catalog storage is libSQL/Turso, not Postgres as the grant text literally names)
- **1.3** — public status dashboard (Grafana Cloud will scrape this PR's `/metrics` endpoint)
- **1.5** — deploy runbook

## Deploy note

⚠️ **Do not redeploy the hosted Render instance from `main` (or this branch) yet.** An earlier commit already on `main` made `CHANNEL_ACCOUNT_SECRET_KEYS` a hard-required boot-time env var (the channel-account pool work) — it is **not currently set** in the Render service's environment. Deploying without it first will crash-loop the live instance on boot. 50 real, funded channel-account keys need to be provisioned and set on Render before any redeploy, independent of this PR's own merge timing.

## Verification

- `npm run typecheck` — clean
- `npm test` — 465/465 passing (456 pre-existing + 9 new)
- `/metrics` live-verified against a real running local instance (correct `Content-Type`, all 11 metric names present, rate limit confirmed active at request 61)