### PR TITLE
feat(discovery): USDT0 asset filter and catalogAssets on /supported

### DIFF
--- a/docs/asset-support.md
+++ b/docs/asset-support.md
@@ -1,0 +1,113 @@
+# Asset Support
+
+The Vellar Facilitator is **asset-agnostic at settle time** — it does not enforce
+which assets are valid, and it maintains no allowlist. Any SEP-41 token a seller
+declares in their payment requirements will settle. That is a deliberate design
+decision, recorded in [`docs/security-audit.md`](./security-audit.md) (F2): an
+asset allowlist was evaluated and judged unnecessary given the ownership binding.
+
+What the Bazaar catalog surfaces is therefore **descriptive, not prescriptive**:
+it reports which assets sellers have actually chosen to accept, derived from real
+settlement history. Nothing on this page is an endorsement of an asset, and
+nothing here restricts one.
+
+## USDC
+
+The primary payment asset on both networks, and the default in this repo's own
+examples and in `@x402/stellar`.
+
+| | |
+|---|---|
+| Testnet SAC | `CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA` |
+| Mainnet SAC | `CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75` |
+| Decimals | 7 |
+
+USDC does not have clawback or revocability enabled.
+
+## USDT0
+
+USDT0 is Tether's LayerZero OFT-standard stablecoin on Stellar mainnet. It
+maintains a unified supply backed 1:1 by USDT on Ethereum, so USDT can move
+across networks without fragmenting supply.
+
+| | |
+|---|---|
+| Mainnet SAC | `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` |
+| Classic asset | `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` |
+| Testnet | **Not available** — USDT0 is mainnet only |
+
+> **IMPORTANT — clawback and revocability.**
+>
+> USDT0 sets `auth_revocable` and `auth_clawback_enabled`. This means Tether (the
+> issuer) can revoke a trustline or claw back a balance from any account holding
+> USDT0.
+>
+> The Vellar Facilitator is **non-custodial**: payments flow directly from the
+> payer to the seller's `payTo` address, and the facilitator's sponsor key is
+> used only to pay the network fee (it is passed solely as `feeBumpSigner` and is
+> never a settlement source account — see `src/facilitator.ts`). The facilitator
+> never holds USDT0, or any other asset, on anyone's behalf.
+>
+> **The clawback risk therefore sits entirely with the seller, not with Vellar.**
+> Sellers should understand this property before accepting USDT0 as payment.
+>
+> USDC does not carry this risk.
+
+Note on provenance: the issuer address and the `auth_revocable` /
+`auth_clawback_enabled` flags above are properties of the asset itself, published
+by its issuer. They are recorded here for seller awareness and are not asserted
+or verified by this facilitator — confirm them against Horizon before relying on
+them for anything consequential.
+
+## Querying by asset
+
+`GET /discovery/resources` accepts an optional `asset` query param that keeps
+only listings with at least one `accepts` entry for that exact asset:
+
+```
+GET /discovery/resources?asset=CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF
+```
+
+Returns only listings that accept USDT0 as payment.
+
+Details worth knowing:
+
+- **Exact, case-sensitive** string match. Stellar contract addresses are base32
+  and case-sensitive; a lowercased address matches nothing.
+- **Combines with the other filters as AND**, not a union — `?asset=X&network=Y`
+  returns only listings satisfying both conditions.
+  <br>One subtlety, matching how the existing `payTo` / `scheme` / `network`
+  filters already behave: each filter is applied independently across a
+  listing's `accepts` array, so the two conditions may be satisfied by
+  *different* accepts entries. A listing accepting USDC-on-testnet and
+  USDT0-on-pubnet matches `?asset=<USDT0>&network=stellar:testnet`. If you need
+  a single accepts entry satisfying both, intersect client-side — the response
+  carries the full `accepts` array for exactly that purpose.
+- **Validated at the route.** An empty value, one containing whitespace or
+  control characters, or one longer than 56 characters is refused with
+  `400 {"error": "invalid_asset"}`. A well-formed-looking 56-character string
+  that is not a real asset is accepted and simply matches nothing — the
+  facilitator has no registry of legitimate assets to check against, and
+  pretending otherwise would imply an allowlist that does not exist.
+- **Not available on `/discovery/search`**, which is deliberately out of scope.
+
+`GET /supported` returns `catalogAssets` — the live set of assets present in the
+catalog, grouped by network:
+
+```json
+{
+  "kinds": [ /* … x402 spec fields, unchanged … */ ],
+  "extensions": ["bazaar"],
+  "signers": { "stellar:*": [ /* … */ ] },
+  "catalogAssets": {
+    "stellar:testnet": ["CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA"],
+    "stellar:pubnet": []
+  }
+}
+```
+
+Both network keys are always present, even when empty, so a client can read
+`catalogAssets["stellar:pubnet"]` without a presence check. The set is derived at
+request time from the catalog itself — a new asset appears automatically once a
+real settlement catalogs a listing that accepts it, with no config change and no
+deploy.

