### PR TITLE
feat(conformance): x402-foundation e2e suite run + Vellar proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ demo-facilitator.log
 demo-seller.log
 contracts/upto-stellar/target/
 contracts/bond-escrow/target/
+.e2e-local/

--- a/docs/conformance-report.md
+++ b/docs/conformance-report.md
@@ -1,9 +1,11 @@
 # Conformance report — x402 `exact` and `upto` on Stellar
 
 **Facilitator:** `https://vellar-facilitator.onrender.com`
-**Report date:** 2026-09-03
-**Status:** partial — see [§6 Known gaps](#6-known-gaps). Two of the RFP's
-conformance line items are **not yet satisfied** and are named plainly below.
+**Report date:** 2026-09-03; e2e suite run added 2026-09-08
+**Status:** partial — see [§6 Known gaps](#6-known-gaps). The e2e suite has now
+been run against the live facilitator (§6.1): **C1 is satisfied on testnet**
+with six Horizon-confirmed settlements, and **C4 is partial**. Pubnet (§6.2)
+and semantic search (§6.3) remain unsatisfied and are named plainly below.
 
 ---
 
@@ -20,10 +22,10 @@ It asks specifically for:
 
 | # | RFP requirement | Status |
 |---|---|---|
-| C1 | An unmodified canonical client completing a payment end to end on both networks | ⛔ **not done** — see §6.1 |
+| C1 | An unmodified canonical client completing a payment end to end on both networks | ✅ **testnet** — 6 settled txs, §6.1. Pubnet: ⛔ §6.2 |
 | C2 | `/supported` emitting the Stellar `extra` contract including `areFeesSponsored` | ✅ verified live, §3.1 |
 | C3 | The spec `payload: {transaction}` format accepted verbatim | ✅ verified live, §3.2 / §5 |
-| C4 | A passing run of the x402 repo's e2e suite for both networks | ⛔ **not done** — see §6.1 |
+| C4 | A passing run of the x402 repo's e2e suite for both networks | ⚠️ **partial** — 6/10 passed testnet, 4 unexecuted, pubnet unrun; §6.1 |
 | C5 | A published settled transaction hash per network per scheme | ⚠️ **testnet only** — §4, §5. Pubnet: §6.2 |
 | C6 | A non-null `reason` on every rejection | ✅ verified live, §3.3 |
 | S1 | Bazaar search: "real ranking" with a stated evaluation approach (RFP §3.2) | ⛔ **lexical only** — see §6.3 |
@@ -175,56 +177,138 @@ production-ready.
 
 ## 6. Known gaps
 
-### 6.1 The x402 e2e suite has not been run — C1, C4 ⛔
+### 6.1 The x402 e2e suite — RUN 2026-09-08 — C1 ✅ testnet, C4 ⚠️ partial
 
-**Suite location and command, confirmed:**
+**The suite has now been run against the live facilitator.** Six scenarios
+settled real payments end to end through
+`https://vellar-facilitator.onrender.com`; four never executed because two
+upstream server components fail to start in this environment. Both halves are
+recorded below, and the four non-executing scenarios are **not** counted as
+passes.
 
-- Repo: `https://github.com/x402-foundation/x402` (HEAD `626df07` at the time of writing)
-- Suite: `e2e/`, entrypoint `e2e/test.ts`, run with `pnpm test` from `e2e/`
-- Stellar catalog: `e2e/config/mechanisms_stellar.json`, declaring routes
-  `/exact/stellar` and `/exact/stellar/upfront` (scheme `exact`, `sdks:
-  ["typescript"]`, extension `bazaar`), with `testnet` (`stellar:testnet`) and
-  `mainnet` (`stellar:pubnet`) both defined
-- Targeting an external facilitator: the resource server reads `FACILITATOR_URL`
-  from the environment (`e2e/src/server-env.ts:70`), so the live URL can be used
-  directly without writing a proxy
+**Suite version:** `x402-foundation/x402` HEAD **`241df66`** ("Enforce
+file-size and complexity limits with coverage thresholds", #3393). *(This
+supersedes the `626df07` cited in earlier revisions of this section.)*
 
-**Why it was not run.** The suite requires three funded Stellar testnet accounts
-— client, server, facilitator — declared `required: true` in the catalog:
-
-```
-SERVER_STELLAR_ADDRESS
-CLIENT_STELLAR_PRIVATE_KEY
-FACILITATOR_STELLAR_PRIVATE_KEY
-```
-
-Per `e2e/README.md`, the client and server accounts additionally need a **USDC
-trustline** and **testnet USDC from the Circle faucet**; the facilitator account
-needs XLM only.
-
-This repository holds only `SPONSOR_SECRET_KEY`. The harness gate was run to
-confirm the blocker empirically rather than assume it:
-
-```
-$ npx tsx scripts/ci-select-families.ts
-No protocol families have all required wallet secrets configured.
-Set variables in e2e/.env or export them in your shell.
-```
-
-**This is an environment gap, not a defect in the facilitator** — but it is
-also not evidence of conformance, and it is the single most load-bearing item
-the RFP asks for. It cannot be closed by any amount of internal testing.
-
-**Plan to close.** Provision three dedicated Stellar testnet accounts, add USDC
-trustlines to client and server, fund the client from the Circle faucet, then:
+**Command:**
 
 ```bash
-cd e2e && cp .env-local .env    # fill in the three STELLAR keys
-FACILITATOR_URL=https://vellar-facilitator.onrender.com \
-  pnpm test --testnet --min --families=stellar --versions=2
+cd e2e
+pnpm test --testnet --min --families=stellar --versions=2 --facilitators=vellar
 ```
 
-Capture the full output verbatim into §3 of this document.
+#### C1 — unmodified canonical client, end to end — ✅ **testnet**
+
+An unmodified stock `@x402/*` TypeScript client completed payment against the
+live facilitator across three server frameworks and both HTTP client libraries.
+Every hash below was re-verified against Horizon after the run — `successful:
+true`, and `fee_account` equal to the facilitator's own sponsor
+`GBUCR6H22CZC5OYHBJIEUS2JFZBOB63AHEGTCV6UEPMD2TMLKG2ZMIW4` rather than the
+payer. That is `areFeesSponsored: true` demonstrated on-chain **by an external
+suite this project does not control**, not by our own assertion.
+
+| # | Client → Server → Route | Tx | Ledger |
+|---|---|---|---|
+| 1 | `fetch` → `express` → `/exact/stellar` | [`b6712023…3ca4`](https://stellar.expert/explorer/testnet/tx/b6712023355eaae20636da32a23909d0c74204ed0f6e46a6c6a10c06f4223ca4) | 4561546 |
+| 2 | `axios` → `express` → `/exact/stellar/upfront` | [`55c3026d…132b`](https://stellar.expert/explorer/testnet/tx/55c3026db406de06d3e24e93ec3a3c57f87ac10bd9bbbc10ab60cb78fc79132b) | 4561549 |
+| 5 | `fetch` → `hono` → `/exact/stellar/upfront` | [`ed32fe90…c670`](https://stellar.expert/explorer/testnet/tx/ed32fe90f4bb2d882919601f5b8706da6cf8420a9f91ee3f765223a9a6c8c670) | 4561559 |
+| 6 | `axios` → `hono` → `/exact/stellar` | [`555d7538…a733`](https://stellar.expert/explorer/testnet/tx/555d7538c0c81e590a2a32a1c9039bea412dcca23d72baae82711b38856fa733) | 4561562 |
+| 7 | `fetch` → `fastify` → `/exact/stellar/upfront` | [`22b97394…61c3`](https://stellar.expert/explorer/testnet/tx/22b97394a8bd99eeacf113cad9d13e390dd8b664cb163be9982e868ffed361c3) | 4561568 |
+| 8 | `axios` → `fastify` → `/exact/stellar` | [`b401ff7b…8a4a`](https://stellar.expert/explorer/testnet/tx/b401ff7bc5c6c5774781588b4f16c2f4a4dff5ae235fa63c7129024d1eeb8a4a) | 4561571 |
+
+All six charged `fee_charged: 23059` stroops to the sponsor, in consecutive
+ledgers 4561546–4561571.
+
+**The exact boundary of this claim:** testnet only, `exact` scheme only, over
+`express` / `hono` / `fastify` with the `fetch` and `axios` clients. It does
+**not** extend to pubnet (§6.2), to the `upto` scheme (which the upstream
+Stellar catalog does not declare), or to the MCP transport (below).
+
+#### C4 — a passing run of the e2e suite for both networks — ⚠️ **partial**
+
+```
+✅ Passed: 6    ❌ Failed: 4    📈 Total: 10    ⏱️ 3.25 min
+
+Breakdown by server:
+  typescript/http/express  ✅ 2 / ❌ 0 (100%)
+  typescript/http/hono     ✅ 2 / ❌ 0 (100%)
+  typescript/http/fastify  ✅ 2 / ❌ 0 (100%)
+  typescript/http/next     ✅ 0 / ❌ 2 (0%)
+  typescript/mcp           ✅ 0 / ❌ 2 (0%)
+```
+
+C4 is **not** claimed as satisfied, for two independent reasons:
+
+1. **Four of ten scenarios never executed.** Tests 3, 4, 9 and 10 failed with
+   `Error: Server failed to start` — `typescript/http/next` and
+   `typescript/mcp` exit non-zero during startup. No payment was attempted and
+   **no request reached the facilitator** on those four.
+2. **The pubnet half was not run.** There is no pubnet deployment (§6.2), so
+   the mainnet side of "both networks" remains unrun and unclaimed.
+
+**Why the four failures are not attributable to this facilitator — with a
+control.** The suite was first run against its own bundled reference
+facilitator (`--facilitators=typescript`) as a negative control, on the same
+machine, with the same accounts, in the same session. That baseline produced
+the **identical** failure set: 6 passed, 4 failed, same two servers, same
+`Server failed to start` error. A component that fails the same way against
+the upstream reference implementation is an environment/upstream build problem,
+not a Vellar defect. The `next` failure in particular matches the Next.js build
+issue already recorded upstream.
+
+This is stated as a control result rather than an assertion precisely because
+"our thing failed but it isn't our fault" is the kind of claim that needs
+evidence rather than confidence.
+
+#### Reproducing this run
+
+The proxy configuration used to target the hosted facilitator as an *external*
+facilitator is committed in this repo at
+[`e2e/facilitators/vellar/`](../e2e/facilitators/vellar/), with step-by-step
+instructions in its `README.md`. Copy that directory into a clone of
+`x402-foundation/x402` at `e2e/facilitators/external-proxies/local/vellar/`
+and follow the README.
+
+#### Corrections to the previous version of this section
+
+The previous revision of §6.1 described a reproduction path that had never been
+executed. Attempting it surfaced four errors, recorded here rather than quietly
+fixed, because a set of instructions that has not been run is a claim and not
+evidence:
+
+1. **`FACILITATOR_URL` alone does not point the suite at an external
+   facilitator.** The previous text said the live URL "can be used directly
+   without writing a proxy." It cannot. `FACILITATOR_URL` tells the *resource
+   server* which facilitator to call; it does not change which facilitator the
+   harness starts. A first run with it set still launched the bundled
+   `typescript` facilitator on port 4027 and tested against that. Per
+   `e2e/facilitators/external-proxies/README.md`, external facilitators live in
+   a proxy directory with a `test.config.json`, are "not selected by default",
+   and "require explicit selection" via `--facilitators=<name>`. **Following the
+   old instructions verbatim would have produced a green run that never
+   contacted this facilitator** — a passing result that proved nothing. That is
+   the failure mode `closing-state.md` §3.2 names, reached through a
+   documentation error rather than a code one.
+2. **`scripts/ci-select-families.ts` does not read `e2e/.env`.** It reads
+   `process.env` only. The previous section quoted its "No protocol families
+   have all required wallet secrets configured" output as empirical proof that
+   the wallets were missing. That output was reproduced here with all three keys
+   correctly present in `e2e/.env`; it resolved to `stellar` only after the
+   variables were `export`ed. The message distinguishes "not exported" from "not
+   available" not at all. The earlier conclusion happened to be true, but this
+   check could not have established it.
+3. **`pnpm install:all` inside `e2e/` is not sufficient.** The e2e workspace
+   references `../typescript/packages/*`, and those packages need their own
+   `pnpm install && pnpm build` in the parent `typescript/` directory first.
+   Without it `@x402/express` does not resolve. `setup.sh` skips them because
+   they carry no `install.sh`, `go.mod` or `pyproject.toml`.
+4. **`pnpm build` in `typescript/` does not complete on a normal machine.**
+   `@x402/evm` exhausts the JS heap (`ERR_WORKER_OUT_OF_MEMORY`) and aborts the
+   turbo run before `@x402/stellar` is compiled. Turbo reported "18 successful,
+   20 total" while every `dist/` directory was empty — tasks counted, nothing
+   emitted. Build the needed subgraph instead:
+   `npx turbo run build --filter=@x402/stellar...`, optionally with
+   `NODE_OPTIONS=--max-old-space-size=8192`.
 
 ### 6.2 No pubnet (mainnet) deployment — C1, C4, C5 ⛔
 

--- a/e2e/facilitators/vellar/README.md
+++ b/e2e/facilitators/vellar/README.md
@@ -1,0 +1,155 @@
+# Running the x402-foundation e2e suite against the live Vellar facilitator
+
+This directory is the proxy configuration used to produce the C1 result in
+[`docs/conformance-report.md`](../../../docs/conformance-report.md) §6.1. It
+exists so a reviewer can recreate that run exactly rather than take the report's
+word for it.
+
+**Result being reproduced:** 6 passed / 4 failed, six settled testnet
+transactions confirmed on Horizon, against `x402-foundation/x402` HEAD
+`241df66` on 2026-09-08.
+
+---
+
+## Why a proxy is needed at all
+
+The e2e suite starts each facilitator as a **local process on a port it
+assigns**, then points the resource server at it. There is no flag that says
+"call this URL instead". Setting `FACILITATOR_URL` does **not** do it —
+that variable tells the *resource server* which facilitator to call, and the
+harness will still have started its own bundled one.
+
+Per the suite's own `e2e/facilitators/external-proxies/README.md`, external
+facilitators must live in a proxy directory carrying a `test.config.json`, are
+"not selected by default", and "require explicit selection". `index.ts` here is
+a transparent relay: it adds no behaviour, so the suite measures the deployed
+service.
+
+> If you skip this step and simply export `FACILITATOR_URL`, the suite will run
+> green **against its own bundled reference facilitator** and tell you nothing
+> about Vellar. That is a false pass, and it is the specific trap this README
+> exists to prevent.
+
+---
+
+## Prerequisites
+
+Three funded Stellar testnet accounts. Client and server need a **USDC
+trustline**; the client needs **testnet USDC**; the facilitator account needs
+XLM only.
+
+1. Generate three keypairs and fund each with
+   [Friendbot](https://friendbot.stellar.org/?addr=PUBLIC_KEY).
+2. Add a USDC trustline to the **client** and **server** accounts.
+   Testnet USDC issuer: `GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5`
+3. Fund the **client** with testnet USDC from
+   [faucet.circle.com](https://faucet.circle.com) (select Stellar testnet).
+   The routes cost `$0.001` each, so a minimal drip is ample.
+
+## Setup
+
+```bash
+git clone --depth 1 https://github.com/x402-foundation/x402
+cd x402
+
+# 1. Build the workspace packages the e2e suite depends on.
+#    NOTE: plain `pnpm build` does NOT work — @x402/evm exhausts the JS heap
+#    (ERR_WORKER_OUT_OF_MEMORY) and aborts turbo before @x402/stellar compiles,
+#    while still reporting tasks as "successful" with empty dist/ directories.
+cd typescript
+pnpm install
+NODE_OPTIONS=--max-old-space-size=8192 npx turbo run build --filter=@x402/stellar...
+cd ..
+
+# 2. Install the e2e workspace.
+cd e2e
+pnpm install
+
+# 3. Install this proxy.
+mkdir -p facilitators/external-proxies/local
+cp -r /path/to/vellar-facilitator/e2e/facilitators/vellar \
+      facilitators/external-proxies/local/vellar
+```
+
+## Credentials
+
+```bash
+cd e2e
+cat > .env <<'EOF'
+SERVER_STELLAR_ADDRESS=G...            # server public key
+CLIENT_STELLAR_PRIVATE_KEY=S...        # client secret (holds USDC)
+FACILITATOR_STELLAR_PRIVATE_KEY=S...   # facilitator secret (XLM only)
+EOF
+chmod 600 .env
+
+# The suite's own gate reads process.env and does NOT load .env itself,
+# so the variables must be exported:
+set -a; . ./.env; set +a
+
+npx tsx scripts/ci-select-families.ts   # must print: stellar
+```
+
+If that prints `No protocol families have all required wallet secrets
+configured`, the variables are not **exported** — it does not mean they are
+missing from `.env`.
+
+## Run
+
+```bash
+cd e2e
+set -a; . ./.env; set +a
+pnpm test --testnet --min --families=stellar --versions=2 --facilitators=vellar
+```
+
+To point at a different deployment, export `VELLAR_FACILITATOR_URL`.
+
+## What a correct result looks like
+
+```
+🏛️ Starting facilitator: vellar on port 4027
+✅ Passed: 6    ❌ Failed: 4    📈 Total: 10
+```
+
+Confirm each reported hash independently rather than trusting the summary:
+
+```bash
+curl -s https://horizon-testnet.stellar.org/transactions/<HASH> \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);print(d['successful'],d['ledger'],d['fee_account'])"
+```
+
+`fee_account` should be the facilitator's sponsor
+(`GBUCR6H22CZC5OYHBJIEUS2JFZBOB63AHEGTCV6UEPMD2TMLKG2ZMIW4`) and **not** the
+payer — that difference is the on-chain evidence for `areFeesSponsored: true`.
+
+## The four scenarios that do not execute — and why they are not Vellar's fault
+
+Tests 3, 4, 9 and 10 fail with `Error: Server failed to start`:
+
+| # | Server | Cause |
+|---|---|---|
+| 3, 4 | `typescript/http/next` | Next.js server exits 1 during startup |
+| 9, 10 | `typescript/mcp` | MCP server exits 1 during startup |
+
+**No payment is attempted and no request reaches the facilitator** on these
+four — the harness never gets far enough to make one.
+
+Verify the attribution yourself rather than accepting it. Run the same command
+against the suite's bundled reference facilitator:
+
+```bash
+pnpm test --testnet --min --families=stellar --versions=2 --facilitators=typescript
+```
+
+That control produces the **identical** failure set — 6 passed, 4 failed, the
+same two servers, the same error. A component that fails the same way against
+the upstream reference implementation is an upstream/environment build problem,
+not a property of the facilitator under test.
+
+## Scope of what this proves
+
+- ✅ testnet, `exact` scheme, `express` / `hono` / `fastify` servers, `fetch`
+  and `axios` clients.
+- ❌ **not** pubnet — no pubnet deployment exists
+  ([`docs/conformance-report.md`](../../../docs/conformance-report.md) §6.2).
+- ❌ **not** the MCP transport, and **not** the `upto` scheme — the upstream
+  Stellar catalog declares neither.

--- a/e2e/facilitators/vellar/index.ts
+++ b/e2e/facilitators/vellar/index.ts
@@ -1,0 +1,41 @@
+/**
+ * External-facilitator proxy for the x402-foundation e2e suite.
+ *
+ * The suite starts every facilitator as a local process listening on a port it
+ * assigns. To exercise a HOSTED facilitator instead, it needs something local
+ * to start that forwards to the real service — hence this file. It adds no
+ * behaviour: every request is relayed unchanged, so what the suite measures is
+ * the deployed facilitator, not this shim.
+ *
+ * Target defaults to the live deployment; override with VELLAR_FACILITATOR_URL.
+ */
+import { createServer } from 'node:http';
+
+const TARGET = (
+  process.env.VELLAR_FACILITATOR_URL ?? 'https://vellar-facilitator.onrender.com'
+).replace(/\/$/, '');
+const PORT = Number(process.env.PORT ?? 4030);
+
+createServer(async (req, res) => {
+  const chunks: Buffer[] = [];
+  for await (const c of req) chunks.push(c as Buffer);
+  const body = Buffer.concat(chunks);
+
+  try {
+    const upstream = await fetch(TARGET + (req.url ?? '/'), {
+      method: req.method,
+      headers: { 'content-type': req.headers['content-type'] ?? 'application/json' },
+      body: ['GET', 'HEAD'].includes(req.method ?? 'GET') ? undefined : body,
+    });
+    const text = await upstream.text();
+    res.writeHead(upstream.status, {
+      'content-type': upstream.headers.get('content-type') ?? 'application/json',
+    });
+    res.end(text);
+  } catch (err) {
+    // A 502 here means the hosted service was unreachable — distinguishable
+    // from a facilitator-level refusal, which arrives as a real status code.
+    res.writeHead(502, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ error: 'proxy_upstream_failure', detail: String(err) }));
+  }
+}).listen(PORT, () => console.log(`vellar proxy -> ${TARGET} on :${PORT}`));

--- a/e2e/facilitators/vellar/package.json
+++ b/e2e/facilitators/vellar/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@x402/e2e-facilitator-vellar",
+  "private": true,
+  "type": "module",
+  "scripts": { "start": "tsx index.ts" }
+}

--- a/e2e/facilitators/vellar/test.config.json
+++ b/e2e/facilitators/vellar/test.config.json
@@ -1,0 +1,13 @@
+{
+  "name": "vellar",
+  "type": "facilitator",
+  "language": "typescript",
+  "protocolFamilies": ["stellar"],
+  "x402Versions": [2],
+  "schemes": ["exact"],
+  "extensions": ["bazaar"],
+  "environment": {
+    "required": [],
+    "optional": ["VELLAR_FACILITATOR_URL"]
+  }
+}


### PR DESCRIPTION
## What this does

Runs the x402-foundation e2e suite against the live Vellar facilitator and updates the conformance report.

## C1 — ✅ testnet

Six settled transactions confirmed on Horizon via the unmodified canonical x402 client suite. `fee_account` = Vellar sponsor on every one — `areFeesSponsored: true` proven on-chain.

| # | Route | Tx | Ledger |
|---|---|---|---|
| 1 | fetch → express → /exact/stellar | `b6712023` | 4561546 |
| 2 | axios → express → /exact/stellar/upfront | `55c3026d` | 4561549 |
| 3 | fetch → hono → /exact/stellar/upfront | `ed32fe90` | 4561559 |
| 4 | axios → hono → /exact/stellar | `555d7538` | 4561562 |
| 5 | fetch → fastify → /exact/stellar/upfront | `22b97394` | 4561568 |
| 6 | axios → fastify → /exact/stellar | `b401ff7b` | 4561571 |

Suite version: `x402-foundation/x402` HEAD `241df66` (updated from the stale `626df07` citation).

## C4 — ⚠️ partial

6 of 10 scenarios passed. 4 never executed (`typescript/http/next` and `typescript/mcp` fail to start in both the Vellar run and the upstream baseline — attributable to the suite environment, not the facilitator). Pubnet unrun — no pubnet deployment exists.

The baseline control run against the suite's own bundled reference facilitator produced the identical failure set, which is what makes the attribution evidence rather than assertion.

## e2e/facilitators/vellar/

Proxy + README required to target Vellar as an external facilitator. `FACILITATOR_URL` alone does not work and produces a false pass against the reference facilitator. The README calls this out explicitly.

## Four corrections to §6.1 documentation

1. `FACILITATOR_URL` targeting — does not redirect the harness; needs a proxy dir + `--facilitators=<name>`
2. `ci-select-families.ts` reads `process.env`, never loads `e2e/.env`
3. Monorepo install order — parent `typescript/` needs its own install and build
4. `@x402/evm` OOMs on plain `pnpm build` before `@x402/stellar` compiles

## Note on branching

Originally committed on `fix/settle-probe-channel-keys`, but the pre-push hook correctly refused: that branch's PR (#84) is already merged, so commits pushed there would belong to no PR. Cherry-picked onto a fresh branch off `origin/main` per the hook's guidance. `6b7932c` (settle-probe CI fix) is already on `main` via #84.