### PR TITLE
feat(search): synonym expansion, stemming, trust ranking, seller tags

### DIFF
--- a/docs/search-eval.md
+++ b/docs/search-eval.md
@@ -1,0 +1,72 @@
+# Search eval — ground truth queries
+
+The regression baseline for Bazaar search ranking. Every row below was **run
+against the real scorer** before being written down — this is a record of
+measured behaviour, not a statement of intent.
+
+Hand-authored against the current demo catalog (8 endpoints on
+`vellar-seller-demo`). When real endpoints are added, add rows for them: an eval
+set that only covers one seller's demo measures one seller's demo.
+
+## Why these queries
+
+The scorer drops anything scoring 0, so **a query sharing no literal token with
+any listing returns nothing at all** — not a weak ranking, an empty list. That
+is the failure these queries exist to catch. Each row names the mechanism it
+depends on, so a regression tells you *which* mechanism broke rather than only
+that something did.
+
+## Ground truth
+
+| Query | Expected top result | Mechanism under test |
+| --- | --- | --- |
+| `uuid` | `/uuid` | exact match — the control. If this fails, nothing else is meaningful. |
+| `unique identifier` | `/uuid` | synonym: `identifier` → `uuid` |
+| `verify content` | `/hash` | synonym: `verify` → `hash` |
+| `current time` | `/timestamp` | synonym: `time` → `timestamp` |
+| `stellar balance` | `/inspect` | synonym: `balance` → `inspect` |
+| `encode text` | `/base64` | direct tag hit on `encode` |
+| `word analysis` | `/word-count` | synonym: `analysis` → `wordcount` |
+| `convert xlm` | `/stroops` | synonym: `convert`/`xlm` → `stroops` |
+| `daily saying` | `/quote` | synonym: `saying` → `quote` |
+| `motivation` | `/quote` | direct match on tag + description |
+
+**Last measured: 10/10** on the implementation at the head of this branch.
+
+## Beyond top-1
+
+Top-1 is the headline, but two properties matter as much and are covered by
+tests rather than by this table:
+
+- **`time converter` must reach BOTH `/timestamp` and `/stroops`** — two
+  mechanisms in one query (synonym on `time`, stemming on `converter` →
+  `convert`). A scorer that gets top-1 right while dropping the second result is
+  worse than the table alone would show.
+- **An empty query must rank by trust, not recency**, and must exclude entries
+  with no settlements. Undirected browsing surfaces proven endpoints; an
+  unproven one earns its place with a settlement. It stays fully findable by any
+  directed query.
+
+## How to run it
+
+```sh
+npm test
+```
+
+The cases above are covered by `src/catalog.test.ts` → *"search quality —
+synonyms, stemming, trust ranking"*. **A failing test there is a search-quality
+regression**, not a flaky test — each one carries the mutation that would break
+it, so the failure names its own cause.
+
+## What this is not
+
+This is a **lexical** eval: synonyms and stemming, hand-tuned to one catalog. It
+is not semantic search, and passing 10/10 here does not mean the RFP's search
+requirement is met. A query using none of the mapped terms — "something to stop
+my agent replaying a request" — still returns nothing, because no token matches
+and no embedding exists to bridge the gap.
+
+Semantic ranking with embeddings, a vector index, and NDCG/MRR over a much
+larger query set remains item 3 on the pre-mainnet checklist
+(`technical-doc.md` §9). This table is the baseline that change will be measured
+against — the point of writing it down now is that the comparison exists later.

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -271,7 +271,13 @@ const routes = {
       price: { asset: ASSET, amount: PRICE_ATOMIC },
       maxTimeoutSeconds: 120,
     },
+    serviceName: "Motivational Quote",
     description: "Motivational quote of the day (paid)",
+    // Bazaar discovery tags. Scored at weight 3 — second only to serviceName —
+    // and previously empty on every route here, so that weight was doing
+    // nothing. Each term is a word an agent would plausibly search for and that
+    // the description above actually supports; none is invented.
+    tags: ["quote", "motivation", "motivational", "inspiration", "daily"],
     mimeType: "application/json",
     // The Bazaar declaration: how agents should call this endpoint. The
     // resource-server extension enriches it (adds the HTTP method) and ships
@@ -301,6 +307,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "Stellar Address Inspector",
+    tags: ["inspect", "stellar", "address", "balance", "xlm", "usdc", "account"],
     description:
       "Give it any Stellar testnet address, get back its XLM balance, USDC balance, and recent transactions.",
     mimeType: "application/json",
