### PR TITLE
feat: channel account balance monitor

### DIFF
--- a/src/catalog.restart-verification.test.ts
+++ b/src/catalog.restart-verification.test.ts
@@ -78,6 +78,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/channelMonitor.test.ts
+++ b/src/channelMonitor.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChannelPool } from "./channelPool.js";
+import { CONSECUTIVE_FAILURE_LIMIT, createChannelMonitor, truncateAddress } from "./channelMonitor.js";
+
+// Channel-account balance monitor.
+//
+// WHAT THESE TESTS ARE REALLY GUARDING. disable()/enable() were implemented,
+// exported and unit-tested from the day the pool shipped, and had zero
+// production callers — so the pool's own tests passed while the behaviour they
+// describe never once happened in production. These tests assert the CALLER:
+// that a real balance reading actually moves an account in and out of rotation.
+//
+// The fail-open posture is the subtle half. BalanceGuard fails open because
+// refusing settlement on a flaky read is self-inflicted downtime. Here the risk
+// inverts — disabling on an unreadable balance would let one Horizon outage
+// empty all 50 lanes — so a failed check changes nothing until a per-account run
+// of CONSECUTIVE_FAILURE_LIMIT failures. Tests 5-8 pin that boundary exactly.
+
+const ADDRS = ["GAAAA1111111111111111111111111111111111111111111111111111", "GBBBB2222222222222222222222222222222222222222222222222222"];
+const FLOOR = 5_000_000; // 5 XLM
+
+/** Captures every line the monitor logs, so a test can assert on content
+ *  (truncation) rather than only on behaviour. */
+function recordingLogger() {
+  const lines: string[] = [];
+  return {
+    lines,
+    info: (m: string) => lines.push(m),
+    warn: (m: string) => lines.push(m),
+    error: (m: string) => lines.push(m),
+  };
+}
+
+/** A monitor over a REAL ChannelPool — the pool is the thing under test as much
+ *  as the monitor is, so it is never mocked. `balances` maps address -> either a
+ *  stroop reading or an Error to throw. */
+function build(balances: Map<string, number | Error>, addresses: readonly string[] = ADDRS) {
+  const pool = new ChannelPool([...addresses]);
+  const logger = recordingLogger();
+  const fetchBalanceStroops = vi.fn(async (address: string) => {
+    const v = balances.get(address);
+    if (v instanceof Error) throw v;
+    if (v === undefined) throw new Error("no reading configured");
+    return v;
+  });
+  const monitor = createChannelMonitor({
+    pool,
+    addresses,
+    fetchBalanceStroops,
+    floorStroops: FLOOR,
+    intervalMs: 60_000,
+    logger,
+  });
+  return { pool, monitor, logger, fetchBalanceStroops };
+}
+
+/** Disabled count, read off the pool's own status — the pool never exposes
+ *  WHICH addresses are disabled, so behaviour is asserted through acquire(). */
+const disabledCount = (pool: ChannelPool) => pool.status().disabled;
+
+describe("channel monitor — disable / enable transitions", () => {
+  it("1. disables an account whose balance is below the floor", async () => {
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, 1_000_000], [ADDRS[1]!, 50_000_000]]));
+    expect(pool.status()).toEqual({ available: 2, inUse: 0, disabled: 0 });
+
+    await monitor.checkAll();
+
+    expect(pool.status()).toEqual({ available: 1, inUse: 0, disabled: 1 });
+    // And the disabled one is genuinely unacquirable: the only address acquire()
+    // can return is the healthy one, twice over would exhaust the pool.
+    expect(pool.acquire()).toBe(ADDRS[1]);
+    expect(() => pool.acquire()).toThrow();
+  });
+
+  it("2. re-enables an account once its balance recovers above the floor", async () => {
+    const balances = new Map<string, number | Error>([[ADDRS[0]!, 1_000_000], [ADDRS[1]!, 50_000_000]]);
+    const { pool, monitor } = build(balances);
+
+    await monitor.checkAll();
+    expect(disabledCount(pool)).toBe(1);
+
+    balances.set(ADDRS[0]!, 9_000_000); // re-funded
+    await monitor.checkAll();
+
+    expect(pool.status()).toEqual({ available: 2, inUse: 0, disabled: 0 });
+  });
+
+  it("3. does not call disable() again for an already-disabled account", async () => {
+    const { pool, monitor, logger } = build(new Map<string, number | Error>([[ADDRS[0]!, 1_000_000], [ADDRS[1]!, 50_000_000]]));
+    const spy = vi.spyOn(pool, "disable");
+
+    await monitor.checkAll();
+    await monitor.checkAll();
+    await monitor.checkAll();
+
+    // MUTATION: drop the `!isDisabled` guard. disable() is idempotent so the
+    // pool state stays right, but the operator gets one alarming DISABLED line
+    // per account per tick — a log nobody reads is a control nobody has.
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(logger.lines.filter((l) => l.includes("DISABLED"))).toHaveLength(1);
+  });
+
+  it("4. does not call enable() for an account that was never disabled", async () => {
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, 50_000_000], [ADDRS[1]!, 50_000_000]]));
+    const spy = vi.spyOn(pool, "enable");
+
+    await monitor.checkAll();
+    await monitor.checkAll();
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(pool.status()).toEqual({ available: 2, inUse: 0, disabled: 0 });
+  });
+
+  it("a balance exactly AT the floor is healthy — the comparison is strict", async () => {
+    // Boundary stated explicitly: `stroops < floor` disables, so == floor does
+    // not. Left implicit, a later refactor to <= would silently disable a
+    // correctly-funded account.
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, FLOOR], [ADDRS[1]!, FLOOR]]));
+    await monitor.checkAll();
+    expect(disabledCount(pool)).toBe(0);
+  });
+});
+
+describe("channel monitor — fail open, with a staleness bound", () => {
+  it("5. a failed check does NOT disable, and increments the failure count", async () => {
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, new Error("Horizon HTTP 503")], [ADDRS[1]!, 50_000_000]]));
+
+    for (let i = 1; i < CONSECUTIVE_FAILURE_LIMIT; i++) {
+      await monitor.checkAll();
+      expect(monitor.failureCount(ADDRS[0]!), `after ${i} failure(s)`).toBe(i);
+      expect(disabledCount(pool), `still in rotation after ${i} failure(s)`).toBe(0);
+    }
+  });
+
+  it("6. disables after EXACTLY the limit — not before, not after", async () => {
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, new Error("boom")], [ADDRS[1]!, 50_000_000]]));
+
+    for (let i = 0; i < CONSECUTIVE_FAILURE_LIMIT - 1; i++) await monitor.checkAll();
+    expect(disabledCount(pool), "one short of the limit").toBe(0);
+
+    await monitor.checkAll(); // the Nth failure
+    expect(disabledCount(pool), "at the limit").toBe(1);
+    expect(monitor.failureCount(ADDRS[0]!)).toBe(CONSECUTIVE_FAILURE_LIMIT);
+  });
+
+  it("7. a successful check resets the failure count to zero", async () => {
+    const balances = new Map<string, number | Error>([[ADDRS[0]!, new Error("boom")], [ADDRS[1]!, 50_000_000]]);
+    const { monitor } = build(balances);
+
+    await monitor.checkAll();
+    await monitor.checkAll();
+    expect(monitor.failureCount(ADDRS[0]!)).toBe(2);
+
+    balances.set(ADDRS[0]!, 50_000_000);
+    await monitor.checkAll();
+
+    // MUTATION: drop the reset. Two failures a week apart then eventually
+    // accumulate to the limit and disable a perfectly healthy account.
+    expect(monitor.failureCount(ADDRS[0]!)).toBe(0);
+  });
+
+  it("8. an account disabled for staleness is re-enabled once it answers healthily", async () => {
+    const balances = new Map<string, number | Error>([[ADDRS[0]!, new Error("boom")], [ADDRS[1]!, 50_000_000]]);
+    const { pool, monitor } = build(balances);
+
+    for (let i = 0; i < CONSECUTIVE_FAILURE_LIMIT; i++) await monitor.checkAll();
+    expect(disabledCount(pool)).toBe(1);
+
+    balances.set(ADDRS[0]!, 50_000_000);
+    await monitor.checkAll();
+
+    expect(pool.status()).toEqual({ available: 2, inUse: 0, disabled: 0 });
+    expect(monitor.failureCount(ADDRS[0]!)).toBe(0);
+  });
+
+  it("a stale-disabled account stays disabled while it keeps failing, logged once", async () => {
+    const { pool, monitor, logger } = build(new Map<string, number | Error>([[ADDRS[0]!, new Error("boom")], [ADDRS[1]!, 50_000_000]]));
+
+    for (let i = 0; i < CONSECUTIVE_FAILURE_LIMIT + 4; i++) await monitor.checkAll();
+
+    expect(disabledCount(pool)).toBe(1);
+    expect(logger.lines.filter((l) => l.includes("consecutive failed balance"))).toHaveLength(1);
+  });
+});
+
+describe("channel monitor — logging discipline", () => {
+  it("9. never writes a full address — only first4…last4", async () => {
+    const balances = new Map<string, number | Error>([[ADDRS[0]!, 1_000_000], [ADDRS[1]!, new Error("boom")]]);
+    const { monitor, logger } = build(balances);
+
+    for (let i = 0; i < CONSECUTIVE_FAILURE_LIMIT; i++) await monitor.checkAll();
+    balances.set(ADDRS[0]!, 50_000_000);
+    await monitor.checkAll(); // produce a re-enable line too
+
+    expect(logger.lines.length, "precondition: something was logged").toBeGreaterThan(0);
+    for (const line of logger.lines) {
+      for (const addr of ADDRS) {
+        expect(line, `full address leaked: ${line}`).not.toContain(addr);
+      }
+    }
+    expect(logger.lines.some((l) => l.includes(truncateAddress(ADDRS[0]!)))).toBe(true);
+  });
+
+  it("truncateAddress keeps a short string intact rather than mangling it", async () => {
+    expect(truncateAddress("GABC")).toBe("GABC");
+    expect(truncateAddress(ADDRS[0]!)).toBe(`${ADDRS[0]!.slice(0, 4)}…${ADDRS[0]!.slice(-4)}`);
+  });
+
+  it("logs balances in XLM, not raw stroops", async () => {
+    // 1_000_000 stroops is 0.1 XLM. An operator reading "1000000 is below
+    // 5000000" has to do the conversion themselves at exactly the moment they
+    // are least inclined to.
+    const { monitor, logger } = build(new Map<string, number | Error>([[ADDRS[0]!, 1_000_000], [ADDRS[1]!, 50_000_000]]));
+    await monitor.checkAll();
+    const line = logger.lines.find((l) => l.includes("DISABLED"))!;
+    expect(line).toContain("0.1000 XLM");
+    expect(line).not.toContain("1000000 stroops");
+  });
+});
+
+describe("channel monitor — lifecycle", () => {
+  it("10. stop() prevents further checks", async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitor, fetchBalanceStroops } = build(new Map<string, number | Error>([[ADDRS[0]!, 50_000_000], [ADDRS[1]!, 50_000_000]]));
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(0); // let the immediate first pass run
+      const afterFirst = fetchBalanceStroops.mock.calls.length;
+      expect(afterFirst).toBeGreaterThan(0);
+
+      monitor.stop();
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      expect(fetchBalanceStroops.mock.calls.length, "no checks after stop()").toBe(afterFirst);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("start() is idempotent — a second call does not double the interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const { monitor, fetchBalanceStroops } = build(new Map<string, number | Error>([[ADDRS[0]!, 50_000_000], [ADDRS[1]!, 50_000_000]]));
+      monitor.start();
+      monitor.start();
+      await vi.advanceTimersByTimeAsync(0);
+      const afterStart = fetchBalanceStroops.mock.calls.length;
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      // One tick's worth of checks (2 accounts), not two ticks' worth.
+      expect(fetchBalanceStroops.mock.calls.length - afterStart).toBe(ADDRS.length);
+      monitor.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("channel monitor — hostile and malformed readings", () => {
+  it("11. a malformed reading (NaN) is treated as a failure, not as healthy", async () => {
+    // THE TRAP: NaN < floor is FALSE, so an unguarded comparison reads a
+    // malformed response as "above the floor" and leaves a possibly-empty
+    // account in rotation. It must count as a failed check instead.
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, Number.NaN], [ADDRS[1]!, 50_000_000]]));
+
+    await monitor.checkAll();
+    expect(monitor.failureCount(ADDRS[0]!), "counted as a failure").toBe(1);
+    expect(disabledCount(pool), "not disabled yet — fail open").toBe(0);
+    expect(monitor.lastKnownBalance(ADDRS[0]!), "no balance recorded").toBeUndefined();
+
+    for (let i = 1; i < CONSECUTIVE_FAILURE_LIMIT; i++) await monitor.checkAll();
+    expect(disabledCount(pool), "disabled once the run reaches the limit").toBe(1);
+  });
+
+  it("12. a negative balance is below the floor and disables the account", async () => {
+    const { pool, monitor } = build(new Map<string, number | Error>([[ADDRS[0]!, -1], [ADDRS[1]!, 50_000_000]]));
+    await monitor.checkAll();
+    expect(disabledCount(pool)).toBe(1);
+  });
+
+  it("one account's failure does not stop the others being checked", async () => {
+    // Sequential iteration must not let a thrown reading abort the pass — the
+    // other 49 accounts would silently stop being monitored.
+    const { pool, monitor, fetchBalanceStroops } = build(
+      new Map<string, number | Error>([[ADDRS[0]!, new Error("boom")], [ADDRS[1]!, 1_000_000]]),
+    );
+    await monitor.checkAll();
+    expect(fetchBalanceStroops).toHaveBeenCalledTimes(2);
+    expect(disabledCount(pool), "the healthy-path account was still evaluated").toBe(1);
+  });
+});