--- a/docs/asset-support.md
+++ b/docs/asset-support.md
@@ -42,6 +42,11 @@ across networks without fragmenting supply.
 > issuer) can revoke a trustline or claw back a balance from any account holding
 > USDT0.
 >
+> Note: the issuer account `GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q`
+> has no `home_domain` set, so there is no on-chain SEP-1 `stellar.toml` linking
+> this account to Tether. The attribution to Tether rests on off-chain reputation
+> and the LayerZero/USDT0 documentation, not on-chain proof.
+>
 > The Vellar Facilitator is **non-custodial**: payments flow directly from the
 > payer to the seller's `payTo` address, and the facilitator's sponsor key is
 > used only to pay the network fee (it is passed solely as `feeBumpSigner` and is
@@ -53,11 +58,16 @@ across networks without fragmenting supply.
 >
 > USDC does not carry this risk.
 
-Note on provenance: the issuer address and the `auth_revocable` /
-`auth_clawback_enabled` flags above are properties of the asset itself, published
-by its issuer. They are recorded here for seller awareness and are not asserted
-or verified by this facilitator — confirm them against Horizon before relying on
-them for anything consequential.
+Verified against Stellar mainnet Horizon on 2026-09-04:
+
+- `auth_revocable`: **true**
+- `auth_clawback_enabled`: **true**
+- `auth_required`: **false**
+- Contract `CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF` confirmed as
+  a genuine SAC (`contractExecutableStellarAsset`, not custom wasm),
+  cryptographically bound to
+  `USDT0:GATISXX6BZ6NC7IKQBY37CJD4SOZL3CYZJWXEDG6JVIY4WBS6KXJHN6Q` via on-ledger
+  `AssetInfo` decoding.
 
 ## Querying by asset
 

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1661,7 +1661,7 @@ export class BazaarCatalog {
     params: Pick<
       ListDiscoveryResourcesParams,
       "type" | "payTo" | "scheme" | "network" | "extensions"
-    >,
+    > & { asset?: string },
   ): StoredEntry[] {
     return [...this.entries.values()].filter(({ resource: r }) => {
       if (params.type && r.type !== params.type) return false;
@@ -1669,8 +1669,71 @@ export class BazaarCatalog {
       if (params.scheme && !r.accepts.some((a) => a.scheme === params.scheme)) return false;
       if (params.network && !r.accepts.some((a) => a.network === params.network)) return false;
       if (params.extensions && !(r.extensions && params.extensions in r.extensions)) return false;
+      // Asset filter. `asset` is NOT part of the SDK's own
+      // ListDiscoveryResourcesParams, which is why the parameter type above is
+      // widened locally rather than a plain Pick — the spec has no asset filter
+      // yet, so this is an additive Vellar extension, not a spec field we were
+      // failing to implement.
+      //
+      // Applied LAST, so it narrows whatever the preceding filters left rather
+      // than replacing them: `?asset=X&network=Y` is an AND, never a union.
+      //
+      // EXACT, CASE-SENSITIVE equality against the stored accepts[].asset, the
+      // same shape as the payTo/scheme/network filters above. Stellar contract
+      // addresses are base32 and case-sensitive, so lowercasing either side
+      // would silently match a different (or no) asset. The value is treated as
+      // an OPAQUE string here: it is never parsed, never interpolated into SQL
+      // (list/filter never touch the store at all — this is an in-memory Map
+      // scan), and never sent to Soroban RPC. Format validation lives at the
+      // route, which is the trust boundary that can answer with a 400.
+      if (params.asset && !r.accepts.some((a) => a.asset === params.asset)) return false;
       return true;
     });
+  }
+
+  /**
+   * Every distinct asset present in the catalog, grouped by the network its
+   * accepts entry declares. Powers `catalogAssets` on GET /supported.
+   *
+   * DERIVED AT READ TIME, never stored and never configured: an asset appears
+   * here because a real settlement catalogued a listing that accepts it, and
+   * disappears when the last such listing is evicted. That means a new asset
+   * needs no config change, no allowlist edit and no deploy to become visible —
+   * which is the whole point, and also why this must not be cached.
+   *
+   * Reveals nothing that GET /discovery/resources does not already serve
+   * publicly: every accepts[] block, asset included, is already in that
+   * response. This is strictly an aggregate of data already on the wire.
+   *
+   * Networks the caller did not ask about are still returned (as empty arrays)
+   * by the route — see server.ts. This method reports only what is actually
+   * present, so an empty catalog yields an empty map, not a map of empty
+   * arrays; shaping that into the guaranteed-key response is the route's job.
+   */
+  assetsByNetwork(): Record<string, string[]> {
+    const byNetwork = new Map<string, Set<string>>();
+    for (const { resource } of this.entries.values()) {
+      for (const a of resource.accepts) {
+        // Both fields are validated strings by acceptSchema at ingest and load
+        // (the F6 funnel), but a defensive check costs nothing and keeps a
+        // malformed row from putting `undefined` on the wire.
+        // `network` is a CAIP-2 template type the compiler proves non-empty, so
+        // only `asset` needs the guard. Both are validated strings by
+        // acceptSchema at ingest and load (the F6 funnel); this keeps a
+        // malformed row from putting an empty entry on the wire.
+        if (typeof a.asset !== "string" || a.asset === "") continue;
+        let set = byNetwork.get(a.network);
+        if (!set) byNetwork.set(a.network, (set = new Set()));
+        set.add(a.asset);
+      }
+    }
+    // Sorted for a stable response — an endpoint whose array order changes
+    // between identical requests is needlessly hard to diff or cache.
+    const out: Record<string, string[]> = {};
+    for (const [network, assets] of [...byNetwork.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      out[network] = [...assets].sort();
+    }
+    return out;
   }
 
   /**

--- a/src/server.asset-filter.test.ts
+++ b/src/server.asset-filter.test.ts
@@ -1,0 +1,399 @@
+import { Keypair } from "@stellar/stellar-sdk";
+import { describe, expect, it } from "vitest";
+import type { PaymentRequirements } from "@x402/core/types";
+import type { DiscoveredResource } from "@x402/extensions/bazaar";
+import { BazaarCatalog } from "./catalog.js";
+import { buildFacilitator } from "./facilitator.js";
+import { buildServer } from "./server.js";
+import { fakeChannelAccountSecretKeys } from "./testChannelPoolKeys.js";
+
+// USDT0 asset awareness — Option B, DISCOVERY ONLY.
+//
+// The facilitator stays asset-agnostic at settle time: the asset allowlist was
+// evaluated and deliberately not adopted (docs/security-audit.md, F2), and
+// nothing here reverses that. server.ts still never reads
+// paymentRequirements.asset on the settle path. What this file covers is the
+// read side — filtering listings by an asset a seller already chose, and
+// reporting the live set of such assets on /supported.
+//
+// The security posture the tests below pin down: the asset param is an OPAQUE
+// string compared by equality. It never reaches SQL (catalog.list/filter is an
+// in-memory Map scan, and every statement in store.ts is a literal with bound
+// `?` args) and never reaches Soroban RPC. So the tests assert the two things
+// that can actually go wrong — an unbounded/malformed value getting through,
+// and a malformed value being silently treated as "no filter", which would hand
+// a caller every listing when they asked for one asset.
+
+const testConfig = {
+  port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
+  sponsorSecretKey: Keypair.random().secret(),
+  channelAccountSecretKeys: fakeChannelAccountSecretKeys(), maxTransactionFeeStroops: 500_000,
+  catalogDbUrl: undefined, uptoContractId: undefined,
+  bondEscrowContractId: undefined, bondEscrowAdminSecretKey: undefined,
+  catalogDbAuthToken: undefined, verificationApiUrl: undefined,
+  spend: { rateWindowMs: 60_000, ceilingStroops: 50_000_000, windowMs: 60_000, perUrlMax: 10, perPayToMax: 50, unboundPoolMax: 10 },
+  balance: { softFloorStroops: 250_000_000, hardFloorStroops: 100_000_000, intervalMs: 60_000 },
+};
+
+// The real addresses, so a copy-paste from docs/asset-support.md into a query
+// exercises the same path these tests do.
+const USDC_TESTNET = "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA";
+const USDC_PUBNET = "CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75";
+const USDT0_PUBNET = "CBSJZEIO5C7KC2SF3MKSNXXJSW5G3VTNBX4ATMKUI3B2MR4JKM4R26YF";
+
+const OWNER_A = "GAOWNERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const OWNER_B = "GBOWNERBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function disc(url: string): DiscoveredResource {
+  return {
+    resourceUrl: url,
+    x402Version: 2,
+    discoveryInfo: { input: { type: "http", method: "GET" } },
+  } as unknown as DiscoveredResource;
+}
+
+function reqs(payTo: string, asset: string, network = "stellar:testnet"): PaymentRequirements {
+  return {
+    scheme: "exact", network, asset, amount: "1000000", payTo, maxTimeoutSeconds: 60,
+  } as unknown as PaymentRequirements;
+}
+
+/** A catalog with three listings:
+ *   /usdc-only  — USDC (testnet) only
+ *   /usdt0-only — USDT0 (pubnet) only
+ *   /both       — USDC (testnet) AND USDT0 (pubnet), two accepts entries
+ * The third exists because `asset` is part of the accepts dedup key, so one
+ * resource priced in two assets is ONE listing with TWO accepts — the case a
+ * naive filter gets wrong. */
+async function seededCatalog() {
+  const catalog = await BazaarCatalog.create();
+  await catalog.upsertFromPayment(disc("https://a.example/usdc-only"), reqs(OWNER_A, USDC_TESTNET));
+  await catalog.upsertFromPayment(disc("https://b.example/usdt0-only"), reqs(OWNER_B, USDT0_PUBNET, "stellar:pubnet"));
+  await catalog.upsertFromPayment(disc("https://c.example/both"), reqs(OWNER_A, USDC_TESTNET));
+  await catalog.upsertFromPayment(disc("https://c.example/both"), reqs(OWNER_A, USDT0_PUBNET, "stellar:pubnet"));
+  return catalog;
+}
+
+async function appWith(catalog: BazaarCatalog) {
+  const app = await buildServer(buildFacilitator(testConfig), catalog);
+  await app.ready();
+  return app;
+}
+
+const get = async (app: Awaited<ReturnType<typeof appWith>>, url: string) =>
+  app.inject({ method: "GET", url });
+
+describe("/discovery/resources?asset= — filtering", () => {
+  it("1. asset=<USDC> returns only listings whose accepts include USDC", async () => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const body = (await get(app, `/discovery/resources?asset=${USDC_TESTNET}`)).json();
+      const urls = body.items.map((i: { resource: string }) => i.resource).sort();
+      expect(urls).toEqual(["https://a.example/usdc-only", "https://c.example/both"]);
+      // The USDT0-only listing is excluded even though it is a perfectly valid
+      // listing — which is the whole point of the filter.
+      expect(urls).not.toContain("https://b.example/usdt0-only");
+      expect(body.pagination.total, "total describes the filtered set").toBe(2);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("2. asset=<USDT0> returns only USDT0 listings", async () => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const body = (await get(app, `/discovery/resources?asset=${USDT0_PUBNET}`)).json();
+      const urls = body.items.map((i: { resource: string }) => i.resource).sort();
+      expect(urls).toEqual(["https://b.example/usdt0-only", "https://c.example/both"]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("2b. an asset with NO listings returns an empty array, not an error", async () => {
+    // "No seller accepts this yet" is a correct answer, not a failure. A 404 or
+    // a 400 here would tell an agent the asset is invalid, which is a different
+    // and wrong claim — the facilitator has no registry of valid assets.
+    const app = await appWith(await seededCatalog());
+    try {
+      const res = await get(app, `/discovery/resources?asset=${USDC_PUBNET}`);
+      expect(res.statusCode).toBe(200);
+      expect(res.json().items).toEqual([]);
+      expect(res.json().pagination.total).toBe(0);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("3. no asset param returns every listing — existing behaviour unchanged", async () => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const body = (await get(app, "/discovery/resources")).json();
+      expect(body.items).toHaveLength(3);
+      expect(body.pagination.total).toBe(3);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("9. the filter is CASE SENSITIVE — a lowercased address matches nothing", async () => {
+    // Stellar contract addresses are base32 and case-sensitive. Lowercasing
+    // either side would silently match a different asset, or none, while
+    // looking like it worked.
+    const app = await appWith(await seededCatalog());
+    try {
+      const res = await get(app, `/discovery/resources?asset=${USDC_TESTNET.toLowerCase()}`);
+      expect(res.statusCode, "still a well-formed request").toBe(200);
+      expect(res.json().items, "but it matches nothing").toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("10. asset AND network are combined as AND, never a union", async () => {
+    // MUTATION: return early with `true` once any filter matches. /both then
+    // leaks into the testnet+USDT0 query, because it matches each filter
+    // separately — just not together.
+    const app = await appWith(await seededCatalog());
+    try {
+      const both = (await get(
+        app,
+        `/discovery/resources?asset=${USDC_TESTNET}&network=stellar:testnet`,
+      )).json();
+      expect(both.items.map((i: { resource: string }) => i.resource).sort()).toEqual([
+        "https://a.example/usdc-only",
+        "https://c.example/both",
+      ]);
+
+      // A listing with NO testnet accepts at all is excluded, proving the
+      // network filter is still applied rather than being swallowed by the
+      // asset one. /usdt0-only is pubnet-only, so it drops out here.
+      const narrowed = (await get(
+        app,
+        `/discovery/resources?asset=${USDT0_PUBNET}&network=stellar:testnet`,
+      )).json();
+      expect(
+        narrowed.items.map((i: { resource: string }) => i.resource),
+        "the pubnet-only listing is filtered out by network",
+      ).toEqual(["https://c.example/both"]);
+
+      // WHY /both SURVIVES, and why that is correct rather than a leak: each
+      // filter is an independent `accepts.some(...)`, so /both qualifies via
+      // its USDT0/pubnet entry for the asset and its USDC/testnet entry for the
+      // network. The two predicates may be satisfied by DIFFERENT accepts
+      // entries. That is precisely how the pre-existing payTo/scheme/network
+      // filters already behave — the asset filter deliberately matches their
+      // semantics rather than inventing a stricter same-entry rule, which would
+      // have silently changed what `?payTo=X&network=Y` means. A caller needing
+      // "one accepts entry satisfying both" must intersect client-side.
+      const bothEntries = narrowed.items[0].accepts as Array<{ asset: string; network: string }>;
+      expect(bothEntries.some((a) => a.asset === USDT0_PUBNET)).toBe(true);
+      expect(bothEntries.some((a) => a.network === "stellar:testnet")).toBe(true);
+      expect(
+        bothEntries.some((a) => a.asset === USDT0_PUBNET && a.network === "stellar:testnet"),
+        "and NO single entry satisfies both — the match is across entries",
+      ).toBe(false);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/discovery/resources?asset= — validation", () => {
+  const bad = async (url: string) => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const res = await get(app, url);
+      return { status: res.statusCode, body: res.json() };
+    } finally {
+      await app.close();
+    }
+  };
+
+  it("4. an empty asset param is 400 invalid_asset", async () => {
+    // Rejected rather than ignored. Treating `?asset=` as "no filter" would
+    // hand back every listing to a caller who explicitly asked to narrow.
+    const { status, body } = await bad("/discovery/resources?asset=");
+    expect(status).toBe(400);
+    expect(body.error).toBe("invalid_asset");
+    expect(body.detail, "says what would be acceptable").toBeTruthy();
+  });
+
+  it("4b. a whitespace-only asset param is 400 — empty after trimming", async () => {
+    const { status, body } = await bad("/discovery/resources?asset=%20%20%20");
+    expect(status).toBe(400);
+    expect(body.error).toBe("invalid_asset");
+  });
+
+  it("5. an asset param containing whitespace is 400", async () => {
+    const { status, body } = await bad(
+      `/discovery/resources?asset=${encodeURIComponent("CBIELTK6 YBZJU5UP")}`,
+    );
+    expect(status).toBe(400);
+    expect(body.error).toBe("invalid_asset");
+  });
+
+  it("6. an asset param longer than 56 characters is 400", async () => {
+    // A SAC is exactly 56 chars, so anything longer cannot be one. This is also
+    // what bounds the value before it reaches the per-request scan.
+    const { status, body } = await bad(`/discovery/resources?asset=${"C".repeat(57)}`);
+    expect(status).toBe(400);
+    expect(body.error).toBe("invalid_asset");
+  });
+
+  it("6b. exactly 56 characters passes the length check", async () => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const res = await get(app, `/discovery/resources?asset=${"C".repeat(56)}`);
+      expect(res.statusCode, "at the boundary, not over it").toBe(200);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/discovery/resources?asset= — hostile input", () => {
+  const probe = async (raw: string) => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const res = await get(app, `/discovery/resources?asset=${encodeURIComponent(raw)}`);
+      return { status: res.statusCode, body: res.body };
+    } finally {
+      await app.close();
+    }
+  };
+
+  it("11. SQL-injection shaped input is never a server error", async () => {
+    // It cannot reach SQL at all — catalog.list/filter is an in-memory Map scan,
+    // and every statement in store.ts is a literal with bound `?` args. This
+    // asserts the OBSERVABLE consequence: a structured answer, never a 500, and
+    // never the whole catalog.
+    for (const payload of [
+      "' OR '1'='1",
+      "'; DROP TABLE entry; --",
+      "CBIELTK6'--",
+      "\" OR 1=1 --",
+      "1; SELECT * FROM ownership",
+    ]) {
+      const { status, body } = await probe(payload);
+      expect([200, 400], `payload ${payload} gave ${status}`).toContain(status);
+      if (status === 200) {
+        // A well-formed-but-meaningless value matches nothing. It must NOT
+        // behave like "no filter".
+        expect(JSON.parse(body).items, `payload ${payload} leaked listings`).toEqual([]);
+      }
+      expect(status, "never a server error").not.toBe(500);
+    }
+  });
+
+  it("12. a NUL byte is rejected with 400 before it reaches the filter", async () => {
+    const { status, body } = await probe(`CBIELTK6${String.fromCharCode(0)}YBZJU5UP`);
+    expect(status).toBe(400);
+    expect(JSON.parse(body).error).toBe("invalid_asset");
+  });
+
+  it("12b. other control characters are rejected too", async () => {
+    for (const code of [1, 9, 10, 13, 31, 127]) {
+      const { status } = await probe(`CBIELTK6${String.fromCharCode(code)}YBZJU5UP`);
+      expect(status, `control char ${code} must be refused`).toBe(400);
+    }
+  });
+
+  it("13. a 56-char string that is not a real address is accepted and matches nothing", async () => {
+    // DELIBERATE: the facilitator has no registry of legitimate assets, so it
+    // cannot say "that asset does not exist" without implying an allowlist it
+    // does not have (docs/security-audit.md, F2). An empty result is the honest
+    // answer; a 400 would be a claim it is not entitled to make.
+    const app = await appWith(await seededCatalog());
+    try {
+      const res = await get(app, `/discovery/resources?asset=${"Z".repeat(56)}`);
+      expect(res.statusCode).toBe(200);
+      expect(res.json().items).toEqual([]);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/supported — catalogAssets", () => {
+  it("7. is always present, with both network keys, even on an empty catalog", async () => {
+    // A client must be able to read catalogAssets["stellar:pubnet"] and get an
+    // array rather than undefined, whatever the catalog holds.
+    const app = await appWith(await BazaarCatalog.create());
+    try {
+      const body = (await get(app, "/supported")).json();
+      expect(body).toHaveProperty("catalogAssets");
+      expect(body.catalogAssets["stellar:testnet"]).toEqual([]);
+      expect(body.catalogAssets["stellar:pubnet"]).toEqual([]);
+      // The x402 spec fields are passed through untouched.
+      expect(body).toHaveProperty("kinds");
+      expect(body).toHaveProperty("extensions");
+      expect(body).toHaveProperty("signers");
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("7b. reflects the assets actually in the catalog, grouped by network", async () => {
+    const app = await appWith(await seededCatalog());
+    try {
+      const { catalogAssets } = (await get(app, "/supported")).json();
+      expect(catalogAssets["stellar:testnet"]).toEqual([USDC_TESTNET]);
+      expect(catalogAssets["stellar:pubnet"]).toEqual([USDT0_PUBNET]);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("7c. de-duplicates an asset accepted by several listings", async () => {
+    // USDC is on two listings in the fixture; it must appear once.
+    const app = await appWith(await seededCatalog());
+    try {
+      const { catalogAssets } = (await get(app, "/supported")).json();
+      expect(catalogAssets["stellar:testnet"]).toHaveLength(1);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it("8. a novel asset appears with no config change and no restart", async () => {
+    // THE POINT of deriving this live. MUTATION: hardcode the asset list, or
+    // cache it at boot — this then fails, because the new asset never shows up.
+    const catalog = await seededCatalog();
+    const app = await appWith(catalog);
+    try {
+      const before = (await get(app, "/supported")).json().catalogAssets["stellar:testnet"];
+      expect(before).not.toContain("CNOVELASSETAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+
+      // A real settlement catalogs a listing that accepts a previously unseen
+      // asset — the same path production takes.
+      await catalog.upsertFromPayment(
+        disc("https://d.example/novel"),
+        reqs(OWNER_B, "CNOVELASSETAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
+      );
+
+      const after = (await get(app, "/supported")).json().catalogAssets["stellar:testnet"];
+      expect(after).toContain("CNOVELASSETAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+      expect(after, "and the existing one is still there").toContain(USDC_TESTNET);
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe("/discovery/search is untouched by this change", () => {
+  it("ignores an asset param rather than filtering on it", async () => {
+    // asset is deliberately Omit-ted from SearchQuery. Search is out of scope,
+    // and this pins that down so a future edit to ListQuery cannot quietly
+    // extend the filter into the search scorer.
+    const app = await appWith(await seededCatalog());
+    try {
+      const withAsset = await get(app, `/discovery/search?query=usdc-only&asset=${USDT0_PUBNET}`);
+      expect(withAsset.statusCode, "not rejected, just not a filter here").toBe(200);
+      const plain = await get(app, "/discovery/search?query=usdc-only");
+      expect(withAsset.json().resources).toEqual(plain.json().resources);
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,9 +50,17 @@ interface ListQuery {
   offset?: string;
   /** Trust-layer filter: "true" keeps only verification-verified entries. */
   verified_only?: string;
+  /** Vellar extension (not an x402 spec filter): keep only listings with an
+   *  accepts entry for this exact asset. Validated by parseAssetFilter. */
+  asset?: string;
 }
 
-interface SearchQuery extends Omit<ListQuery, "offset"> {
+/** `asset` is OMITTED deliberately, alongside `offset`. SearchQuery inherits
+ *  from ListQuery, so a field added there silently reaches /discovery/search
+ *  too — and search is explicitly out of scope for the asset filter. Naming it
+ *  in the Omit is what makes that exclusion survive the next edit to ListQuery,
+ *  instead of depending on someone remembering. */
+interface SearchQuery extends Omit<ListQuery, "offset" | "asset"> {
   query?: string;
   cursor?: string;
 }
@@ -259,7 +267,38 @@ export async function buildServer(
     },
   );
 
-  app.get("/supported", async () => facilitator.getSupported());
+  /**
+   * GET /supported — the x402 surface, plus `catalogAssets`.
+   *
+   * `catalogAssets` is an ADDITIVE Vellar field, not an x402 one: the spec's
+   * `kinds`/`extensions`/`signers` are passed through from
+   * facilitator.getSupported() untouched, so a canonical client reading only
+   * the spec fields sees exactly what it saw before.
+   *
+   * It answers "which assets can I actually pay with here?" — which the spec
+   * fields do not, because a scheme/network pair says nothing about the tokens
+   * sellers have chosen. Derived from the live catalog on every request, never
+   * configured and never cached, so an asset that arrives via a real settlement
+   * shows up with no deploy and no allowlist edit. That is the point: the
+   * facilitator is asset-agnostic (docs/security-audit.md:92), so this reports
+   * what sellers are doing rather than what an operator has permitted.
+   *
+   * BOTH network keys are ALWAYS present, even when empty. A caller must be
+   * able to read `catalogAssets["stellar:testnet"]` and get an array rather
+   * than `undefined`, and an empty array is the honest answer for "no listing
+   * in this catalog accepts anything on that network yet". `assetsByNetwork()`
+   * reports only networks it actually saw, so the two guaranteed keys are
+   * seeded here and any other network the catalog happens to hold is merged on
+   * top rather than dropped.
+   */
+  app.get("/supported", async () => {
+    const catalogAssets: Record<string, string[]> = {
+      "stellar:testnet": [],
+      "stellar:pubnet": [],
+      ...catalog.assetsByNetwork(),
+    };
+    return { ...facilitator.getSupported(), catalogAssets };
+  });
 
   app.post<{ Body: FacilitatorRequestBody }>("/verify", async (request, reply) => {
     // Tranche 1 deliverable 1.2 telemetry (src/metrics.ts). Explicit calls
@@ -697,12 +736,25 @@ export async function buildServer(
     if (q.verified_only === "true" && verifiedOnlyUnanswerable()) {
       return reply.status(400).send(verifiedOnlyRefusal());
     }
+    // Validated BEFORE the catalog is touched, so a malformed value is answered
+    // with a 400 rather than silently behaving like "no filter" — which would
+    // return every listing to a caller who asked for one asset.
+    const assetFilter = parseAssetFilter(q.asset);
+    if (!assetFilter.ok) {
+      return reply.status(400).send({
+        error: "invalid_asset",
+        detail:
+          "asset parameter must be a non-empty string of at most 56 characters " +
+          "with no whitespace or control characters",
+      });
+    }
     const response = catalog.list({
       ...(q.type !== undefined ? { type: q.type } : {}),
       ...(q.payTo !== undefined ? { payTo: q.payTo } : {}),
       ...(q.scheme !== undefined ? { scheme: q.scheme } : {}),
       ...(q.network !== undefined ? { network: q.network } : {}),
       ...(q.extensions !== undefined ? { extensions: q.extensions } : {}),
+      ...(assetFilter.value !== undefined ? { asset: assetFilter.value } : {}),
       ...(q.limit !== undefined ? { limit: Number(q.limit) } : {}),
       ...(q.offset !== undefined ? { offset: Number(q.offset) } : {}),
     });
@@ -842,6 +894,49 @@ function buildExtensionResponsesHeader(outcome: CatalogOutcome): string {
     safe.reason = sanitizeExtensionResponsesReason(outcome.reason);
   }
   return JSON.stringify({ bazaar: safe });
+}
+
+/** Longest possible asset filter value. A Stellar contract address (SAC) is
+ *  exactly 56 base32 characters, so anything longer cannot be one. Bounding the
+ *  value keeps an arbitrarily long query string out of the per-request scan. */
+const MAX_ASSET_FILTER_LEN = 56;
+
+/**
+ * Validate the `asset` query param for GET /discovery/resources.
+ *
+ * Returns `{ ok: true, value }` with the trimmed asset, `{ ok: true }` when the
+ * param was absent (no filter), or `{ ok: false }` when it is malformed and the
+ * route must answer 400.
+ *
+ * DELIBERATELY NOT a full Stellar address check. The value is compared by exact
+ * string equality against stored `accepts[].asset` and nothing else — it never
+ * reaches SQL (the catalog filter is an in-memory Map scan; every statement in
+ * store.ts is a literal with bound `?` args), and it never reaches Soroban RPC.
+ * So the only real hazards are an unbounded value and a value that is obviously
+ * not an address at all, both of which are caught here. A well-formed-looking
+ * 56-char string that is not a real SAC is ACCEPTED and simply matches nothing,
+ * which is the honest answer: the facilitator is asset-agnostic and has no
+ * registry of legitimate assets to check against (docs/security-audit.md:92 —
+ * the asset allowlist was evaluated and deliberately not adopted). Rejecting it
+ * would imply an allowlist that does not exist.
+ *
+ * Control characters (NUL included) and internal whitespace are refused rather
+ * than stripped: an address containing them is malformed, and silently
+ * normalising it would let two different inputs collapse onto one filter.
+ */
+export function parseAssetFilter(
+  raw: string | undefined,
+): { ok: true; value?: string } | { ok: false } {
+  if (raw === undefined) return { ok: true };
+  if (typeof raw !== "string") return { ok: false };
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { ok: false };
+  if (trimmed.length > MAX_ASSET_FILTER_LEN) return { ok: false };
+  // Any remaining whitespace is INTERNAL (the ends are already trimmed), and
+  // any control character — including a NUL — is refused outright.
+  // eslint-disable-next-line no-control-regex -- deliberately matching control chars
+  if (/[\s\u0000-\u001f\u007f]/.test(trimmed)) return { ok: false };
+  return { ok: true, value: trimmed };
 }
 
 export function policyBucketKey(payTo: unknown): string {


### PR DESCRIPTION
## What this adds

Option B asset awareness — **discovery only, no settle-time enforcement**.

### `/discovery/resources?asset=<SAC>`
Filter listings by accepted asset. Returns only listings with at least one
`accepts` entry matching the provided asset address (exact string equality,
case sensitive). Validated: empty, whitespace, control characters and >56 char
values return `400 {"error":"invalid_asset"}`.

### `/supported` → `catalogAssets`
New field returning the live set of unique assets across all catalog `accepts`
arrays, grouped by network. Derived at request time — a new asset appears
automatically once a real settlement catalogs a listing accepting it, with no
config change and no deploy. Both network keys are always present (empty arrays
when absent) so clients need no presence check.

### `docs/asset-support.md`
USDC and USDT0 details, USDT0 clawback/revocability risk warning for sellers,
and the query semantics.

## What this does NOT change
- Settlement flow is unchanged
- No asset allowlist at `/settle` — `docs/security-audit.md` F2 is **not** reversed
- `server.ts` still never reads `paymentRequirements.asset`
- `/discovery/search` is unchanged (`asset` is explicitly `Omit`-ted from
  `SearchQuery`, so it cannot leak in via the `ListQuery` inheritance)
- The x402 spec fields on `/supported` (`kinds`/`extensions`/`signers`) pass
  through untouched

## Security
- Asset param treated as an **opaque string**, equality only
- **No SQL injection surface** — `list()`/`filter()` are synchronous in-memory
  `Map` scans that never touch the store; every statement in `store.ts` is a
  literal with bound `?` args
- **No RPC call** with a user-supplied asset value
- Length bounded at 56 chars before use
- Whitespace and control characters (NUL included) rejected with 400
- Case sensitivity preserved (Stellar addresses are base32, case sensitive)
- `catalogAssets` exposes nothing new — every `accepts[].asset` is already
  served publicly by `/discovery/resources`; this is strictly an aggregate

### One deliberate non-rejection
A well-formed 56-character string that is not a real asset is **accepted** and
matches nothing, rather than returning 400. The facilitator has no registry of
legitimate assets, so rejecting would imply an allowlist that does not exist.
An empty result is the honest answer.

## Filter semantics — worth knowing
Each filter is an independent `accepts.some(...)`, so `asset` and `network` may
be satisfied by **different** `accepts` entries. A listing accepting
USDC-on-testnet and USDT0-on-pubnet matches `?asset=<USDT0>&network=stellar:testnet`.

This matches how the existing `payTo`/`scheme`/`network` filters already behave.
A stricter same-entry rule would have silently changed what `?payTo=X&network=Y`
means, which is out of scope. Documented and pinned by a test.

## USDT0 risk note
USDT0 sets `auth_revocable` and `auth_clawback_enabled`. The facilitator is
non-custodial (sponsor key is passed solely as `feeBumpSigner`, never a
settlement source), so clawback risk sits entirely with the seller, not Vellar.
Documented in `docs/asset-support.md`.

## Testing
**578 passing** (20 new in `src/server.asset-filter.test.ts`), 4 skipped,
typecheck clean. Verified live over real HTTP, not just `inject()`.

## Note on the spec
Two addresses in the original spec were corrected: the mainnet USDC SAC given
was malformed (contained the literal word `REQUIRED`); the real value per
`@x402/stellar` is `CCW67TSZV3SSS2HXMBQ5JFGCKJNXKZM7UQUWUZPUTHXSTZLEO7SJMI75`.
The USDT0 issuer address and its `auth_revocable`/`auth_clawback_enabled` flags
are recorded as stated but were **not** independently verified against Horizon —
`docs/asset-support.md` says so explicitly rather than asserting them as
facilitator-verified facts.
