### PR TITLE
fix(ci): provision channel accounts so the settle probe can boot

### DIFF
--- a/.github/workflows/settle-probe.yml
+++ b/.github/workflows/settle-probe.yml
@@ -72,10 +72,28 @@ jobs:
       - name: fund sponsor
         run: |
           curl -fsS "https://friendbot.stellar.org/?addr=${{ steps.provision.outputs.SPONSOR_PUBLIC }}" > /dev/null
+      # The 50 channel accounts the pool settles from. CHANNEL_ACCOUNT_SECRET_KEYS
+      # became REQUIRED with no default in 6f5de85 (2026-08-31) and this workflow
+      # was never updated, so the facilitator refused to boot on every scheduled
+      # run from that day — 24 consecutive failures, all reported only as
+      # `curl: (7) ... port 4100`, because the real error went to facilitator.log
+      # and nothing printed it. See the "boot diagnostics" step below.
+      #
+      # Created from the sponsor rather than via 50 friendbot calls: channel
+      # accounts need only the minimum reserve (the sponsor is the feeBumpSigner
+      # — docs/channel-pool-design.md §5/§6), and 50 sequential friendbot calls
+      # would be minutes of wall clock and a fresh rate-limit flake surface.
+      - name: provision channel accounts
+        id: channels
+        run: |
+          SPONSOR_SECRET='${{ steps.provision.outputs.SPONSOR_SECRET }}' \
+            node scripts/provision-channel-accounts.mjs >> "$GITHUB_OUTPUT"
       - name: boot stack
         run: |
           mkdir -p data
-          SPONSOR_SECRET_KEY='${{ steps.provision.outputs.SPONSOR_SECRET }}' PORT=4100 \
+          SPONSOR_SECRET_KEY='${{ steps.provision.outputs.SPONSOR_SECRET }}' \
+            CHANNEL_ACCOUNT_SECRET_KEYS='${{ steps.channels.outputs.CHANNEL_ACCOUNT_SECRET_KEYS }}' \
+            PORT=4100 \
             CATALOG_DB_URL=file:./data/catalog.db npm start > facilitator.log 2>&1 &
           for i in $(seq 1 60); do curl -fsS http://localhost:4100/health >/dev/null 2>&1 && break; sleep 2; done
           cd examples
@@ -84,6 +102,17 @@ jobs:
             node seller.mjs > ../seller.log 2>&1 &
           for i in $(seq 1 90); do curl -fsS http://localhost:4031/whoami >/dev/null 2>&1 && break; sleep 2; done
           curl -fsS http://localhost:4100/health && curl -fsS http://localhost:4031/whoami
+      # WHY THIS STEP EXISTS. The boot failure above was invisible for 24 runs:
+      # the facilitator wrote its exact cause to facilitator.log, the log was
+      # uploaded as an artifact nobody opened, and the run page showed only
+      # "exit code 7". A config error that names itself is worth nothing if the
+      # name never reaches the log an operator actually reads. `if: failure()`
+      # so a healthy run stays quiet.
+      - name: boot diagnostics (on failure)
+        if: failure()
+        run: |
+          echo "───── facilitator.log ─────"; tail -60 facilitator.log || true
+          echo "───── seller.log ─────";      tail -40 seller.log      || true
       - name: probe (burst)
         run: |
           cd examples