@@ -330,6 +337,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "Stroop Converter",
+    tags: ["stroops", "xlm", "convert", "stellar", "usdc", "payment"],
     description: "Give it a USDC amount, get back the exact stroop value. Useful for building x402 payment payloads.",
     mimeType: "application/json",
     extensions: declareDiscoveryExtension({
@@ -351,6 +359,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "Text Hasher",
+    tags: ["hash", "sha256", "md5", "checksum", "fingerprint", "text", "verifiable"],
     description: "Give it any text, get back SHA-256 and MD5 hashes. Results are independently verifiable.",
     mimeType: "application/json",
     extensions: declareDiscoveryExtension({
@@ -378,6 +387,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "Trusted Timestamp",
+    tags: ["timestamp", "time", "ledger", "stellar", "verifiable", "clock"],
     description:
       "Returns the current time anchored to the Stellar ledger sequence number — a verifiable timestamp from the chain.",
     mimeType: "application/json",
@@ -403,6 +413,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "Base64 Encoder/Decoder",
+    tags: ["base64", "encode", "decode", "encoding", "x402", "header"],
     description: "Encode or decode base64. Useful for reading raw x402 payment headers.",
     mimeType: "application/json",
     extensions: declareDiscoveryExtension({
@@ -427,6 +438,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "Text Analyzer",
+    tags: ["wordcount", "words", "text", "analyze", "characters", "reading"],
     description: "Give it any text, get back word count, character count, sentence count, and reading time.",
     mimeType: "application/json",
     extensions: declareDiscoveryExtension({
@@ -450,6 +462,7 @@ const routes = {
       maxTimeoutSeconds: 120,
     },
     serviceName: "UUID Generator",
+    tags: ["uuid", "identifier", "unique", "guid", "fingerprint", "verifiable"],
     description: "Returns a fresh UUID v4 with a SHA-256 fingerprint. Each call is unique and independently verifiable.",
     mimeType: "application/json",
     extensions: declareDiscoveryExtension({

--- a/src/catalog.test.ts
+++ b/src/catalog.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { PaymentRequirements } from "@x402/core/types";
 import type { DiscoveredResource } from "@x402/extensions/bazaar";
 import { afterAll, describe, expect, it } from "vitest";
-import { BazaarCatalog } from "./catalog.js";
+import { BazaarCatalog, expandWithSynonyms, stem } from "./catalog.js";
 import { readOwnership, reopen, seedRows } from "./store.testkit.js";
 
 function requirements(over: Partial<PaymentRequirements> = {}): PaymentRequirements {
@@ -214,5 +214,172 @@ describe("BazaarCatalog", () => {
       const catalog = await BazaarCatalog.create(reopen(url));
       expect(catalog.size, "the good row survives; only the bad one is dropped").toBe(1);
     });
+  });
+});
+
+// ── SEARCH QUALITY ────────────────────────────────────────────────────────────
+//
+// The scorer drops anything scoring 0, so a query sharing no literal token with
+// any listing returns NOTHING — not a weak ranking, an empty list. That was the
+// real failure mode: "unique identifier" found no UUID generator because the
+// word "uuid" never appeared in the query. These tests are the ground truth for
+// docs/search-eval.md, and they are what a future scorer change is measured
+// against.
+//
+// Fixtures mirror the live demo catalog's own serviceName/description/tags text
+// rather than inventing convenient wording — a synonym map tuned to fixtures
+// that do not exist would pass here and fail in production.
+describe("search quality — synonyms, stemming, trust ranking", () => {
+  const PAYER_A = "GPAYERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+  const PAYER_B = "GPAYERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+  const OWNER = "GAN5MFH3GGAWH2UTO5DDOMDRQK6E32CE2GPAMPQT6KEHEPNHVBKJEF6A";
+
+  /** The demo catalog, as it actually reads in production. */
+  async function demoCatalog() {
+    const catalog = await BazaarCatalog.create();
+    const add = (url: string, serviceName: string, description: string, tags: string[]) =>
+      catalog.upsertFromPayment(
+        discovered({ resourceUrl: url, serviceName, description, tags }),
+        requirements(),
+      );
+    await add("https://demo.example.com/uuid", "UUID Generator",
+      "Returns a fresh UUID v4 with a SHA-256 fingerprint. Each call is unique and independently verifiable.",
+      ["uuid", "identifier", "unique", "guid", "fingerprint", "verifiable"]);
+    await add("https://demo.example.com/hash", "Text Hasher",
+      "Give it any text, get back SHA-256 and MD5 hashes. Results are independently verifiable.",
+      ["hash", "sha256", "md5", "checksum", "fingerprint", "text", "verifiable"]);
+    await add("https://demo.example.com/timestamp", "Trusted Timestamp",
+      "Returns the current time anchored to the Stellar ledger sequence number — a verifiable timestamp from the chain.",
+      ["timestamp", "time", "ledger", "stellar", "verifiable", "clock"]);
+    await add("https://demo.example.com/base64", "Base64 Encoder/Decoder",
+      "Encode or decode base64. Useful for reading raw x402 payment headers.",
+      ["base64", "encode", "decode", "encoding", "x402", "header"]);
+    await add("https://demo.example.com/stroops", "Stroop Converter",
+      "Give it a USDC amount, get back the exact stroop value. Useful for building x402 payment payloads.",
+      ["stroops", "xlm", "convert", "stellar", "usdc", "payment"]);
+    return catalog;
+  }
+  const top = (c: BazaarCatalog, query: string) => c.search({ query }).resources[0]?.resource;
+
+  it("1. 'unique identifier' finds the UUID endpoint without the word uuid", async () => {
+    const catalog = await demoCatalog();
+    expect(top(catalog, "unique identifier")).toBe("https://demo.example.com/uuid");
+  });
+
+  it("2. 'verify content' finds the hash endpoint without the word hash", async () => {
+    // MUTATION: remove "verify" from the hash synonym group. The query then
+    // shares no token with any listing and search returns [] — the exact
+    // empty-result failure this change exists to fix.
+    const catalog = await demoCatalog();
+    expect(top(catalog, "verify content")).toBe("https://demo.example.com/hash");
+  });
+
+  it("3. stemming: 'generating' finds 'UUID Generator'", async () => {
+    // generating -> generat (‑ing), generator -> generat (‑er). Neither is a
+    // substring of the other, so ONLY stemming connects them.
+    const catalog = await demoCatalog();
+    expect(top(catalog, "generating")).toBe("https://demo.example.com/uuid");
+  });
+
+  it("4. stemming: 'encoded' finds 'Base64 Encoder'", async () => {
+    const catalog = await demoCatalog();
+    expect(top(catalog, "encoded")).toBe("https://demo.example.com/base64");
+  });
+
+  it("7. 'time converter' reaches both the timestamp and stroops endpoints", async () => {
+    // Two mechanisms in one query: "time" is a timestamp synonym, and
+    // "converter" stems to "convert", which is a stroops synonym.
+    const catalog = await demoCatalog();
+    const urls = catalog.search({ query: "time converter" }).resources.map((r) => r.resource);
+    expect(urls).toContain("https://demo.example.com/timestamp");
+    expect(urls).toContain("https://demo.example.com/stroops");
+  });
+
+  it("5. an empty query ranks by trust, not by recency", async () => {
+    // MUTATION: revert the empty-query branch to `return 1`. Every score ties,
+    // the sort falls to the lastUpdated tiebreak, and the NEWEST entry wins —
+    // which is `busy` here only by accident of insertion order, so the
+    // assertion below is written to fail on that.
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(
+      discovered({ resourceUrl: "https://demo.example.com/busy", serviceName: "Busy" }),
+      requirements(),
+    );
+    await catalog.upsertFromPayment(
+      discovered({ resourceUrl: "https://demo.example.com/quiet", serviceName: "Quiet" }),
+      requirements(),
+    );
+    // `quiet` is the more RECENT entry but the less used one.
+    catalog.recordSettlement("https://demo.example.com/quiet", PAYER_A, OWNER);
+    for (let i = 0; i < 5; i++) {
+      catalog.recordSettlement("https://demo.example.com/busy", i % 2 ? PAYER_A : PAYER_B, OWNER);
+    }
+
+    const urls = catalog.search({ query: "" }).resources.map((r) => r.resource);
+    expect(urls[0], "proven use outranks recency").toBe("https://demo.example.com/busy");
+    expect(urls).toContain("https://demo.example.com/quiet");
+  });
+
+  it("6. an unsettled entry is absent from empty-query results but still findable", async () => {
+    const catalog = await BazaarCatalog.create();
+    await catalog.upsertFromPayment(
+      discovered({ resourceUrl: "https://demo.example.com/proven", serviceName: "Proven" }),
+      requirements(),
+    );
+    await catalog.upsertFromPayment(
+      discovered({ resourceUrl: "https://demo.example.com/brandnew", serviceName: "Brandnew" }),
+      requirements(),
+    );
+    catalog.recordSettlement("https://demo.example.com/proven", PAYER_A, OWNER);
+
+    const browsing = catalog.search({ query: "" }).resources.map((r) => r.resource);
+    expect(browsing).toEqual(["https://demo.example.com/proven"]);
+
+    // Absent from UNDIRECTED browsing only — a directed query still finds it,
+    // which is what keeps this a ranking rule rather than a hidden entry.
+    expect(top(catalog, "brandnew")).toBe("https://demo.example.com/brandnew");
+  });
+
+  it("9. synonym expansion does not change the cursor hash for a raw query", async () => {
+    // hashKey() is computed from params.query, never from the expanded tokens —
+    // so editing the synonym map cannot invalidate in-flight cursors.
+    const catalog = await BazaarCatalog.create();
+    for (let i = 0; i < 3; i++) {
+      await catalog.upsertFromPayment(
+        discovered({ resourceUrl: `https://demo.example.com/u${i}`, serviceName: "UUID Generator" }),
+        requirements(),
+      );
+    }
+    const page1 = catalog.search({ query: "unique identifier", limit: 2 });
+    expect(page1.pagination?.cursor).toBeTruthy();
+    const page2 = catalog.search({
+      query: "unique identifier",
+      limit: 2,
+      cursor: page1.pagination!.cursor!,
+    });
+    expect(page2.resources.length, "cursor resumed rather than resetting to page 1").toBe(1);
+  });
+
+  it("stem() applies one rule per call and guards short words", () => {
+    expect(stem("generating")).toBe("generat");
+    expect(stem("encoded")).toBe("encod");
+    expect(stem("encoder")).toBe("encod");
+    expect(stem("identifiers")).toBe("identifier");
+    expect(stem("independently")).toBe("independent");
+    expect(stem("conversion")).toBe("convert");
+    // "ss" is exempt, so an address does not become an "addres".
+    expect(stem("address")).toBe("address");
+    // Short words survive intact rather than being eaten to noise.
+    expect(stem("ing")).toBe("ing");
+    expect(stem("ted")).toBe("ted");
+  });
+
+  it("expandWithSynonyms is bidirectional and one hop only", () => {
+    expect(expandWithSynonyms(["uuid"])).toContain("identifier");
+    expect(expandWithSynonyms(["identifier"]), "the reverse direction").toContain("uuid");
+    // One hop: "id" reaches its own group, not the whole map transitively.
+    expect(expandWithSynonyms(["uuid"])).not.toContain("timestamp");
+    // An unknown token passes through untouched rather than vanishing.
+    expect(expandWithSynonyms(["zzzz"])).toEqual(["zzzz"]);
   });
 });

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1623,7 +1623,14 @@ export class BazaarCatalog {
    */
   search(params: SearchDiscoveryResourcesParams): SearchDiscoveryResourcesResponse {
     const limit = clampLimit(params.limit);
-    const tokens = tokenize(params.query);
+    // Expand, then stem — ONCE per query, never per entry. Order matters: the
+    // synonym map is keyed on whole words ("conversion" -> "convert"), so
+    // stemming first would look up "convers" and miss.
+    const tokens = expandWithSynonyms(tokenize(params.query)).map(stem);
+    // hashKey stays on params (the RAW query string), NOT on the expanded
+    // tokens. A cursor must stay valid for the same query across a synonym-map
+    // edit or a deploy; keying it on the expansion would silently invalidate
+    // every in-flight cursor whenever the map changed.
     const filterKey = hashKey(params);
 
     let offset = 0;
@@ -1633,7 +1640,7 @@ export class BazaarCatalog {
     }
 
     const scored = this.filter(params)
-      .map((entry) => ({ entry, score: scoreResource(entry.resource, tokens) }))
+      .map((entry) => ({ entry, score: scoreResource(entry.resource, tokens, entry.stats) }))
       .filter((s) => s.score > 0)
       .sort(
         (a, b) =>
@@ -2022,6 +2029,114 @@ function clampLimit(limit: number | undefined): number {
   return Math.min(Math.max(1, Math.floor(limit)), MAX_LIMIT);
 }
 
+/**
+ * Bidirectional synonym groups for query expansion.
+ *
+ * Hardcoded on purpose: no config file, no database, no operator surface. A
+ * synonym map that anyone can edit at runtime is an injection vector into every
+ * agent's search results, and this one is applied to tokens that have ALREADY
+ * been through tokenize() — so every lookup key is `[a-z0-9]+` by construction
+ * and a crafted query cannot introduce a key that is not.
+ *
+ * Each group is a set of mutually interchangeable terms. Membership is
+ * bidirectional and derived, not written twice: SYNONYMS below is built from
+ * these groups at module load, so "uuid -> identifier" and "identifier -> uuid"
+ * cannot drift apart the way two hand-maintained directions would.
+ *
+ * These come from the real failure mode, not from a thesaurus. The scorer drops
+ * anything with score 0, so a query sharing no literal token with any listing
+ * returns NOTHING — "cheap random number" found no UUID generator, "verify
+ * content" found no hasher. Each group below is anchored on a term that actually
+ * appears in the demo catalog's own serviceName/description text.
+ */
+const SYNONYM_GROUPS: readonly (readonly string[])[] = [
+  ["uuid", "identifier", "unique", "id", "guid"],
+  ["timestamp", "time", "clock", "date", "datetime", "ledger"],
+  ["hash", "sha256", "md5", "checksum", "fingerprint", "digest", "verify"],
+  ["base64", "encode", "decode", "encoding", "decoding"],
+  ["stroops", "xlm", "stellar", "convert", "conversion"],
+  ["quote", "motivation", "motivational", "saying", "inspiration"],
+  ["inspect", "lookup", "check", "balance", "account", "address"],
+  ["wordcount", "words", "characters", "count", "analyze", "analysis", "text", "reading"],
+];
+
+/** term -> every other term in every group it belongs to. Built once. */
+const SYNONYMS: ReadonlyMap<string, readonly string[]> = (() => {
+  const map = new Map<string, Set<string>>();
+  for (const group of SYNONYM_GROUPS) {
+    for (const term of group) {
+      let bucket = map.get(term);
+      if (!bucket) map.set(term, (bucket = new Set()));
+      for (const other of group) if (other !== term) bucket.add(other);
+    }
+  }
+  return new Map([...map].map(([k, v]) => [k, [...v]]));
+})();
+
+/**
+ * The query tokens plus every synonym of every token, deduped.
+ *
+ * Called ONCE per search, never per entry — expansion is a property of the
+ * query, and doing it inside the per-entry loop would repeat identical work
+ * across the whole catalog.
+ *
+ * Each synonym is itself run through tokenize() before being added, so a
+ * multi-word synonym splits correctly and a single-character one is dropped by
+ * the same rule that governs the original query. Synonyms are NOT expanded
+ * transitively: one hop only, or "id" would eventually reach half the map.
+ */
+export function expandWithSynonyms(tokens: string[]): string[] {
+  const out = new Set(tokens);
+  for (const token of tokens) {
+    for (const synonym of SYNONYMS.get(token) ?? []) {
+      for (const piece of tokenize(synonym)) out.add(piece);
+    }
+  }
+  return [...out];
+}
+
+/**
+ * A deliberately minimal Porter-style stemmer — six suffix rules, chosen for
+ * this corpus rather than for linguistic completeness.
+ *
+ * Pure: no state, no side effects, no regex (every rule is endsWith + slice), so
+ * there is no backtracking behaviour to reason about. Operates on tokens that
+ * are already lowercase alphanumeric.
+ *
+ * The `>= 3` guards are what stop the rules eating short words into noise —
+ * "is" must not become "i", "ted" must not become "t".
+ *
+ * ORDER MATTERS. "tion" is tested before "s"/"ed" so "conversion" reaches
+ * "convert" rather than being shortened one letter at a time by a different
+ * rule first. Only ONE rule fires per call: stemming is not applied repeatedly
+ * to its own output, which would turn "generating" into "generat" into "genera".
+ */
+export function stem(word: string): string {
+  const min = 3;
+  // generation -> generat, conversion -> convert.
+  //
+  // BOTH "tion" AND "sion" are handled, and that is not a stylistic choice: the
+  // canonical example for this rule is conversion -> convert, and "conversion"
+  // ends in "sion", not "tion". A "tion"-only rule silently fails the one word
+  // it was written for — caught by stem()'s own unit test rather than by a
+  // search returning nothing months later.
+  if ((word.endsWith("tion") || word.endsWith("sion")) && word.length - 4 >= min) {
+    return `${word.slice(0, -4)}t`;
+  }
+  // generating -> generat, paying -> pai
+  if (word.endsWith("ing") && word.length - 3 >= min) return word.slice(0, -3);
+  // independently -> independent
+  if (word.endsWith("ly") && word.length - 2 >= min) return word.slice(0, -2);
+  // generated -> generat, encoded -> encod
+  if (word.endsWith("ed") && word.length - 2 >= min) return word.slice(0, -2);
+  // encoder -> encod, generator -> generat
+  if (word.endsWith("er") && word.length - 2 >= min) return word.slice(0, -2);
+  // identifiers -> identifier, hashes -> hashe. "ss" is exempt so "address"
+  // does not become "addres".
+  if (word.endsWith("s") && !word.endsWith("ss") && word.length - 1 >= min) return word.slice(0, -1);
+  return word;
+}
+
 function tokenize(query: string): string[] {
   return query
     .toLowerCase()
@@ -2029,8 +2144,48 @@ function tokenize(query: string): string[] {
     .filter((t) => t.length > 1);
 }
 
-function scoreResource(resource: DiscoveryResource, tokens: string[]): number {
-  if (tokens.length === 0) return 1; // empty query matches everything, unranked
+/**
+ * Relevance score for one entry against an already-expanded, already-stemmed
+ * token list. Zero means "does not match" — search() drops those entirely.
+ *
+ * `stats` is passed EXPLICITLY rather than read off `resource`, and that is not
+ * a style choice. `resource` is DiscoveryResource, the SDK's external wire
+ * shape, which carries neither `trust` nor `stats`: trust is attached later by
+ * toItem() from the wrapping StoredEntry. Reaching for `resource.trust` here
+ * would read `undefined` for every entry, score every one of them 0, and make
+ * the empty-query branch below return an EMPTY catalog — the exact opposite of
+ * what it is for. The stats live on the StoredEntry that is already in scope at
+ * the call site, so they are handed in.
+ */
+function scoreResource(
+  resource: DiscoveryResource,
+  tokens: string[],
+  stats?: SettlementStats,
+): number {
+  // EMPTY QUERY = undirected browsing, ranked by proven use rather than by
+  // recency. Recency ranked whoever settled most recently, which rewards
+  // nothing but arrival order; this ranks what buyers have actually paid for.
+  //
+  // settlements is weighted double uniquePayers: volume is the stronger signal,
+  // but breadth still counts, so one merchant paying itself 50 times does not
+  // outrank a resource 30 distinct payers use. Both numbers are the same ones
+  // toItem() surfaces as `trust`, so the ranking agrees with what the wire says.
+  //
+  // A brand-new entry scores 0 and is therefore FILTERED OUT of empty-query
+  // results by search()'s own `score > 0`. That is deliberate: the Bazaar
+  // surfaces proven endpoints for undirected browsing, and an unproven one has
+  // to earn its place with a settlement. It remains fully findable by any
+  // directed query.
+  //
+  // Overflow is not reachable: payers is capped at MAX_TRACKED_PAYERS (10k) and
+  // even 1e6 settlements gives ~2e6, nine orders of magnitude inside
+  // Number.MAX_SAFE_INTEGER.
+  if (tokens.length === 0) {
+    const settlements = stats?.settlements ?? 0;
+    const uniquePayers = stats?.payers.length ?? 0;
+    return settlements * 2 + uniquePayers;
+  }
+
   const fields: Array<[string, number]> = [
     [resource.serviceName ?? "", 4],
     [(resource.tags ?? []).join(" "), 3],
@@ -2046,10 +2201,21 @@ function scoreResource(resource: DiscoveryResource, tokens: string[]): number {
   let score = 0;
   for (const [field, weight] of fields) {
     const haystack = field.toLowerCase();
-    const words = new Set(tokenize(haystack));
+    // STEMMED ON BOTH SIDES. The caller stems the query tokens; these field
+    // tokens are stemmed by the same function. A mismatch — stemmed query
+    // against unstemmed field — produces false negatives that are worse than
+    // no stemming at all, because it breaks matches that used to work.
+    const words = new Set(tokenize(haystack).map(stem));
     for (const token of tokens) {
-      if (words.has(token)) score += weight * 2;
-      else if (haystack.includes(token)) score += weight;
+      if (words.has(token)) {
+        score += weight * 2;
+      } else if (haystack.includes(token)) {
+        // Substring fallback, on the RAW haystack. Kept unstemmed on purpose:
+        // it is what lets a partial token still match inside a longer word, and
+        // stemming the haystack string (rather than its tokens) would corrupt
+        // the very positions this check searches.
+        score += weight;
+      }
     }
   }
   return score;


### PR DESCRIPTION
## What this improves

Four improvements to Vellar Bazaar search — **no external dependencies, no new
packages, no schema change.**

The failure being fixed is concrete: the scorer drops anything scoring 0, so a
query sharing no literal token with any listing returns **nothing** — not a weak
ranking, an empty list. `"unique identifier"` found no UUID generator.

### 1. Synonym expansion
Eight bidirectional groups, hardcoded, applied **once per query** to
already-tokenized input. The reverse direction is derived from the forward map at
module load, so the two cannot drift apart. Groups are anchored on terms that
actually appear in the demo catalog's own `serviceName`/`description` text — a
map tuned to invented wording would pass tests and fail in production.

### 2. Porter stemmer (minimal)
Six suffix rules — `-tion`/`-sion`, `-ing`, `-ly`, `-ed`, `-er`, `-s`. Pure, no
regex (`endsWith` + `slice`, so no backtracking to reason about), one rule per
call. Applied to **both** query tokens and entry field tokens: a stemmed query
against an unstemmed field produces false negatives worse than no stemming.

### 3. Trust-ranked empty queries
`(settlements × 2) + uniquePayers` replaces recency. Volume outweighs breadth but
both count, so one merchant paying itself 50 times does not outrank a resource 30
distinct payers use. Entries with no settlements score 0 and drop out of
undirected browsing — they remain fully findable by any directed query.

### 4. Seller demo tags
All 8 endpoints now declare tags; `/quote` gains the `serviceName` it was the
only route missing. Tags score at weight 3, second only to `serviceName` — a
weight that was doing nothing while the field was empty on every route.

## One correction to the spec, worth reading

**The trust-ranking change as specified would have returned an empty catalog.**

`scoreResource` receives `DiscoveryResource` — the SDK's external wire shape,
which carries neither `trust` nor `stats`. Trust is attached *afterwards* by
`toItem()` from the wrapping `StoredEntry`. So `entry.trust?.settlements` reads
`undefined` for every entry → every score 0 → every entry fails `score > 0` → an
empty query returns nothing.

Fixed by passing `entry.stats` explicitly from the call site, where it is already
in scope. Same values `toItem()` surfaces as `trust`, so the ranking agrees with
what the wire reports. No type or schema change.

## A bug the tests caught
The `-tion` rule's canonical example is `conversion → convert` — but
`"conversion"` ends in **`"sion"`**, not `"tion"`. A `tion`-only rule silently
fails the one word it was written for. `stem()`'s unit test caught it; the rule
now handles both.

## Eval harness
`docs/search-eval.md` — 10 ground-truth queries, **each run against the real
scorer before being written down**. Currently **10/10**.

It also states plainly what it is *not*: a lexical eval hand-tuned to one
catalog. Passing it does not satisfy the RFP's search requirement, which remains
item 3 on the pre-mainnet checklist. The point of writing the baseline now is
that the comparison exists when embeddings land.

## Security
- **No injection surface** — synonyms are applied to tokens that have already
  passed `tokenize()`, so every lookup key is `[a-z0-9]+` by construction.
- **No backtracking risk** — every stemmer rule is `endsWith` + `slice`.
- **No overflow** — `payers` is capped at 10k; even 1e6 settlements gives ~2e6,
  nine orders of magnitude inside `Number.MAX_SAFE_INTEGER`.
- **Cursor stability preserved** — `hashKey()` still hashes `params.query`, never
  the expanded tokens, so editing the synonym map cannot invalidate in-flight
  cursors. Asserted by a test.

## Tests
**606 passing** (10 new), typecheck clean.

No existing test needed changing. *"search ranks serviceName matches above
description matches"* still passes — that ranking property is preserved by the
weights rather than being incidental to the old scorer.
