### PR TITLE
fix: resolve fast-uri and qs vulnerabilities

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -742,9 +742,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -1311,9 +1311,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -15,5 +15,11 @@
     "@x402/stellar": "^2.20.0",
     "express": "^5.2.1",
     "passkey-kit-sdk": "^0.8.0"
+  },
+  "overrides": {
+    "ajv": {
+      "fast-uri": "^3.1.7"
+    },
+    "qs": "^6.16.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2550,9 +2550,9 @@
       }
     },
     "node_modules/fast-json-stringify/node_modules/fast-uri": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+      "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
       "funding": [
         {
           "type": "github",
@@ -2575,9 +2575,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -3573,9 +3573,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,17 @@
     "tsx": "^4.20.0",
     "typescript": "^5.9.2",
     "vitest": "^3.2.7"
+  },
+  "overrides": {
+    "ajv": {
+      "fast-uri": "^3.1.7"
+    },
+    "@fastify/ajv-compiler": {
+      "fast-uri": "^3.1.7"
+    },
+    "fast-json-stringify": {
+      "fast-uri": "^4.1.4"
+    },
+    "qs": "^6.16.0"
   }
 }


### PR DESCRIPTION
Closes 18 of 22 Dependabot alerts (16 high `fast-uri`, 2 moderate `qs`, across root and `examples/`).

## Fixed

**`fast-uri`** → 3.1.7 / 4.1.4. Closes 4 high-severity SSRF/host-confusion advisories: GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp.

Overrides are **scoped per consumer** so each stays inside its own major (`ajv` and `@fastify/ajv-compiler` → `^3.1.7`; `fast-json-stringify` → `^4.1.4`) rather than forcing a cross-major bump.

**`qs`** → 6.16.0. Closes GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g.

Same fixes applied to `examples/`.

### Does this touch the ownership SSRF guards?

**No.** Two of the `fast-uri` advisories are SSRF-by-URL-parsing, which looks adjacent to RA-1/RA-2/RA-14 in `docs/security-audit.md` — but `verifyResourceOwnership` does **not** reach `fast-uri`. It parses with the WHATWG `URL` and fetches through `undici@8`, which declares zero dependencies. `fast-uri` is reached only via `ajv` / `@fastify/ajv-compiler` / `fast-json-stringify` — Fastify inbound request validation and response serialization. Different layer.

## Held back — `fastify` at 5.11.0

`fastify` 5.12.x **breaks the D4 rate-limit control.** `src/hardening.test.ts > Fix 2 — rate limiting > partitions the rate limit by X-Forwarded-For, not the proxy IP (D4)` fails on 5.12.3 and passes on 5.11.0.

Measured rather than inferred — `req.ip` under `trustProxy: 1`:

| fastify | client 203.0.113.1 | client 203.0.113.9 |
|---|---|---|
| 5.11.0 | `203.0.113.1` | `203.0.113.9` ✅ partitioned |
| 5.12.3 | `10.0.0.1` | `10.0.0.1` ❌ shared bucket |

The advisory fix (GHSA-3m5p-2c4r-xxw2) changed hop-count trustProxy resolution, so every client behind Render's proxy now shares one rate-limit bucket — the exact D4 failure the control exists to prevent.

`trustProxy: true` is **not** the fix: it takes the attacker-controlled leftmost XFF entry, allowing unlimited bucket minting (see `src/server.ts:122-128`). Both settings are wrong under 5.12.x.

Proper fix needs an explicit `keyGenerator` reading the rightmost-untrusted XFF entry — tracked separately, since that is security-relevant new code touching a closed audit finding, not a dependency bump.

The failing test was **not** modified or skipped. It caught a real regression, which is what closed-by-test is for.

## Skipped — Rust contracts

`stellar-xdr` MEDIUM (25.0.0 → 25.0.1) and `soroban-env-host` LOW (major 25 → 26) in `contracts/upto-stellar/` and `contracts/bond-escrow/`.

`upto-stellar` is vendored at a pinned commit with a reproducible-build hash published in `docs/upto-deployment.md` and verified against the deployed contract. Rebuilding to fix a LOW and a MEDIUM invalidates that provenance claim. Deferred to a planned contract upgrade cycle.

## Verification

```
npm test    → 613 passed | 4 skipped | 0 failed
npm audit   → root: 1 finding (fastify, 2 advisories)
              examples: 0 vulnerabilities
```

**Remaining: 4 Dependabot alerts** — 2 fastify moderate, 2 Rust contract. All documented above.