--- a/scripts/provision-channel-accounts.mjs
+++ b/scripts/provision-channel-accounts.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Provision the 50 channel accounts the facilitator needs to boot.
+//
+// WHY THIS EXISTS. `CHANNEL_ACCOUNT_SECRET_KEYS` became REQUIRED with no
+// default when the channel pool shipped (6f5de85, 2026-08-31), and
+// .github/workflows/settle-probe.yml was never updated. The facilitator has
+// refused to boot in CI on every scheduled run since that commit — the probe
+// failed 24 consecutive times with `curl: (7) Failed to connect to localhost
+// port 4100`, because the real error was written to facilitator.log and never
+// surfaced. This script is the missing provisioning step.
+//
+// WHY NOT 50 FRIENDBOT CALLS. Friendbot is rate-limited and slow; 50 sequential
+// calls is minutes of wall clock and a new flake surface on a job that already
+// takes six. Channel accounts need only the Stellar minimum reserve (never a
+// fee budget — the sponsor is the feeBumpSigner, docs/channel-pool-design.md
+// §5/§6), so they are created straight from the already-friendbot-funded
+// sponsor with `createAccount` ops batched into a handful of transactions.
+//
+// Prints `CHANNEL_ACCOUNT_SECRET_KEYS=<50 comma-separated secrets>` on stdout
+// for `>> "$GITHUB_OUTPUT"`. Everything else goes to stderr so the output line
+// is the only thing on stdout.
+//
+// Env: SPONSOR_SECRET (required), STELLAR_RPC_URL, CHANNEL_STARTING_BALANCE.
+
+import { Keypair, Operation, TransactionBuilder, rpc } from "@stellar/stellar-sdk";
+
+const PASSPHRASE = "Test SDF Network ; September 2015";
+const RPC_URL = process.env.STELLAR_RPC_URL || "https://soroban-testnet.stellar.org";
+/** Locked at 50 by src/config.ts's parseChannelAccountSecretKeys, which rejects
+ *  any other count rather than trimming or padding. */
+const POOL_SIZE = 50;
+/** Comfortably above the 1 XLM a subentry-free account needs, and far below the
+ *  ~10,000 XLM friendbot grants the sponsor — so one friendbot call covers all
+ *  50 with room to spare. */
+const STARTING_BALANCE = process.env.CHANNEL_STARTING_BALANCE || "5";
+/** Stellar allows 100 ops/tx; 25 keeps each transaction small enough to confirm
+ *  quickly and bounds the blast radius if one submission has to be retried. */
+const OPS_PER_TX = 25;
+
+const sponsorSecret = process.env.SPONSOR_SECRET;
+if (!sponsorSecret) {
+  console.error("SPONSOR_SECRET is required (the friendbot-funded sponsor for this run)");
+  process.exit(1);
+}
+
+const server = new rpc.Server(RPC_URL);
+const sponsor = Keypair.fromSecret(sponsorSecret);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Submit one transaction and wait for it to actually confirm. Same shape as
+ *  scripts/run-load-test.js's own `submit` — sendTransaction returning PENDING
+ *  is not confirmation. */
+async function submit(label, ops) {
+  // Sequence is re-read per transaction: these are submitted in series from one
+  // source account, so each build must see the previous one's consumed sequence.
+  const account = await server.getAccount(sponsor.publicKey());
+  let tx = new TransactionBuilder(account, { fee: "1000000", networkPassphrase: PASSPHRASE });
+  for (const op of ops) tx = tx.addOperation(op);
+  tx = tx.setTimeout(120).build();
+  tx.sign(sponsor);
+
+  const sent = await server.sendTransaction(tx);
+  if (sent.status === "ERROR") {
+    throw new Error(`${label}: send rejected — ${JSON.stringify(sent.errorResult ?? sent.status)}`);
+  }
+  for (let i = 0; i < 45; i++) {
+    await sleep(1500);
+    const got = await server.getTransaction(sent.hash);
+    if (got.status === "SUCCESS") return sent.hash;
+    if (got.status === "FAILED") throw new Error(`${label}: ${sent.hash} FAILED on-chain`);
+  }
+  throw new Error(`${label}: ${sent.hash} never confirmed`);
+}
+
+const channels = Array.from({ length: POOL_SIZE }, () => Keypair.random());
+
+// The same invariants config.ts enforces at boot, asserted here so a violation
+// surfaces in provisioning rather than as an opaque boot failure two steps later.
+const secrets = channels.map((k) => k.secret());
+if (new Set(secrets).size !== POOL_SIZE) throw new Error("duplicate channel key generated");
+if (secrets.includes(sponsor.secret())) throw new Error("sponsor key landed in the channel pool");
+
+console.error(`[provision] creating ${POOL_SIZE} channel accounts @ ${STARTING_BALANCE} XLM from ${sponsor.publicKey().slice(0, 8)}…`);
+
+for (let i = 0; i < channels.length; i += OPS_PER_TX) {
+  const batch = channels.slice(i, i + OPS_PER_TX);
+  const ops = batch.map((kp) =>
+    Operation.createAccount({ destination: kp.publicKey(), startingBalance: STARTING_BALANCE }),
+  );
+  const hash = await submit(`createAccount[${i}..${i + batch.length - 1}]`, ops);
+  console.error(`[provision]   ${batch.length} accounts created — ${hash}`);
+}
+
+// Confirm the pool is visible to the RPC before the facilitator tries to use it.
+// friendbot/createAccount returning success does not mean the RPC can see the
+// account yet, and a settle against an invisible source account fails in a way
+// that looks like a facilitator bug.
+console.error("[provision] waiting for the RPC to see every channel account…");
+for (const kp of channels) {
+  let seen = false;
+  for (let i = 0; i < 30 && !seen; i++) {
+    try {
+      await server.getAccount(kp.publicKey());
+      seen = true;
+    } catch {
+      await sleep(1000);
+    }
+  }
+  if (!seen) throw new Error(`${kp.publicKey().slice(0, 8)}…: created but never visible to the RPC`);
+}
+
+console.error(`[provision] all ${POOL_SIZE} channel accounts funded and visible`);
+console.log(`CHANNEL_ACCOUNT_SECRET_KEYS=${secrets.join(",")}`);