--- a/src/channelMonitor.ts
+++ b/src/channelMonitor.ts
@@ -1,0 +1,213 @@
+// Channel-account balance monitor.
+//
+// THE GAP THIS CLOSES. `ChannelPool.disable()` / `enable()` have been fully
+// implemented, exported and tested since the pool shipped — and had ZERO
+// production call sites. Nothing ever pulled a channel account out of rotation,
+// so an account drifting toward the Stellar minimum reserve stayed `available`
+// and kept being acquired until a settlement using it failed on-chain. That is
+// the operational gap named in docs/deploy-runbook.md §11 and BUILD-PLAN.md
+// Phase 3; this module is the caller those two methods were waiting for.
+//
+// WHY CHANNEL ACCOUNTS NEED SO LITTLE. They never pay their own transaction
+// fees — the sponsor is the `feeBumpSigner` for every settlement — and they
+// never hold the payment asset, since funds move payer -> payTo directly. So
+// each one only needs the Stellar minimum reserve to keep existing
+// (docs/channel-pool-design.md §5/§6). The floor here is a reserve floor, not a
+// fee budget.
+//
+// HOW THIS DIFFERS FROM BalanceGuard, deliberately. BalanceGuard watches ONE
+// account and fails OPEN on an unreadable balance: refusing settlement because
+// Horizon hiccuped would be self-inflicted downtime. Here the risk inverts — if
+// an unreadable balance disabled an account, a single Horizon outage would
+// disable all 50 and take the pool to zero, halting settlement completely. So a
+// failed check leaves the account exactly as it is, and only a PER-ACCOUNT run
+// of CONSECUTIVE_FAILURE_LIMIT failures disables it. That bound exists so a
+// genuinely unreachable account is eventually pulled, without letting a global
+// outage empty the pool on the first tick.
+
+import type { ChannelPool } from "./channelPool.js";
+
+/**
+ * Consecutive failed checks for ONE account before it is disabled as stale.
+ *
+ * Hardcoded, not configurable: it is a safety backstop, and the failure mode of
+ * tuning it is asymmetric. Too low and a transient Horizon blip empties the
+ * pool; too high and a genuinely dead account keeps being handed out. Five at
+ * the default 60s interval means ~5 minutes of sustained per-account failure
+ * before withdrawal — long enough to ride out a blip, short enough to matter.
+ */
+export const CONSECUTIVE_FAILURE_LIMIT = 5;
+
+const STROOPS_PER_XLM = 10_000_000;
+
+export interface ChannelMonitorOptions {
+  pool: ChannelPool;
+  /** PUBLIC keys (G…) of every channel account. Derived from the keypairs at
+   *  the call site — never secrets, which this module must never see, and never
+   *  read out of the pool, whose address sets are deliberately private. */
+  addresses: readonly string[];
+  /** Injected so the monitor is testable without a network. Production passes
+   *  the same Horizon-backed reader the sponsor guard uses. */
+  fetchBalanceStroops: (address: string) => Promise<number>;
+  /** Below this, an account is pulled from rotation. */
+  floorStroops: number;
+  intervalMs: number;
+  logger?: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void };
+}
+
+/**
+ * `GABC…WXYZ` — enough to identify one of 50 accounts in a log line without
+ * writing a full address into log storage. These are public keys, so this is
+ * hygiene rather than secrecy; the monitor is never given a secret key at all,
+ * so there is nothing here that COULD leak one.
+ */
+export function truncateAddress(address: string): string {
+  if (address.length <= 8) return address;
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
+
+function toXlm(stroops: number): string {
+  return (stroops / STROOPS_PER_XLM).toFixed(4);
+}
+
+export class ChannelMonitor {
+  private readonly opts: Required<Pick<ChannelMonitorOptions, "logger">> &
+    Omit<ChannelMonitorOptions, "logger">;
+  /** Per-account consecutive failure counts. Reset to 0 by any success. */
+  private readonly failures = new Map<string, number>();
+  /** Last successfully read balance, for observability only — never a decision
+   *  input, so a stale value can never gate a disable/enable. */
+  private readonly lastBalance = new Map<string, number>();
+  /** Mirrors what THIS monitor has disabled. The pool's own `disabled` set is
+   *  private and `status()` returns counts only, so tracking intent here is the
+   *  only way to avoid calling disable()/enable() repeatedly on every tick —
+   *  both are idempotent, but a log line per tick per account is not. */
+  private readonly disabledByMonitor = new Set<string>();
+  private timer: ReturnType<typeof setInterval> | undefined;
+  private stopped = false;
+
+  constructor(opts: ChannelMonitorOptions) {
+    this.opts = { ...opts, logger: opts.logger ?? console };
+  }
+
+  /** Consecutive failure count for one address. Test/observability seam. */
+  failureCount(address: string): number {
+    return this.failures.get(address) ?? 0;
+  }
+
+  /** Last successfully read balance in stroops, or undefined if never read. */
+  lastKnownBalance(address: string): number | undefined {
+    return this.lastBalance.get(address);
+  }
+
+  /**
+   * One pass over every account, SEQUENTIALLY.
+   *
+   * Sequential is the point, not an accident: 50 accounts checked in parallel is
+   * a 50-request burst at Horizon, whereas awaiting each in turn spreads them
+   * across the interval. At the default 60s tick that is ~50 req/min against a
+   * ~60 req/min per-IP budget, with the sponsor guard taking one more — which is
+   * why lowering SPONSOR_BALANCE_INTERVAL_MS is the thing that would make this
+   * the binding constraint. Never throws.
+   */
+  async checkAll(): Promise<void> {
+    for (const address of this.opts.addresses) {
+      if (this.stopped) return;
+      await this.checkOne(address);
+    }
+  }
+
+  private async checkOne(address: string): Promise<void> {
+    let stroops: number;
+    try {
+      stroops = await this.opts.fetchBalanceStroops(address);
+      // A non-finite reading is a malformed answer, not a balance. Treated as a
+      // failed check rather than compared against the floor — NaN < floor is
+      // false, so letting it through would silently mean "healthy".
+      if (!Number.isFinite(stroops)) {
+        this.recordFailure(address, "non-numeric balance");
+        return;
+      }
+    } catch (err) {
+      this.recordFailure(address, String(err));
+      return;
+    }
+
+    // Success: the account answered, so any prior run of failures is over.
+    this.failures.set(address, 0);
+    this.lastBalance.set(address, stroops);
+
+    const belowFloor = stroops < this.opts.floorStroops;
+    const isDisabled = this.disabledByMonitor.has(address);
+
+    if (belowFloor && !isDisabled) {
+      this.opts.pool.disable(address);
+      this.disabledByMonitor.add(address);
+      this.opts.logger.warn(
+        `[channel-monitor] DISABLED ${truncateAddress(address)} — ${toXlm(stroops)} XLM is below the ` +
+          `${toXlm(this.opts.floorStroops)} XLM floor. It will not be handed to a new settlement until ` +
+          `it is re-funded; any settlement already in flight on it finishes normally.`,
+      );
+      return;
+    }
+
+    if (!belowFloor && isDisabled) {
+      this.opts.pool.enable(address);
+      this.disabledByMonitor.delete(address);
+      this.opts.logger.info(
+        `[channel-monitor] re-enabled ${truncateAddress(address)} — ${toXlm(stroops)} XLM is back above ` +
+          `the ${toXlm(this.opts.floorStroops)} XLM floor.`,
+      );
+    }
+    // Otherwise: state already matches the balance. Say nothing — a healthy pool
+    // logging 50 lines a minute is a pool nobody reads the logs of.
+  }
+
+  private recordFailure(address: string, detail: string): void {
+    const count = this.failureCount(address) + 1;
+    this.failures.set(address, count);
+
+    if (count >= CONSECUTIVE_FAILURE_LIMIT) {
+      // Already disabled by an earlier tick: keep counting, stay quiet. The
+      // account is out of rotation, which is the outcome that matters.
+      if (this.disabledByMonitor.has(address)) return;
+      this.opts.pool.disable(address);
+      this.disabledByMonitor.add(address);
+      this.opts.logger.error(
+        `[channel-monitor] DISABLED ${truncateAddress(address)} after ${count} consecutive failed balance ` +
+          `checks — its balance is unknown, so it is withdrawn rather than handed out blind. ` +
+          `Last error: ${detail}`,
+      );
+      return;
+    }
+
+    this.opts.logger.warn(
+      `[channel-monitor] balance check failed for ${truncateAddress(address)} ` +
+        `(${count}/${CONSECUTIVE_FAILURE_LIMIT}) — leaving it in its current state. ${detail}`,
+    );
+  }
+
+  /** First pass fires immediately and unawaited, so boot is never blocked —
+   *  same contract as BalanceGuard.start(). The interval is unref'd so it can
+   *  never hold the process alive. */
+  start(): void {
+    if (this.timer) return;
+    this.stopped = false;
+    void this.checkAll();
+    this.timer = setInterval(() => void this.checkAll(), this.opts.intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}
+
+/** Factory, mirroring how BalanceGuard is constructed at its call site. */
+export function createChannelMonitor(opts: ChannelMonitorOptions): ChannelMonitor {
+  return new ChannelMonitor(opts);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,18 @@ export interface FacilitatorConfig {
    * first upgrade produces, and equally the state a tamperer produces. Off by
    * default; must be set deliberately and removed once the upgrade is done.
    */
+  /**
+   * Reserve floor for ONE channel account, in stroops. Below this the account is
+   * pulled from the settlement pool by the channel monitor (src/channelMonitor.ts)
+   * and returned to it automatically once re-funded.
+   *
+   * This is a RESERVE floor, not a fee budget: channel accounts never pay their
+   * own transaction fees (the sponsor is the feeBumpSigner) and never hold the
+   * payment asset, so each only needs enough XLM to keep existing —
+   * docs/channel-pool-design.md §5/§6. Default 5 XLM leaves generous headroom
+   * over the 1 XLM a subentry-free account actually requires.
+   */
+  channelAccountMinStroops: number;
   /** Fix 3 sponsor balance guard floors, in stroops. */
   balance: {
     /** Warn below this (default 250_000_000 = 25 XLM). */
@@ -196,6 +208,18 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
   // check-interval stale. Otherwise the guard can read "above floor" and then be
   // drained straight through it before the next check — a floor that cannot
   // hold. Defaults: 25 XLM warn / 10 XLM refuse, against a 5 XLM window ceiling.
+  // Deliberately NOT given its own interval: the channel monitor runs on
+  // config.balance.intervalMs alongside the sponsor guard. Two knobs for "how
+  // often do we ask Horizon about a balance" would be two things to keep in
+  // agreement, and the request budget they share is what actually matters —
+  // ~50 channel checks plus 1 sponsor check per tick against Horizon's per-IP
+  // rate limit (see src/channelMonitor.ts's checkAll doc comment).
+  const channelAccountMinStroops = positiveIntEnv(
+    env.CHANNEL_ACCOUNT_MIN_STROOPS,
+    5_000_000,
+    "CHANNEL_ACCOUNT_MIN_STROOPS",
+  );
+
   const balance = {
     softFloorStroops: positiveIntEnv(env.SPONSOR_SOFT_FLOOR_STROOPS, 250_000_000, "SPONSOR_SOFT_FLOOR_STROOPS"),
     hardFloorStroops: positiveIntEnv(env.SPONSOR_HARD_FLOOR_STROOPS, 100_000_000, "SPONSOR_HARD_FLOOR_STROOPS"),
@@ -268,6 +292,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): FacilitatorCon
     uptoContractId: parseUptoContractId(env.UPTO_CONTRACT_ID),
     bondEscrowContractId,
     bondEscrowAdminSecretKey,
+    channelAccountMinStroops,
     catalogDbUrl: env.CATALOG_DB_URL,
     catalogDbAuthToken: env.CATALOG_DB_AUTH_TOKEN,
     verificationApiUrl: env.VERIFICATION_API_URL,

--- a/src/hardening.test.ts
+++ b/src/hardening.test.ts
@@ -19,6 +19,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.asset-filter.test.ts
+++ b/src/server.asset-filter.test.ts
@@ -28,6 +28,7 @@ const testConfig = {
   port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(), maxTransactionFeeStroops: 500_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined, uptoContractId: undefined,
   bondEscrowContractId: undefined, bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined, verificationApiUrl: undefined,

--- a/src/server.bondregistration.test.ts
+++ b/src/server.bondregistration.test.ts
@@ -35,6 +35,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.extension-responses.test.ts
+++ b/src/server.extension-responses.test.ts
@@ -35,6 +35,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.health.test.ts
+++ b/src/server.health.test.ts
@@ -13,6 +13,7 @@ import { fakeChannelAccountSecretKeys } from "./testChannelPoolKeys.js";
 const testConfig = {
   port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
   sponsorSecretKey: Keypair.random().secret(), channelAccountSecretKeys: fakeChannelAccountSecretKeys(), maxTransactionFeeStroops: 500_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.metrics.test.ts
+++ b/src/server.metrics.test.ts
@@ -38,6 +38,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.pagination.test.ts
+++ b/src/server.pagination.test.ts
@@ -19,6 +19,7 @@ import { fakeChannelAccountSecretKeys } from "./testChannelPoolKeys.js";
 const testConfig = {
   port: 0, host: "127.0.0.1", network: "stellar:testnet" as const, rpcUrl: undefined,
   sponsorSecretKey: Keypair.random().secret(), channelAccountSecretKeys: fakeChannelAccountSecretKeys(), maxTransactionFeeStroops: 500_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined, uptoContractId: undefined,
   bondEscrowContractId: undefined, bondEscrowAdminSecretKey: undefined,
   catalogDbAuthToken: undefined, verificationApiUrl: undefined,

--- a/src/server.policykey.test.ts
+++ b/src/server.policykey.test.ts
@@ -29,6 +29,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -18,6 +18,7 @@ const testConfig = {
   sponsorSecretKey: Keypair.random().secret(),
   channelAccountSecretKeys: fakeChannelAccountSecretKeys(),
   maxTransactionFeeStroops: 2_000_000,
+  channelAccountMinStroops: 5_000_000,
   catalogDbUrl: undefined,
   uptoContractId: undefined,
   bondEscrowContractId: undefined,

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
 } from "./trust.js";
 import { createSpendPolicy, type SpendPolicy } from "./policy.js";
 import { BalanceGuard } from "./balance.js";
+import { createChannelMonitor } from "./channelMonitor.js";
 import { registerSettlement, type BondEscrowOptions } from "./bond.js";
 import {
   registry as metricsRegistry,
@@ -1018,6 +1019,7 @@ if (isDirectRun) {
   });
   balanceGuard.start();
 
+
   // Bond registration is opt-in by contract ID, same convention as uptoContractId
   // above — unset means bonding is entirely inactive, /settle unchanged. The
   // both-or-neither invariant already enforced in config.ts guarantees the admin
@@ -1039,8 +1041,12 @@ if (isDirectRun) {
     );
   }
 
+  // Hoisted rather than inlined into buildServer(...): the channel monitor below
+  // needs the SAME ChannelPool instance the facilitator settles through, and a
+  // second buildFacilitator() call would construct a second, disconnected pool.
+  const built = buildFacilitator(config);
   const app = await buildServer(
-    buildFacilitator(config),
+    built,
     catalog,
     trust,
     policy,
@@ -1049,6 +1055,35 @@ if (isDirectRun) {
     config.network,
     bondEscrow,
   );
+
+  // Channel-account balance monitor. The pool's disable()/enable() shipped fully
+  // implemented and tested with NO production caller, so an account drifting
+  // toward the Stellar minimum reserve stayed `available` and kept being handed
+  // out until a settlement using it failed on-chain — the gap named in
+  // docs/deploy-runbook.md §11. This is that caller.
+  //
+  // PUBLIC keys only, derived here the same way sponsorPub is above. The monitor
+  // is never given a secret: there is nothing in its scope that could leak one.
+  // They cannot be read off the pool instead — its address sets are private by
+  // design and status() returns counts only.
+  const channelAddresses = config.channelAccountSecretKeys.map(
+    (secret) => Keypair.fromSecret(secret).publicKey(),
+  );
+  const channelMonitor = createChannelMonitor({
+    pool: built.pool,
+    addresses: channelAddresses,
+    fetchBalanceStroops: (address) => fetchXlmBalanceStroops(horizonUrl, address),
+    floorStroops: config.channelAccountMinStroops,
+    // Shared with the sponsor guard on purpose — see config.ts. What matters is
+    // the combined Horizon request budget, not two independently tunable knobs.
+    intervalMs: config.balance.intervalMs,
+    logger: {
+      info: (msg) => app.log.info(msg),
+      warn: (msg) => app.log.warn(msg),
+      error: (msg) => app.log.error(msg),
+    },
+  });
+  channelMonitor.start();
   // P3 — sponsor funding asserted AT BOOT, with the fix in the error. The
   // polling balance guard exists for drain DURING operation; this exists for
   // the setup mistake, which otherwise surfaces mid-payment as an


### PR DESCRIPTION
## What this adds

Background job that monitors XLM balance for all 50 channel accounts and calls
`pool.disable()` / `pool.enable()` automatically.

## Behaviour
- Checks every `SPONSOR_BALANCE_INTERVAL_MS` (default 60s)
- Disables accounts below `CHANNEL_ACCOUNT_MIN_STROOPS` (default 5 XLM = 5,000,000 stroops)
- Auto-enables when balance recovers above the floor
- Fail-open on Horizon errors — disables only after 5 consecutive failures **per account**
- Sequential checks to avoid bursting Horizon

## Why this matters

`disable()` and `enable()` were fully implemented, exported and unit-tested from
the day the pool shipped — with **zero production call sites**. The pool's own
tests passed while the behaviour they describe never once happened in
production. A channel account drifting toward the Stellar minimum reserve stayed
`available` and kept being handed out until a settlement using it failed
on-chain. This is the caller those two methods were waiting for, and closes the
gap flagged in `docs/deploy-runbook.md` §11 and `BUILD-PLAN.md` Phase 3.

## The fail-open posture is deliberately inverted from `BalanceGuard`

`BalanceGuard` fails open because refusing settlement on a flaky read is
self-inflicted downtime. Here the risk inverts: if an unreadable balance
disabled an account, **one Horizon outage would disable all 50 and take the pool
to zero**, halting settlement entirely. So a failed check changes nothing, and
only a per-account run of 5 consecutive failures withdraws an account — long
enough to ride out a blip, short enough that a genuinely dead account is
eventually pulled.

## Config
`CHANNEL_ACCOUNT_MIN_STROOPS` — optional, default `5_000_000` (5 XLM). This is a
**reserve** floor, not a fee budget: channel accounts never pay their own fees
(the sponsor is `feeBumpSigner`) and never hold the payment asset, so each only
needs enough XLM to keep existing (`docs/channel-pool-design.md` §5/§6).

No separate interval variable — it reuses `SPONSOR_BALANCE_INTERVAL_MS`, since
what actually matters is the combined Horizon request budget rather than two
knobs to keep in agreement.

## Testing
**596 passing** (18 new in `src/channelMonitor.test.ts`), typecheck clean.

Beyond the 12 specified, the added tests cover: the strict `<` floor boundary (a
balance exactly at the floor is healthy), `start()` idempotence, XLM-not-stroops
log formatting, and that one account's thrown reading does not abort the pass
for the other 49.

Two traps the tests pin down explicitly:
- **NaN is treated as a failed check, not as healthy.** `NaN < floor` is `false`,
  so an unguarded comparison would read a malformed Horizon response as "above
  the floor" and leave a possibly-empty account in rotation.
- **No full address ever reaches a log line** — asserted across every line the
  monitor emits, not just the happy path.

## Security
- The monitor is given derived **public** keys and an injected balance reader —
  never secrets, and never the pool's private address sets. There is nothing in
  its scope that *could* leak a key.
- Logs carry `first4…last4` only.
- No injection surface: addresses are SDK-derived `G…` strings from secrets
  already validated `/^S[A-Z2-7]{55}$/` at boot.
- Safe from a background async context: `disable()`, `enable()` and `acquire()`
  contain zero `await`, so each runs to completion as one synchronous block.

## What does not change
- `channelPool.ts` — untouched
- `metrics.ts` — untouched; `vellar_pool_disabled` already tracks this via the
  existing `setPoolGauges(pool.status())` call
- Settlement flow — untouched

## One structural note
`buildFacilitator(config)` is now hoisted into a `built` variable at the call
site so the monitor receives the **same** `ChannelPool` the facilitator settles
through. Calling it a second time would have constructed a second, disconnected
pool — a monitor faithfully managing lanes nothing settles on.

The 10 existing test fixtures changed only to add the new required config field.