### PR DESCRIPTION
## The problem

The settle probe has failed **every scheduled run since 2026-08-31** — 24
consecutive failures, including [run #84](https://github.com/Vellar-Wallet/vellar-facilitator/actions/runs/33967740103).

Nothing is wrong with the facilitator. `main` is green (613 tests) and the
deployed instance is healthy. The workflow booted it with only
`SPONSOR_SECRET_KEY`, `PORT` and `CATALOG_DB_URL` — but
`CHANNEL_ACCOUNT_SECRET_KEYS` became **required with no default** in `6f5de85`
(the channel pool), merged that same day. `loadConfig` throws, the process
exits, and the wait loop then spins 60 times against a port nothing is
listening on. Both matrix arms exit 7.

Reproduced locally with exactly the workflow's env before changing anything:

```
Error: [config] CHANNEL_ACCOUNT_SECRET_KEYS is required: a comma-separated list
of exactly 50 funded Stellar classic (S...) secrets, one per channel account in
the settlement pool — see docs/channel-pool-design.md. There is no default...
```

The boundary is clean:

| Date | Result |
|---|---|
| 2026-08-28 → 08-30 | 13 runs, **all success** |
| 2026-08-31 | 1 success, then **failures** ← `6f5de85` merges 13:36 |
| 2026-09-01 → 09-06 | **all failure** |

## The fix

**`scripts/provision-channel-accounts.mjs`** creates the 50 accounts from the
already-friendbot-funded sponsor using batched `createAccount` ops — 2
transactions of 25, not 50 sequential friendbot calls. Channel accounts need
only the minimum reserve, since the sponsor is the `feeBumpSigner`
(`docs/channel-pool-design.md` §5/§6), and 50 friendbot calls would add minutes
of wall clock and a fresh rate-limit flake surface to a job that already takes
six.

It also asserts `config.ts`'s own pool invariants (50 distinct, sponsor
excluded) *during provisioning*, and waits for every account to be visible to
the RPC — `createAccount` succeeding does not mean the RPC can see it yet, and a
settle against an invisible source account fails in a way that reads like a
facilitator bug.

## Verified against real testnet, not just by inspection

```
[provision] creating 50 channel accounts @ 5 XLM from GCJD3QID…
[provision]   25 accounts created — 5ac92b9edaa605f365fd2be822c2b239a5f3179f4fa751c44ec5e741c152dd46
[provision]   25 accounts created — 29bd010d8194faf495d44172d9f2caefd5128072e5fbc838fd3a6d57a58b9eb6
[provision] all 50 channel accounts funded and visible
```

Then booting the facilitator with those keys:

```json
{ "status": "ok", "channelPool": { "available": 50, "inUse": 0, "disabled": 0, "total": 50 } }
[boot] sponsor preflight ok — GA6IKQQC… holds 10000.0000000 XLM
```

## Why it went unnoticed for six days

The facilitator wrote its exact cause to `facilitator.log`, which was uploaded
as an artifact nobody opened, while the run page showed only "exit code 7". A
config error that names itself is worth nothing if the name never reaches the
log an operator actually reads.

This PR adds a `boot diagnostics (on failure)` step that tails both logs. `if:
failure()`, so a healthy run stays quiet.

## Scope

`settle-probe.yml` is the **only** workflow that boots the facilitator
(`grep -ln "npm start" .github/workflows/*.yml`), so no other job carries this
latent break. 613 tests passing, typecheck clean, no `src/` changes.
