### PR TITLE
feat(search): hybrid lexical + vector search fused with RRF

### DIFF
--- a/docs/search-eval.md
+++ b/docs/search-eval.md
@@ -47,26 +47,118 @@ tests rather than by this table:
   unproven one earns its place with a settlement. It stays fully findable by any
   directed query.
 
+## The semantic set
+
+Ten queries that share **no token** with any catalog entry. They exist to
+measure the gap the lexical eval above cannot see: the table above is 10/10
+precisely because every one of its queries has a synonym mapping or a stem that
+reaches the target, and a query with neither returns an empty list rather than a
+weak ranking.
+
+| Query | Expected top result |
+| --- | --- |
+| `barcode for a link` | `/qr` |
+| `change color format` | `/color` |
+| `render documentation` | `/markdown` |
+| `what changed between versions` | `/diff` |
+| `find pattern in string` | `/regex` |
+| `filler text for design` | `/lorem` |
+| `parse spreadsheet data` | `/csv` |
+| `secure login credential` | `/password` |
+| `when does this job run` | `/cron` |
+| `imperial to metric` | `/units` |
+
+## Methodology
+
+Two rank-aware metrics, both over a single relevant document per query, both
+computed by the harness against the **real scorer** rather than by hand.
+
+**MRR (Mean Reciprocal Rank).** For each query, find the rank of the expected
+result in the returned list (1-based). Score `1/rank`, or `0` if it is absent
+entirely. Average across the query set. MRR answers "how far down the list does
+the user have to read", and it rewards moving a result from rank 3 to rank 1
+(0.33 to 1.0) far more than from rank 30 to rank 10.
+
+**NDCG@3 (Normalised Discounted Cumulative Gain, cut off at 3).** For each
+query, `DCG = 1/log2(rank + 1)` when the expected result appears in the top 3,
+else `0`. With exactly one relevant document the ideal ranking puts it first, so
+`IDCG = 1/log2(2) = 1` and NDCG is just the DCG. Average across the set. The
+cutoff at 3 is the point: an agent calling `/discovery/search` acts on the first
+few results, so a correct answer at rank 8 is worth approximately nothing, and
+NDCG@3 scores it as such while MRR still gives it 0.125.
+
+The two are reported together because they disagree usefully. MRR rewards deep
+recall; NDCG@3 measures whether the answer is actually *usable*. A change that
+improves MRR while leaving NDCG@3 flat has moved results up the list without
+getting them onto the first screen.
+
+## Baseline vs hybrid
+
+Measured against a 19-entry catalog on the same shape of data, with the same
+scorer, changing only whether `VOYAGE_API_KEY` is set.
+
+| Query set | Metric | Lexical (baseline) | Hybrid (RRF) |
+| --- | --- | --- | --- |
+| Original 10 | top-1 | 9/10 | see below |
+| Original 10 | MRR | 0.950 | see below |
+| Original 10 | NDCG@3 | 0.963 | see below |
+| Semantic 10 | top-1 | 2/10 | see below |
+| Semantic 10 | MRR | 0.264 | see below |
+| Semantic 10 | NDCG@3 | 0.263 | see below |
+
+**The semantic row is the whole point of the comparison.** Lexical search gets
+2/10 top-1 on queries that share no vocabulary with the catalog, and four of the
+ten (`secure login credential`, `when does this job run`, plus two others) return
+results that do not contain the answer anywhere in the top 10. Two of the ten
+score by accident rather than by understanding: `change color format` hits
+`/color`'s tag `convert`, and `render documentation` hits `/markdown`'s tag
+`render`. The rest are misses, and several return a confidently wrong first
+result (`barcode for a link` returns `/weather`), which is worse for an agent
+than returning nothing.
+
+## Hybrid architecture
+
+Lexical search is **not replaced**. It scores 9/10 on the original set, and
+replacing it would risk regressing exactly the queries it already answers well.
+The vector ranking is fused alongside it with Reciprocal Rank Fusion:
+
+```
+rrf(d) = 1/(k + lexicalRank(d)) + 1/(k + vectorRank(d)),  k = 60
+```
+
+Ranks are 1-based, and a document missing from one list is given a penalty rank
+of `len(list) + 1` so a purely-semantic hit can still surface. RRF fuses *ranks*
+rather than *scores* deliberately: a lexical score is an unbounded sum of field
+weights while a cosine similarity is bounded and tightly clustered, so summing
+the two raw numbers would let whichever has the larger spread silently dominate.
+
+With `VOYAGE_API_KEY` unset the vector path is skipped entirely and results are
+byte-identical to the lexical baseline. That is also true for an empty query,
+which is ranked by trust rather than by text and has nothing meaningful to
+embed.
+
+**One honest caveat.** `search()` is synchronous, and a query's vector cannot be
+fetched without blocking. The first search for a novel query therefore returns
+the lexical ranking and warms the vector in the background; the next identical
+query is hybrid. The alternative was making `search()` async and paying a Voyage
+round trip on every request, which turns a vendor outage into a hung discovery
+endpoint instead of a degraded ranking. The numbers above are measured with the
+query cache warm.
+
 ## How to run it
 
 ```sh
 npm test
 ```
 
-The cases above are covered by `src/catalog.test.ts` → *"search quality —
+The lexical cases are covered by `src/catalog.test.ts` → *"search quality —
 synonyms, stemming, trust ranking"*. **A failing test there is a search-quality
 regression**, not a flaky test — each one carries the mutation that would break
 it, so the failure names its own cause.
 
-## What this is not
+Embeddings are backfilled separately, and the job is idempotent (entries that
+already carry a vector are not re-embedded):
 
-This is a **lexical** eval: synonyms and stemming, hand-tuned to one catalog. It
-is not semantic search, and passing 10/10 here does not mean the RFP's search
-requirement is met. A query using none of the mapped terms — "something to stop
-my agent replaying a request" — still returns nothing, because no token matches
-and no embedding exists to bridge the gap.
-
-Semantic ranking with embeddings, a vector index, and NDCG/MRR over a much
-larger query set remains item 3 on the pre-mainnet checklist
-(`technical-doc.md` §9). This table is the baseline that change will be measured
-against — the point of writing it down now is that the comparison exists later.
+```sh
+npm run backfill-embeddings
+```

--- a/docs/search-eval.md
+++ b/docs/search-eval.md
@@ -31,7 +31,11 @@ that something did.
 | `daily saying` | `/quote` | synonym: `saying` → `quote` |
 | `motivation` | `/quote` | direct match on tag + description |
 
-**Last measured: 10/10** on the implementation at the head of this branch.
+**Last measured: 10/10** on the implementation at the head of this branch,
+against the 8-endpoint demo catalog. The baseline table further down re-measures
+these same ten queries against a larger 19-entry corpus, where they score 9/10 —
+the difference is the corpus, not a regression: the extra entries introduce a
+competing match for `stellar balance`.
 
 ## Beyond top-1
 
@@ -50,7 +54,7 @@ tests rather than by this table:
 ## The semantic set
 
 Ten queries that share **no token** with any catalog entry. They exist to
-measure the gap the lexical eval above cannot see: the table above is 10/10
+measure the gap the lexical eval above cannot see: that table scores 9-10/10
 precisely because every one of its queries has a synonym mapping or a stem that
 reaches the target, and a query with neither returns an empty list rather than a
 weak ranking.
@@ -97,24 +101,46 @@ getting them onto the first screen.
 Measured against a 19-entry catalog on the same shape of data, with the same
 scorer, changing only whether `VOYAGE_API_KEY` is set.
 
-| Query set | Metric | Lexical (baseline) | Hybrid (RRF) |
-| --- | --- | --- | --- |
-| Original 10 | top-1 | 9/10 | see below |
-| Original 10 | MRR | 0.950 | see below |
-| Original 10 | NDCG@3 | 0.963 | see below |
-| Semantic 10 | top-1 | 2/10 | see below |
-| Semantic 10 | MRR | 0.264 | see below |
-| Semantic 10 | NDCG@3 | 0.263 | see below |
+| Query set | Metric | Lexical (baseline) | Hybrid (RRF) | Change |
+| --- | --- | --- | --- | --- |
+| Original 10 | top-1 | 9/10 | 9/10 | unchanged |
+| Original 10 | MRR | 0.950 | 0.950 | unchanged |
+| Original 10 | NDCG@3 | 0.963 | 0.963 | unchanged |
+| Semantic 10 | top-1 | 2/10 | **5/10** | +3 |
+| Semantic 10 | MRR | 0.264 | **0.717** | +0.453 |
+| Semantic 10 | NDCG@3 | 0.263 | **0.789** | +0.526 |
 
-**The semantic row is the whole point of the comparison.** Lexical search gets
+**The original set does not move, and that is the first thing to check.** The
+whole risk of adding a second ranking signal is that it degrades the queries the
+first one already answers. It does not: all three metrics are identical to the
+baseline, and the one query that was not top-1 before (`stellar balance`, which
+ranks `/stroops` above `/inspect`) is not top-1 after either. RRF's flat top
+(k=60) is what buys this, and the fusion is only consulted at all when a query
+vector is available.
+
+**The semantic set is the whole point of the comparison.** Lexical search gets
 2/10 top-1 on queries that share no vocabulary with the catalog, and four of the
-ten (`secure login credential`, `when does this job run`, plus two others) return
-results that do not contain the answer anywhere in the top 10. Two of the ten
-score by accident rather than by understanding: `change color format` hits
-`/color`'s tag `convert`, and `render documentation` hits `/markdown`'s tag
-`render`. The rest are misses, and several return a confidently wrong first
-result (`barcode for a link` returns `/weather`), which is worse for an agent
-than returning nothing.
+ten (`secure login credential`, `when does this job run`, `filler text for
+design`, `imperial to metric`) return results that do not contain the answer
+anywhere in the top 10 — an empty or wrong list, not a weak ranking. The two it
+does get are accidents of vocabulary rather than understanding: `change color
+format` hits `/color`'s tag `convert`, and `render documentation` hits
+`/markdown`'s tag `render`. Several of the misses return a confidently wrong
+first result (`barcode for a link` returns `/weather`), which is worse for an
+agent than returning nothing.
+
+Under hybrid ranking **every one of the ten reaches the top 3**, which is why
+NDCG@3 roughly triples while top-1 only goes from 2 to 5. That gap between the
+two metrics is the honest read of this change: it reliably gets the right answer
+onto the first screen, and it does not yet reliably get it into first place.
+`find pattern in string` still puts `/cron` above `/regex`, and `parse
+spreadsheet data` still puts `/weather` above `/csv`. Closing that is a
+reranking problem, not a retrieval one.
+
+Caveat on the corpus: these were measured against a 19-entry catalog whose
+descriptions were authored for this eval. The relative movement is the
+meaningful part; the absolute numbers will shift as real endpoints are added,
+and the table should be re-measured when they are.
 
 ## Hybrid architecture
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "fastify": "^5.2.0",
         "prom-client": "^15.1.3",
         "undici": "^8.10.0",
+        "voyageai": "^0.4.0",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -3257,6 +3258,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4155,6 +4176,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tsx": {
       "version": "4.23.1",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
@@ -4521,6 +4548,46 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/voyageai": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/voyageai/-/voyageai-0.4.0.tgz",
+      "integrity": "sha512-RCWGknFqwbZORdRo7dHwBuZYeO64TnE+G30Qv4IGxq5jkMa2uK+eqMbOv/DhszcFUtE1iZjb4LqO9G/hj2EjxA==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@huggingface/transformers": "^3.8.0",
+        "onnxruntime-node": ">=1.17.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        },
+        "onnxruntime-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "tsx --env-file-if-exists=.env src/server.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "backfill-embeddings": "tsx --env-file-if-exists=.env src/backfill-embeddings.ts"
   },
   "dependencies": {
     "@fastify/cors": "^11.3.0",
@@ -19,12 +20,13 @@
     "@libsql/client": "^0.17.4",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@stellar/stellar-sdk": "^16.0.1",
-    "prom-client": "^15.1.3",
     "@x402/core": "^2.20.0",
     "@x402/extensions": "^2.20.0",
     "@x402/stellar": "^2.20.0",
     "fastify": "^5.2.0",
+    "prom-client": "^15.1.3",
     "undici": "^8.10.0",
+    "voyageai": "^0.4.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/backfill-embeddings.ts
+++ b/src/backfill-embeddings.ts
@@ -1,0 +1,200 @@
+// One-shot backfill: embed every catalog entry that has no vector yet.
+//
+// WHY A SCRIPT AND NOT A BOOT STEP. Embedding the whole catalog is a paid API
+// call per entry and takes as long as it takes. Doing it at boot would put an
+// unbounded external dependency in front of the server accepting traffic, for a
+// feature that is additive to a lexical ranking that already works. So it is
+// run deliberately, and it is idempotent: entries that already carry a vector
+// are not selected, so re-running it after a partial failure costs only the
+// entries that actually still need one.
+//
+// Safe to run against production while the server is live. Every write is an
+// UPDATE of a single nullable column that nothing reads synchronously; a
+// running server picks the vectors up on its next restart.
+
+import { LibsqlCatalogStore } from "./store.js";
+import { buildEmbeddingText, embeddingsEnabled, embedTexts } from "./embeddings.js";
+
+/** Voyage allows 128 inputs per request; 10 keeps each request small enough
+ *  that one failure re-costs almost nothing, and keeps the progress log
+ *  meaningful on a catalog of a few dozen entries. */
+const BATCH_SIZE = 10;
+
+/**
+ * The stored payload is a StoredEntry as JSON — the same bytes the catalog
+ * re-validates on load. Only the four fields the embedding text is built from
+ * are pulled out here, and each is checked rather than asserted: this is the F6
+ * trust boundary, and a row someone else wrote gets the treatment a wire
+ * payload gets even though all we do with it is build a string.
+ */
+function resourceFromPayload(payload: string):
+  | { resource: string; serviceName?: string; description?: string; tags?: string[] }
+  | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) return undefined;
+  const outer = parsed as Record<string, unknown>;
+  // Entries are stored either as a bare DiscoveryResource or wrapped in a
+  // StoredEntry with the resource under `resource`. Both shapes are in the
+  // database, so both are handled rather than guessed at.
+  const inner =
+    typeof outer.resource === "object" && outer.resource !== null
+      ? (outer.resource as Record<string, unknown>)
+      : outer;
+  const url = inner.resource;
+  if (typeof url !== "string" || url.length === 0) return undefined;
+  const tags = Array.isArray(inner.tags)
+    ? inner.tags.filter((t): t is string => typeof t === "string")
+    : undefined;
+  return {
+    resource: url,
+    ...(typeof inner.serviceName === "string" ? { serviceName: inner.serviceName } : {}),
+    ...(typeof inner.description === "string" ? { description: inner.description } : {}),
+    ...(tags && tags.length > 0 ? { tags } : {}),
+  };
+}
+
+/**
+ * Retry a batch through a 429.
+ *
+ * MEASURED, NOT ANTICIPATED: a Voyage account without a payment method is
+ * limited to 3 requests per minute, and a first run of this script against 19
+ * entries hit it on the second batch. Without this the operator's recourse is
+ * to keep re-running the script until it happens to fit inside the window,
+ * which the idempotence makes safe but tedious and easy to mistake for a
+ * permanent failure.
+ *
+ * Only 429 is retried. A 401 is a bad key, a 400 is a bad request, and both
+ * return the same answer on the second attempt — the same reasoning
+ * classifyStoreError() applies in store.ts, which retries the transient class
+ * and fails fast on the deterministic one.
+ */
+async function withRateLimitRetry<T>(fn: () => Promise<T>): Promise<T> {
+  // ~21s covers the 3 RPM window with margin. Four attempts is a little over a
+  // minute per batch, which is slow but finishes.
+  const backoffMs = [21_000, 21_000, 42_000];
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      const message = String((err as Error)?.message ?? err);
+      const rateLimited = message.includes("429");
+      const wait = backoffMs[attempt];
+      if (!rateLimited || wait === undefined) throw err;
+      console.warn(`[backfill] rate limited, waiting ${wait / 1000}s before retrying`);
+      await new Promise((resolve) => setTimeout(resolve, wait));
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  if (!embeddingsEnabled()) {
+    console.error(
+      "[backfill] VOYAGE_API_KEY is not set. Set it in .env (the key itself is never logged) and re-run.",
+    );
+    process.exit(1);
+  }
+
+  // CATALOG_DB_URL / CATALOG_DB_AUTH_TOKEN are read DIRECTLY rather than through
+  // loadConfig(), and that is a deliberate departure from how server.ts builds
+  // the same store.
+  //
+  // loadConfig() validates the whole SETTLEMENT config: it throws unless
+  // SPONSOR_SECRET_KEY and fifty funded CHANNEL_ACCOUNT_SECRET_KEYS are present,
+  // because a facilitator that cannot settle should not boot. None of that is
+  // true of a backfill. Routing this through loadConfig() would mean an operator
+  // needs PRODUCTION SIGNING KEYS in their environment to run a read-mostly
+  // catalog maintenance job — handing out settlement credentials for a task that
+  // only ever writes one nullable text column. The narrower dependency is the
+  // safer one, and it is the same two variables server.ts ultimately passes.
+  const catalogDbUrl = process.env.CATALOG_DB_URL;
+  const catalogDbAuthToken = process.env.CATALOG_DB_AUTH_TOKEN;
+  if (!catalogDbUrl) {
+    console.error(
+      "[backfill] CATALOG_DB_URL is not set — there is no durable catalog to backfill. " +
+        "An in-memory catalog has nothing to write to.",
+    );
+    process.exit(1);
+  }
+
+  const store = new LibsqlCatalogStore(catalogDbUrl, catalogDbAuthToken);
+  // init() FIRST: it is what runs the `entry.embedding` migration. Without it a
+  // database that predates semantic search has no such column and every query
+  // below fails with a diagnosis that points at the wrong thing.
+  await store.init();
+
+  try {
+    const pending = await store.getEntriesWithoutEmbeddings();
+    console.log(`[backfill] ${pending.length} entries without embeddings`);
+    if (pending.length === 0) return;
+
+    let embedded = 0;
+    let skipped = 0;
+    let failed = 0;
+
+    for (let i = 0; i < pending.length; i += BATCH_SIZE) {
+      const batch = pending.slice(i, i + BATCH_SIZE);
+      // Rows whose payload will not yield a resource url are dropped BEFORE the
+      // API call, not after: they would otherwise misalign the response array
+      // against the batch and attach one entry's vector to another's key.
+      const usable: Array<{
+        key: string;
+        resource: NonNullable<ReturnType<typeof resourceFromPayload>>;
+      }> = [];
+      for (const row of batch) {
+        const resource = resourceFromPayload(row.payload);
+        if (resource) {
+          usable.push({ key: row.resource_key, resource });
+        } else {
+          skipped++;
+          console.warn(`[backfill] skipping ${row.resource_key}: payload has no usable resource url`);
+        }
+      }
+      if (usable.length === 0) continue;
+
+      try {
+        const vectors = await withRateLimitRetry(() =>
+          embedTexts(usable.map((u) => buildEmbeddingText(u.resource))),
+        );
+        // Written one at a time rather than as a batch so a single failing row
+        // does not cost the other nine their vectors.
+        for (let j = 0; j < usable.length; j++) {
+          const vector = vectors[j];
+          const key = usable[j]!.key;
+          if (!vector) {
+            failed++;
+            continue;
+          }
+          await store.saveEmbedding(key, vector);
+          embedded++;
+        }
+        console.log(
+          `[backfill] ${Math.min(i + BATCH_SIZE, pending.length)}/${pending.length} processed`,
+        );
+      } catch (err) {
+        failed += usable.length;
+        console.error(
+          `[backfill] batch starting at ${i} failed (${String((err as Error)?.message ?? err)}) — ` +
+            `those entries keep no embedding and will be retried on the next run`,
+        );
+      }
+    }
+
+    console.log(`[backfill] done: ${embedded} embedded, ${skipped} skipped, ${failed} failed`);
+    // A non-zero exit on failure so a CI or cron invocation notices. Skipped
+    // rows are not a failure: they are entries whose payload genuinely carries
+    // nothing to embed.
+    if (failed > 0) process.exitCode = 1;
+  } finally {
+    await store.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(`[backfill] fatal: ${String((err as Error)?.message ?? err)}`);
+  process.exit(1);
+});

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -18,6 +18,13 @@ import type {
 import { isIP } from "node:net";
 import { isBlockedAddress } from "./ownership.js";
 import type { OwnershipVerdict } from "./ownership.js";
+import {
+  buildEmbeddingText,
+  cosineSimilarity,
+  embeddingsEnabled,
+  embedQuery,
+  embedTexts,
+} from "./embeddings.js";
 import type { TrustedDiscoveryResource } from "./trust.js";
 
 const DEFAULT_LIMIT = 20;
@@ -38,6 +45,11 @@ const MAX_ACCEPTS = 20;
 /** Max ownership tombstones. At this cap the catalog FREEZES new bindings
  * rather than forgetting ownership — see `frozen`. */
 const MAX_TOMBSTONES = 100_000;
+
+/** Distinct query vectors held in memory. Bounded because the key is
+ *  attacker-supplied text on a public endpoint — see the queryVectors field.
+ *  1024 floats is ~8KB, so this caps the cache at ~8MB. */
+const MAX_QUERY_VECTORS = 1_000;
 /** Longest string that can be a payTo identity. Shared by the catalog and the
  *  spend policy — see BazaarCatalog.canonicalPayTo. */
 export const MAX_PAYTO_LEN = 128;
@@ -605,6 +617,47 @@ export class BazaarCatalog {
    * once per settlement. */
   private readonly warnedUnverifiable = new Set<string>();
 
+  /**
+   * Document vectors, keyed by canonical resource key. Loaded once at boot and
+   * maintained by the fire-and-forget ingest writer.
+   *
+   * WHY IN MEMORY, AND WHY THIS DECIDES search()'s SIGNATURE.
+   *
+   * search() is synchronous and has 12 call sites in the test suite plus one in
+   * server.ts. The alternative was to make it async, which is cheap at the call
+   * sites (server.ts:797 is already an async handler) but expensive in a way
+   * that does not show up in a diff: it would put a NETWORK CALL TO VOYAGE on
+   * the request path of every search, with a vendor outage turning into a hung
+   * discovery endpoint rather than a degraded one.
+   *
+   * Holding the vectors in memory keeps the store out of the hot path entirely.
+   * 1024 floats x 8 bytes is 8KB per entry, so even at the MAX_ENTRIES cap this
+   * is single-digit megabytes, and it is the same order as the entries map
+   * already held beside it.
+   *
+   * That leaves exactly ONE thing that cannot be done synchronously: embedding
+   * the QUERY, which is by definition not known ahead of time. See
+   * searchHybrid() for how that is handled without changing search()'s
+   * signature.
+   */
+  private readonly embeddings = new Map<string, number[]>();
+
+  /**
+   * Query-vector cache, bounded, most-recent-wins. This is what lets the
+   * synchronous search() consult the vector ranking at all: a repeated query
+   * finds its vector already here, and a first-time query warms it in the
+   * background for next time.
+   *
+   * Bounded because it is keyed on ATTACKER-SUPPLIED text. An unbounded map
+   * keyed on the query string is a trivial memory-exhaustion vector: a few
+   * thousand distinct queries would pin megabytes each, and discovery is a
+   * public endpoint.
+   */
+  private readonly queryVectors = new Map<string, number[]>();
+  /** Queries whose embedding is being fetched, so N concurrent identical
+   *  searches make ONE API call rather than N. */
+  private readonly queryInFlight = new Set<string>();
+
   constructor(store?: CatalogStore) {
     this.store = store;
   }
@@ -712,6 +765,24 @@ export class BazaarCatalog {
       if (incomingVerified || existingVerified) catalog.everVerified.add(key);
     }
     await catalog.load(opts.maxEntries ?? MAX_ENTRIES);
+    // Document vectors, loaded ONCE into memory so search() can stay
+    // synchronous. Best-effort by construction: a store that cannot answer here
+    // leaves the map empty and the catalog runs lexical-only, which is a
+    // ranking-quality degradation and not a correctness one. It must not join
+    // ownership in freezing the catalog — semantic search is additive, and
+    // taking discovery down because a vector column would not read would be a
+    // far worse outcome than ranking without it.
+    try {
+      for (const row of (await store.loadEmbeddings()) ?? []) {
+        catalog.embeddings.set(row.resource_key, row.embedding);
+      }
+    } catch (err) {
+      console.warn(
+        `[catalog] embeddings could not be loaded (${String(
+          (err as Error)?.message ?? err,
+        )}) — search runs lexical-only until the next restart`,
+      );
+    }
     return catalog;
   }
 
@@ -1548,6 +1619,11 @@ export class BazaarCatalog {
     }
     this.evictToCap();
     this.save();
+    // Semantic index, updated out of band. AFTER evictToCap() so a resource
+    // that was just evicted is not embedded, and fire-and-forget so the
+    // settlement this call is part of never waits on, or fails because of, an
+    // embedding API.
+    this.embedEntryInBackground(key, candidate.resource);
     // Accepted — "cataloged: true" regardless of isFirstCatalog. A seller
     // reading EXTENSION-RESPONSES cares whether their resource IS in the
     // catalog now, not whether this particular settlement happened to be the
@@ -1639,15 +1715,20 @@ export class BazaarCatalog {
       if (decoded && decoded.k === filterKey) offset = decoded.o;
     }
 
-    const scored = this.filter(params)
+    // ── Lexical ranking. UNCHANGED, and deliberately computed in full even when
+    // the vector path is about to run. It scores 10/10 on docs/search-eval.md;
+    // the vector ranking is added ALONGSIDE it, never in place of it.
+    const lexical = this.filter(params)
       .map((entry) => ({ entry, score: scoreResource(entry.resource, tokens, entry.stats) }))
       .filter((s) => s.score > 0)
       .sort(
         (a, b) =>
           b.score - a.score ||
           b.entry.resource.lastUpdated.localeCompare(a.entry.resource.lastUpdated),
-      )
-      .map((s) => toItem(s.entry));
+      );
+
+    const fused = this.fuseWithVectorRanking(lexical, params);
+    const scored = fused.map((entry) => toItem(entry));
 
     const page = scored.slice(offset, offset + limit);
     const nextOffset = offset + page.length;
@@ -1662,6 +1743,176 @@ export class BazaarCatalog {
         cursor: hasMore ? encodeCursor({ o: nextOffset, k: filterKey }) : null,
       },
     };
+  }
+
+  /**
+   * Fuse the lexical ranking with a vector ranking, if one is available.
+   *
+   * RETURNS THE LEXICAL ORDER UNTOUCHED whenever semantic search cannot
+   * contribute, which is what makes the VOYAGE_API_KEY-unset path
+   * byte-identical to what shipped before. There are four such cases and each
+   * is a normal operating state, not an error:
+   *
+   *   1. no API key           — semantic search was never turned on
+   *   2. empty query          — scoreResource() ranks these by TRUST, not by
+   *                             text. There is no query to embed, and a vector
+   *                             ranking would replace a deliberate "proven
+   *                             endpoints first" ordering with a meaningless
+   *                             similarity to the empty string.
+   *   3. no document vectors  — the backfill has not run yet
+   *   4. query vector not yet cached — see below
+   *
+   * Case 4 is the interesting one, and it is the price of keeping search()
+   * synchronous. The FIRST search for a given query cannot embed it without
+   * blocking, so it returns the lexical ranking and warms the vector in the
+   * background; the next identical query is hybrid. The alternative was making
+   * search() async and paying a Voyage round trip on every request, including
+   * the ones lexical already answers perfectly.
+   *
+   * That tradeoff is honest about what it costs: a cold query is lexical-only.
+   * It is the right trade because the lexical path is not a degraded fallback
+   * here, it is a ranking that already scores 10/10 on the eval, and because
+   * the failure mode of the alternative is a hung endpoint rather than a
+   * slightly worse ordering.
+   */
+  private fuseWithVectorRanking(
+    lexical: Array<{ entry: StoredEntry; score: number }>,
+    params: SearchDiscoveryResourcesParams,
+  ): StoredEntry[] {
+    const query = params.query?.trim() ?? "";
+    if (!query || !embeddingsEnabled() || this.embeddings.size === 0) {
+      return lexical.map((s) => s.entry);
+    }
+
+    const queryVector = this.queryVectors.get(query);
+    if (!queryVector) {
+      this.warmQueryVector(query);
+      return lexical.map((s) => s.entry);
+    }
+
+    // The vector ranking runs over the SAME filtered candidate set as the
+    // lexical one, not over the whole catalog. Ranking outside the filter would
+    // let a semantic match on a resource the caller explicitly excluded (wrong
+    // network, wrong payTo) consume a slot in the fused list.
+    // Keys come from the entries map itself rather than being re-derived from
+    // the resource url. An MCP entry's key is COMPOUND (`url \0 toolName`), so
+    // re-deriving it here would mean reconstructing a key inline — the exact
+    // thing §3.7 forbids, and the thing that would silently miss every MCP
+    // entry's vector.
+    const keyOf = new Map<StoredEntry, string>();
+    for (const [key, entry] of this.entries) keyOf.set(entry, key);
+
+    const candidates = this.filter(params);
+    const vectorRanked = candidates
+      .map((entry) => {
+        const key = keyOf.get(entry);
+        const vector = key ? this.embeddings.get(key) : undefined;
+        return vector ? { entry, similarity: cosineSimilarity(queryVector, vector) } : undefined;
+      })
+      .filter((v): v is { entry: StoredEntry; similarity: number } => v !== undefined)
+      .sort((a, b) => b.similarity - a.similarity);
+
+    if (vectorRanked.length === 0) return lexical.map((s) => s.entry);
+
+    // 1-BASED ranks, because rrfScore()'s k is calibrated against 1-based ranks
+    // — a 0-based rank 0 would give the top hit 1/60 instead of 1/61, a
+    // different and undocumented weighting.
+    const lexicalRank = new Map<StoredEntry, number>();
+    lexical.forEach((s, i) => lexicalRank.set(s.entry, i + 1));
+    const vectorRank = new Map<StoredEntry, number>();
+    vectorRanked.forEach((v, i) => vectorRank.set(v.entry, i + 1));
+
+    // A resource present in one list and absent from the other gets a PENALTY
+    // RANK of (that list's length + 1): it is treated as ranking just past the
+    // end of the list it missed. This is what lets a purely semantic hit — zero
+    // lexical score, so absent from the lexical list entirely — still surface,
+    // which is the entire point of the feature. It also means a resource in
+    // both lists beats one in only a single list, all else equal.
+    const union = new Set<StoredEntry>([...lexicalRank.keys(), ...vectorRank.keys()]);
+    const lexicalMiss = lexical.length + 1;
+    const vectorMiss = vectorRanked.length + 1;
+
+    return [...union]
+      .map((entry) => ({
+        entry,
+        rrf: rrfScore(lexicalRank.get(entry) ?? lexicalMiss, vectorRank.get(entry) ?? vectorMiss),
+      }))
+      .sort(
+        (a, b) =>
+          b.rrf - a.rrf ||
+          // Same tiebreak as the lexical path, so fusion never introduces a
+          // nondeterministic ordering between two equally ranked resources.
+          b.entry.resource.lastUpdated.localeCompare(a.entry.resource.lastUpdated),
+      )
+      .map((r) => r.entry);
+  }
+
+  /**
+   * Fetch a query's vector in the background so the NEXT identical search can
+   * fuse. Fire-and-forget, matching the displacement/reverify pattern: a search
+   * must never fail, or slow down, because an embedding call did.
+   */
+  private warmQueryVector(query: string): void {
+    if (this.queryInFlight.has(query)) return;
+    this.queryInFlight.add(query);
+    void (async () => {
+      try {
+        const vector = await embedQuery(query);
+        // Bounded, oldest-out. Map preserves insertion order, so the first key
+        // is the least recently ADDED — good enough for a cache whose only job
+        // is to make repeated queries hybrid, and far cheaper than tracking
+        // true LRU access times.
+        if (this.queryVectors.size >= MAX_QUERY_VECTORS) {
+          const oldest = this.queryVectors.keys().next().value;
+          if (oldest !== undefined) this.queryVectors.delete(oldest);
+        }
+        this.queryVectors.set(query, vector);
+      } catch (err) {
+        console.warn(
+          `[catalog] could not embed query for semantic search (${String(
+            (err as Error)?.message ?? err,
+          )}) — this query stays lexical-only`,
+        );
+      } finally {
+        this.queryInFlight.delete(query);
+      }
+    })();
+  }
+
+  /**
+   * Embed one freshly cataloged resource and persist the vector.
+   *
+   * FIRE-AND-FORGET, and the caller must keep it that way. This runs after a
+   * SETTLEMENT has already succeeded: the payment is complete and the entry is
+   * cataloged before this is reached, so an embedding failure must be invisible
+   * to the payer. It is caught and warned, never rethrown, and never awaited on
+   * the settle path.
+   */
+  private embedEntryInBackground(key: string, resource: DiscoveryResource): void {
+    if (!embeddingsEnabled()) return;
+    void (async () => {
+      try {
+        const text = buildEmbeddingText({
+          resource: resource.resource,
+          serviceName: resource.serviceName,
+          description: resource.description,
+          tags: resource.tags,
+        });
+        const [vector] = await embedTexts([text]);
+        if (!vector) return;
+        this.embeddings.set(key, vector);
+        // Persisted so a restart does not have to re-embed the whole catalog.
+        // The store call is last: an in-memory vector is useful even if the
+        // write fails, and this process keeps serving hybrid results either way.
+        await this.store?.saveEmbedding(key, vector);
+      } catch (err) {
+        console.warn(
+          `[catalog] could not embed ${key} (${String(
+            (err as Error)?.message ?? err,
+          )}) — it stays searchable lexically and will be picked up by the next backfill`,
+        );
+      }
+    })();
   }
 
   private filter(
@@ -2219,6 +2470,32 @@ function scoreResource(
     }
   }
   return score;
+}
+
+/**
+ * Reciprocal Rank Fusion — combine a lexical ranking and a vector ranking into
+ * one ordering.
+ *
+ * RRF fuses RANKS, never SCORES, and that is the whole reason it is the right
+ * tool here. A lexical score is an unbounded sum of field weights (a strong
+ * match on a long description can reach 30+); a cosine similarity is bounded in
+ * [-1, 1] and, on this model, clusters tightly around 0.4-0.7 even for
+ * unrelated pairs. Adding or averaging those two numbers compares quantities
+ * with no common unit, and whichever one happens to have the larger spread
+ * silently becomes the only one that matters. Ranks are unitless, so neither
+ * side can dominate by accident, and no per-corpus score normalisation has to
+ * be tuned and re-tuned as the catalog grows.
+ *
+ * `k = 60` is the value from the original Cormack et al. paper and the de-facto
+ * default across search stacks. Its effect is to FLATTEN the top of each list:
+ * with k=60 the gap between rank 1 and rank 2 is small (1/61 vs 1/62), so a
+ * resource must rank well in BOTH lists to beat one that is second in both.
+ * That is exactly the behaviour wanted here, because the lexical list is the
+ * one already known to be good and a confident-but-wrong vector hit should not
+ * be able to displace it from a single first place.
+ */
+export function rrfScore(lexicalRank: number, vectorRank: number, k = 60): number {
+  return 1 / (k + lexicalRank) + 1 / (k + vectorRank);
 }
 
 function hashKey(params: SearchDiscoveryResourcesParams): string {

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1716,7 +1716,7 @@ export class BazaarCatalog {
     }
 
     // ── Lexical ranking. UNCHANGED, and deliberately computed in full even when
-    // the vector path is about to run. It scores 10/10 on docs/search-eval.md;
+    // the vector path is about to run. It scores 9-10/10 on docs/search-eval.md;
     // the vector ranking is added ALONGSIDE it, never in place of it.
     // Filtered ONCE and shared with the vector ranking below. Both rankings must
     // run over the same candidate set anyway (ranking outside the filter would
@@ -1776,7 +1776,7 @@ export class BazaarCatalog {
    *
    * That tradeoff is honest about what it costs: a cold query is lexical-only.
    * It is the right trade because the lexical path is not a degraded fallback
-   * here, it is a ranking that already scores 10/10 on the eval, and because
+   * here, it is a ranking that already scores 9-10/10 on the eval, and because
    * the failure mode of the alternative is a hung endpoint rather than a
    * slightly worse ordering.
    */

--- a/src/catalog.ts
+++ b/src/catalog.ts
@@ -1718,7 +1718,12 @@ export class BazaarCatalog {
     // ── Lexical ranking. UNCHANGED, and deliberately computed in full even when
     // the vector path is about to run. It scores 10/10 on docs/search-eval.md;
     // the vector ranking is added ALONGSIDE it, never in place of it.
-    const lexical = this.filter(params)
+    // Filtered ONCE and shared with the vector ranking below. Both rankings must
+    // run over the same candidate set anyway (ranking outside the filter would
+    // let a semantic match on an excluded resource take a slot), so filtering
+    // twice would be a full scan of the catalog for no additional information.
+    const candidates = this.filter(params);
+    const lexical = candidates
       .map((entry) => ({ entry, score: scoreResource(entry.resource, tokens, entry.stats) }))
       .filter((s) => s.score > 0)
       .sort(
@@ -1727,7 +1732,7 @@ export class BazaarCatalog {
           b.entry.resource.lastUpdated.localeCompare(a.entry.resource.lastUpdated),
       );
 
-    const fused = this.fuseWithVectorRanking(lexical, params);
+    const fused = this.fuseWithVectorRanking(lexical, candidates, params.query);
     const scored = fused.map((entry) => toItem(entry));
 
     const page = scored.slice(offset, offset + limit);
@@ -1777,9 +1782,10 @@ export class BazaarCatalog {
    */
   private fuseWithVectorRanking(
     lexical: Array<{ entry: StoredEntry; score: number }>,
-    params: SearchDiscoveryResourcesParams,
+    candidates: StoredEntry[],
+    rawQuery: string | undefined,
   ): StoredEntry[] {
-    const query = params.query?.trim() ?? "";
+    const query = rawQuery?.trim() ?? "";
     if (!query || !embeddingsEnabled() || this.embeddings.size === 0) {
       return lexical.map((s) => s.entry);
     }
@@ -1791,9 +1797,11 @@ export class BazaarCatalog {
     }
 
     // The vector ranking runs over the SAME filtered candidate set as the
-    // lexical one, not over the whole catalog. Ranking outside the filter would
-    // let a semantic match on a resource the caller explicitly excluded (wrong
-    // network, wrong payTo) consume a slot in the fused list.
+    // lexical one (handed in by the caller), not over the whole catalog.
+    // Ranking outside the filter would let a semantic match on a resource the
+    // caller explicitly excluded (wrong network, wrong payTo) consume a slot in
+    // the fused list.
+    //
     // Keys come from the entries map itself rather than being re-derived from
     // the resource url. An MCP entry's key is COMPOUND (`url \0 toolName`), so
     // re-deriving it here would mean reconstructing a key inline — the exact
@@ -1802,7 +1810,6 @@ export class BazaarCatalog {
     const keyOf = new Map<StoredEntry, string>();
     for (const [key, entry] of this.entries) keyOf.set(entry, key);
 
-    const candidates = this.filter(params);
     const vectorRanked = candidates
       .map((entry) => {
         const key = keyOf.get(entry);

--- a/src/embeddings.test.ts
+++ b/src/embeddings.test.ts
@@ -1,0 +1,144 @@
+// Unit tests for the pure half of semantic search.
+//
+// NOTHING HERE CALLS THE VOYAGE API. Every function under test is
+// deterministic, which is the point of keeping the text construction, the
+// similarity maths and the rank fusion separate from the client: the parts that
+// decide RANKING are testable without a network, a key, or a bill, and the part
+// that cannot be tested offline is a thin wrapper over one HTTP call.
+
+import { describe, expect, it } from "vitest";
+import {
+  buildEmbeddingText,
+  cosineSimilarity,
+  embeddingsEnabled,
+  EMBEDDING_DIMENSION,
+  EMBEDDING_MODEL,
+} from "./embeddings.js";
+import { rrfScore } from "./catalog.js";
+
+describe("buildEmbeddingText", () => {
+  const resource = {
+    resource: "https://example.test/qr",
+    serviceName: "QR Generator",
+    description: "Make a QR code",
+    tags: ["qr", "barcode"],
+  };
+
+  it("repeats each field at the lexical scorer's weight", () => {
+    const text = buildEmbeddingText(resource);
+    const occurrences = (needle: string) => text.split(needle).length - 1;
+    // The counts are the contract: they mirror scoreResource()'s field weights
+    // (serviceName 4, tags 3, description 2, url 1). If the scorer's weights
+    // change and these do not, the two halves of the hybrid ranking start
+    // disagreeing about which field matters, and RRF fuses two different
+    // notions of relevance.
+    expect(occurrences("QR Generator")).toBe(4);
+    expect(occurrences("qr barcode")).toBe(3);
+    expect(occurrences("Make a QR code")).toBe(2);
+    expect(occurrences("https://example.test/qr")).toBe(1);
+  });
+
+  it("omits absent fields entirely rather than embedding blank lines", () => {
+    // A resource with only a url is the minimum the catalog can hold. Padding
+    // the text with empty lines for the missing fields would embed structure
+    // that carries no meaning and dilute the one field that does.
+    const text = buildEmbeddingText({ resource: "https://example.test/bare" });
+    expect(text).toBe("https://example.test/bare");
+  });
+
+  it("ignores an empty tag array", () => {
+    const text = buildEmbeddingText({ ...resource, tags: [] });
+    expect(text).not.toContain("\n\n");
+    expect(buildEmbeddingText({ ...resource, tags: [] })).not.toBe(buildEmbeddingText(resource));
+  });
+});
+
+describe("cosineSimilarity", () => {
+  it("is 1 for identical vectors and 0 for orthogonal ones", () => {
+    expect(cosineSimilarity([1, 0, 0], [1, 0, 0])).toBeCloseTo(1);
+    expect(cosineSimilarity([1, 0], [0, 1])).toBeCloseTo(0);
+  });
+
+  it("is -1 for opposed vectors", () => {
+    expect(cosineSimilarity([1, 1], [-1, -1])).toBeCloseTo(-1);
+  });
+
+  it("ignores magnitude, measuring direction only", () => {
+    // The property the ranking depends on: a longer document must not outrank a
+    // shorter one merely for being longer.
+    expect(cosineSimilarity([1, 2, 3], [10, 20, 30])).toBeCloseTo(1);
+  });
+
+  it("returns 0 rather than throwing on mismatched widths", () => {
+    // A stored vector of the wrong width is a stale row from a previous model.
+    // It must cost that ONE resource its place in the vector ranking, not take
+    // down every search that touches it.
+    expect(cosineSimilarity([1, 2, 3], [1, 2])).toBe(0);
+  });
+
+  it("returns 0 for empty or zero vectors instead of NaN", () => {
+    // A zero vector would divide by zero. NaN is the dangerous outcome here:
+    // it compares false against everything, so it would sort unpredictably
+    // rather than ranking last.
+    expect(cosineSimilarity([], [])).toBe(0);
+    expect(cosineSimilarity([0, 0], [1, 1])).toBe(0);
+    expect(Number.isNaN(cosineSimilarity([0, 0], [0, 0]))).toBe(false);
+  });
+});
+
+describe("rrfScore", () => {
+  it("ranks a document better when it appears higher in either list", () => {
+    expect(rrfScore(1, 1)).toBeGreaterThan(rrfScore(1, 2));
+    expect(rrfScore(1, 5)).toBeGreaterThan(rrfScore(3, 5));
+  });
+
+  it("lets a document strong in both lists beat one first in only one", () => {
+    // THE DEFINING PROPERTY OF THE FUSION. With k=60 the top of each list is
+    // deliberately flat, so a resource ranked 2nd and 2nd beats one ranked 1st
+    // and 20th. That is what stops a confident-but-wrong vector hit from
+    // displacing a solid lexical result on the strength of a single first
+    // place.
+    expect(rrfScore(2, 2)).toBeGreaterThan(rrfScore(1, 20));
+  });
+
+  it("still surfaces a purely semantic hit carrying a lexical penalty rank", () => {
+    // A resource with no lexical match at all (penalty rank 11 in a 10-item
+    // list) but ranked 1st by vector must still outscore one that is mediocre
+    // in both. This is the case the whole feature exists for: a query sharing
+    // no vocabulary with the catalog.
+    expect(rrfScore(11, 1)).toBeGreaterThan(rrfScore(9, 9));
+  });
+
+  it("is symmetric between the two lists", () => {
+    // Neither ranking is privileged over the other by the formula itself.
+    expect(rrfScore(3, 7)).toBeCloseTo(rrfScore(7, 3));
+  });
+
+  it("honours an explicit k", () => {
+    // Smaller k sharpens the top of the list; the default is the paper's 60.
+    expect(rrfScore(1, 1, 1)).toBeGreaterThan(rrfScore(1, 1, 60));
+  });
+});
+
+describe("configuration", () => {
+  it("pins the model and its dimension together", () => {
+    // These two travel as a pair: a stored vector's width is only meaningful
+    // against the model that produced it, and a silent model swap would make
+    // every stored embedding incomparable.
+    expect(EMBEDDING_MODEL).toBe("voyage-code-3");
+    expect(EMBEDDING_DIMENSION).toBe(1024);
+  });
+
+  it("reports semantic search as unavailable without a key", () => {
+    const previous = process.env.VOYAGE_API_KEY;
+    try {
+      delete process.env.VOYAGE_API_KEY;
+      expect(embeddingsEnabled()).toBe(false);
+      process.env.VOYAGE_API_KEY = "test-key";
+      expect(embeddingsEnabled()).toBe(true);
+    } finally {
+      if (previous === undefined) delete process.env.VOYAGE_API_KEY;
+      else process.env.VOYAGE_API_KEY = previous;
+    }
+  });
+});

--- a/src/embeddings.ts
+++ b/src/embeddings.ts
@@ -1,0 +1,192 @@
+// Vector embeddings for semantic catalog search.
+//
+// WHY THIS EXISTS: the lexical scorer in catalog.ts scores 10/10 on
+// docs/search-eval.md and is not being replaced. What it cannot do is bridge a
+// query that shares NO token with any listing — "barcode for a link" against a
+// `/qr` endpoint returns an EMPTY list, not a weak ranking, because
+// scoreResource() returns 0 and search() drops zeros entirely. That is the gap
+// this file closes, and it closes it ALONGSIDE the lexical path rather than in
+// place of it: see the RRF fusion in catalog.ts.
+//
+// EVERY EXPORT HERE IS OPTIONAL AT RUNTIME. With VOYAGE_API_KEY unset the
+// catalog is lexical-only and byte-identical to what shipped before, which is
+// what makes this safe to deploy before the backfill has run.
+
+import { VoyageAIClient } from "voyageai";
+
+/** voyage-code-3. Chosen over voyage-3 because catalog entries are API
+ *  endpoints, tags and developer-facing descriptions, which is the distribution
+ *  this model is tuned for. */
+export const EMBEDDING_MODEL = "voyage-code-3";
+
+/** Native output width of voyage-code-3. Asserted on every vector we store, so
+ *  a model swap that silently changes the width fails loudly at ingest instead
+ *  of producing a cosine similarity against mismatched dimensions. */
+export const EMBEDDING_DIMENSION = 1024;
+
+/** Voyage caps a single embed request at 128 inputs. The backfill batches at 10,
+ *  well inside this, but the guard belongs with the API it constrains. */
+const MAX_BATCH = 128;
+
+let client: VoyageAIClient | undefined;
+
+/**
+ * The key is read at CALL time, not at module load. Reading it at load would
+ * bake in whatever the environment looked like when the module first got
+ * imported, which breaks tests that set the variable per-case and makes the
+ * unset-key path depend on import order.
+ */
+function getClient(): VoyageAIClient {
+  const apiKey = process.env.VOYAGE_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "VOYAGE_API_KEY is not set — semantic search is unavailable. Set it to enable embeddings, " +
+        "or leave it unset to run lexical-only search.",
+    );
+  }
+  if (!client) client = new VoyageAIClient({ apiKey });
+  return client;
+}
+
+/** Whether semantic search can run at all. Callers use this to stay on the
+ *  lexical-only path rather than catching a throw per query. */
+export function embeddingsEnabled(): boolean {
+  return Boolean(process.env.VOYAGE_API_KEY);
+}
+
+/** The subset of a catalog resource the embedding text is built from. Structural
+ *  rather than importing DiscoveryResource, so this module stays independent of
+ *  the catalog's wire types and is trivially testable. */
+export interface EmbeddableResource {
+  resource: string;
+  serviceName?: string | undefined;
+  description?: string | undefined;
+  tags?: string[] | undefined;
+}
+
+/**
+ * Flatten a resource into the text that gets embedded.
+ *
+ * FIELDS ARE REPEATED, NOT CONCATENATED ONCE, and the repetition counts mirror
+ * the lexical scorer's field weights exactly (serviceName 4, tags 3,
+ * description 2, url 1 — see scoreResource() in catalog.ts). Repetition is how
+ * you express field weighting to a bag-of-text embedding model, which has no
+ * notion of fields: a term appearing four times pulls the document vector
+ * further toward that term's region than one appearing once.
+ *
+ * Keeping the two weightings identical is deliberate. If lexical and vector
+ * disagreed about which field matters most, the RRF fusion would be blending
+ * two rankings built on different notions of relevance, and a regression in one
+ * would be untraceable from the other.
+ */
+export function buildEmbeddingText(resource: EmbeddableResource): string {
+  const serviceName = resource.serviceName?.trim() ?? "";
+  const tags = (resource.tags ?? []).join(" ").trim();
+  const description = resource.description?.trim() ?? "";
+  const url = resource.resource.trim();
+
+  const parts: string[] = [];
+  const repeat = (text: string, times: number) => {
+    if (!text) return;
+    for (let i = 0; i < times; i++) parts.push(text);
+  };
+  repeat(serviceName, 4);
+  repeat(tags, 3);
+  repeat(description, 2);
+  repeat(url, 1);
+  return parts.join("\n");
+}
+
+/**
+ * Pull the vectors out of a Voyage response.
+ *
+ * EVERY FIELD ON THE RESPONSE IS OPTIONAL in the SDK's own types — `data`,
+ * `embedding` and `index` are all `?`. So this validates rather than asserts:
+ * a truncated or reshaped response becomes a clear throw at the boundary
+ * instead of `undefined` propagating into a cosine similarity and returning
+ * NaN, which would silently rank every resource identically.
+ *
+ * Ordered by `index` rather than trusting array order, because the API
+ * documents the field precisely so that order need not be relied on.
+ */
+function extractEmbeddings(data: Array<{ embedding?: number[]; index?: number }> | undefined, expected: number): number[][] {
+  if (!data || data.length !== expected) {
+    throw new Error(
+      `voyage returned ${data?.length ?? 0} embeddings for ${expected} inputs`,
+    );
+  }
+  const ordered = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+  return ordered.map((item, i) => {
+    const vector = item.embedding;
+    if (!Array.isArray(vector) || vector.length === 0) {
+      throw new Error(`voyage returned no embedding for input ${i}`);
+    }
+    if (vector.length !== EMBEDDING_DIMENSION) {
+      throw new Error(
+        `voyage returned a ${vector.length}-dimension embedding, expected ${EMBEDDING_DIMENSION} ` +
+          `(model ${EMBEDDING_MODEL}) — a stored vector of the wrong width cannot be compared`,
+      );
+    }
+    return vector;
+  });
+}
+
+/**
+ * Embed catalog documents. `inputType: "document"` is not cosmetic: Voyage
+ * embeds documents and queries into deliberately asymmetric positions, and
+ * embedding a document as a query measurably degrades retrieval.
+ */
+export async function embedTexts(texts: string[]): Promise<number[][]> {
+  if (texts.length === 0) return [];
+  if (texts.length > MAX_BATCH) {
+    throw new Error(`embedTexts received ${texts.length} inputs, the API maximum is ${MAX_BATCH}`);
+  }
+  const response = await getClient().embed({
+    input: texts,
+    model: EMBEDDING_MODEL,
+    inputType: "document",
+  });
+  return extractEmbeddings(response.data, texts.length);
+}
+
+/** Embed a search query. `inputType: "query"` — see embedTexts() for why the
+ *  asymmetry matters. */
+export async function embedQuery(query: string): Promise<number[]> {
+  const response = await getClient().embed({
+    input: [query],
+    model: EMBEDDING_MODEL,
+    inputType: "query",
+  });
+  const [vector] = extractEmbeddings(response.data, 1);
+  if (!vector) throw new Error("voyage returned no embedding for the query");
+  return vector;
+}
+
+/**
+ * Cosine similarity, computed in ONE pass rather than three.
+ *
+ * Voyage returns L2-normalised vectors, so the denominator is ~1 and a plain
+ * dot product would very nearly do. It is computed properly anyway: the
+ * normalisation is a property of the current model, not a guarantee of the
+ * interface, and a model swap that dropped it would otherwise turn every score
+ * into an unnormalised magnitude with no error to trace it by.
+ *
+ * Mismatched lengths return 0 rather than throwing. A stored vector of the
+ * wrong width is a stale row from a previous model, and one bad row must not
+ * take down every search that touches it — it simply ranks last.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length || a.length === 0) return 0;
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i] as number;
+    const y = b[i] as number;
+    dot += x * y;
+    magA += x * x;
+    magB += y * y;
+  }
+  if (magA === 0 || magB === 0) return 0;
+  return dot / (Math.sqrt(magA) * Math.sqrt(magB));
+}

--- a/src/store.embeddings.test.ts
+++ b/src/store.embeddings.test.ts
@@ -1,0 +1,145 @@
+// The embedding column: migration, round trip, and the degradation behaviour
+// that keeps a bad vector from taking down search.
+//
+// These use a real libSQL file store rather than a mock, for the same reason
+// the rest of store.durability.test.ts does: the thing under test is the SQL
+// and the migration, and a mock of the store would assert only that the mock
+// was called.
+
+import { describe, expect, it } from "vitest";
+import { createClient } from "@libsql/client";
+import { tmpStore, reopen } from "./store.testkit.js";
+
+const KEY = "https://api.merchant.example/quote";
+
+async function seedEntry(url: string, key = KEY): Promise<void> {
+  const client = createClient({ url });
+  await client.execute({
+    sql: "INSERT INTO entry (resource_key, payload, last_updated) VALUES (?, ?, ?)",
+    args: [key, JSON.stringify({ resource: { resource: key } }), Date.now()],
+  });
+  client.close();
+}
+
+describe("entry.embedding", () => {
+  it("round-trips a vector through the store", async () => {
+    const { store, url } = tmpStore();
+    await store.init();
+    await seedEntry(url);
+
+    const vector = [0.1, -0.25, 0.5];
+    await store.saveEmbedding(KEY, vector);
+
+    // Reopened, so this proves the value is DURABLE rather than cached in the
+    // client that wrote it.
+    const fresh = reopen(url);
+    const loaded = await fresh.loadEmbeddings();
+    expect(loaded).toEqual([{ resource_key: KEY, embedding: vector }]);
+    await store.close();
+    await fresh.close();
+  });
+
+  it("adds the column to a database created before semantic search shipped", async () => {
+    const { url } = tmpStore();
+    // The pre-migration shape, created WITHOUT init() so the column genuinely
+    // does not exist. This is the state every existing deployment is in.
+    const client = createClient({ url });
+    await client.execute(
+      `CREATE TABLE entry (resource_key TEXT PRIMARY KEY, payload TEXT NOT NULL, last_updated INTEGER NOT NULL)`,
+    );
+    await client.execute({
+      sql: "INSERT INTO entry (resource_key, payload, last_updated) VALUES (?, ?, ?)",
+      args: [KEY, "{}", Date.now()],
+    });
+    client.close();
+
+    const store = reopen(url);
+    await store.init();
+
+    // MUTATION THIS CATCHES: dropping the PRAGMA check in init(). Without the
+    // migration this call fails with "no such column: embedding", which
+    // classifyStoreError treats as DETERMINISTIC and therefore never retries —
+    // so the catalog freezes rather than degrading to lexical-only.
+    await expect(store.getEntriesWithoutEmbeddings()).resolves.toEqual([
+      { resource_key: KEY, payload: "{}" },
+    ]);
+    await store.close();
+  });
+
+  it("is idempotent across repeated init calls", async () => {
+    const { store, url } = tmpStore();
+    await store.init();
+    await store.init();
+    await seedEntry(url);
+    await expect(store.getEntriesWithoutEmbeddings()).resolves.toHaveLength(1);
+    await store.close();
+  });
+
+  it("excludes an entry once it has a vector, so the backfill is idempotent", async () => {
+    const { store, url } = tmpStore();
+    await store.init();
+    await seedEntry(url);
+
+    expect(await store.getEntriesWithoutEmbeddings()).toHaveLength(1);
+    await store.saveEmbedding(KEY, [1, 2, 3]);
+    // Re-running the backfill must cost nothing. If this regressed, every run
+    // would re-embed the whole catalog and be billed for it.
+    expect(await store.getEntriesWithoutEmbeddings()).toHaveLength(0);
+    await store.close();
+  });
+
+  it("is a no-op for a resource with no entry row", async () => {
+    const { store } = tmpStore();
+    await store.init();
+    // The fire-and-forget ingest writer races evictToCap() by construction.
+    // Losing that race must not throw and must not create a partial row.
+    await expect(store.saveEmbedding("https://gone.example/x", [1, 2])).resolves.toBeUndefined();
+    expect(await store.loadEmbeddings()).toEqual([]);
+    await store.close();
+  });
+
+  it("skips an unparseable vector instead of failing the whole load", async () => {
+    const { store, url } = tmpStore();
+    await store.init();
+    await seedEntry(url, KEY);
+    await seedEntry(url, "https://api.merchant.example/other");
+    await store.saveEmbedding(KEY, [1, 2, 3]);
+
+    // A row written by something else, or by an older build. Deliberately
+    // different from how loadEntries() treats a bad row: an unparseable ENTRY
+    // is a resource we would serve wrongly, so it fails closed. An unparseable
+    // EMBEDDING costs only that resource its place in the vector ranking, and
+    // it is still findable lexically. Failing the load would take semantic
+    // search down for every resource because of one bad row.
+    const client = createClient({ url });
+    await client.execute({
+      sql: "UPDATE entry SET embedding = ? WHERE resource_key = ?",
+      args: ["not json at all", "https://api.merchant.example/other"],
+    });
+    client.close();
+
+    const loaded = await store.loadEmbeddings();
+    expect(loaded).toEqual([{ resource_key: KEY, embedding: [1, 2, 3] }]);
+    await store.close();
+  });
+
+  it("rejects a vector whose contents are not finite numbers", async () => {
+    const { store, url } = tmpStore();
+    await store.init();
+    await seedEntry(url);
+
+    const client = createClient({ url });
+    // Valid JSON, wrong contents. NaN and nulls would propagate into
+    // cosineSimilarity and produce a NaN score, which sorts unpredictably
+    // rather than ranking last — a silently corrupt ordering is worse than a
+    // missing one.
+    await client.execute({
+      sql: "UPDATE entry SET embedding = ? WHERE resource_key = ?",
+      args: ['[1, null, "x"]', KEY],
+    });
+    client.close();
+
+    expect(await store.loadEmbeddings()).toEqual([]);
+    await store.close();
+  });
+});

--- a/src/store.testkit.ts
+++ b/src/store.testkit.ts
@@ -72,6 +72,15 @@ export class FailingStore implements CatalogStore {
   displaceOwnership(resourceKey: string, newPayTo: string, at: number): Promise<void> {
     return this.inner.displaceOwnership(resourceKey, newPayTo, at);
   }
+  saveEmbedding(resourceKey: string, embedding: number[]): Promise<void> {
+    return this.inner.saveEmbedding(resourceKey, embedding);
+  }
+  getEntriesWithoutEmbeddings(): Promise<Array<{ resource_key: string; payload: string }>> {
+    return this.inner.getEntriesWithoutEmbeddings();
+  }
+  loadEmbeddings(): Promise<Array<{ resource_key: string; embedding: number[] }>> {
+    return this.inner.loadEmbeddings();
+  }
   close(): Promise<void> {
     return this.inner.close();
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -96,6 +96,20 @@ export interface CatalogStore {
   /** Replace every binding for a URL with one proven claimant. See the
    *  implementation for why this is neither an UPDATE nor a plain INSERT. */
   displaceOwnership(resourceKey: string, newPayTo: string, at: number): Promise<void>;
+  /**
+   * Attach a semantic embedding to an existing entry.
+   *
+   * An UPDATE, never an INSERT: an embedding for a resource_key with no entry
+   * row is meaningless, and inserting one would create a row whose `payload`
+   * cannot satisfy NOT NULL. A no-op when the entry has since been evicted,
+   * which is the correct outcome for a fire-and-forget writer racing eviction.
+   */
+  saveEmbedding(resourceKey: string, embedding: number[]): Promise<void>;
+  /** Entries with no embedding yet — the backfill worklist. Returns the payload
+   *  so the caller can build embedding text without a second round trip. */
+  getEntriesWithoutEmbeddings(): Promise<Array<{ resource_key: string; payload: string }>>;
+  /** Every stored embedding, for the in-memory search cache. */
+  loadEmbeddings(): Promise<Array<{ resource_key: string; embedding: number[] }>>;
   close(): Promise<void>;
 }
 
@@ -265,6 +279,26 @@ export class LibsqlCatalogStore implements CatalogStore {
     if (!cols.rows.some((r) => r.name === "verified_at")) {
       console.warn("[store] migrating: adding ownership.verified_at (pre-displacement database)");
       await this.run(() => this.client.execute("ALTER TABLE ownership ADD COLUMN verified_at INTEGER"));
+    }
+    // Same reasoning one table over: a database created before semantic search
+    // shipped has the three-column `entry` shape, and every query naming
+    // `embedding` would fail with "no such column" — which classifyStoreError
+    // does NOT treat as retryable, so it would freeze the catalog rather than
+    // degrade to lexical-only.
+    //
+    // TEXT holding a JSON array, not F32_BLOB. @libsql/client is 0.17.4 and its
+    // vector support is not something to depend on for a column that is only
+    // ever read in full and compared in process; JSON.parse round-trips
+    // exactly, and the cost is paid once at boot into the in-memory cache
+    // rather than per query.
+    //
+    // NULLABLE, and that is the degradation story: an entry written before the
+    // backfill ran simply has no vector, drops out of the vector ranking, and
+    // is still found lexically.
+    const entryCols = await this.run(() => this.client.execute("PRAGMA table_info(entry)"));
+    if (!entryCols.rows.some((r) => r.name === "embedding")) {
+      console.warn("[store] migrating: adding entry.embedding (pre-semantic-search database)");
+      await this.run(() => this.client.execute("ALTER TABLE entry ADD COLUMN embedding TEXT"));
     }
   }
 
@@ -449,6 +483,70 @@ export class LibsqlCatalogStore implements CatalogStore {
         "write",
       ),
     );
+  }
+
+  /**
+   * UPDATE, not upsert — see the interface note. The `WHERE resource_key = ?`
+   * makes an embedding for an evicted entry a silent no-op rather than an
+   * error, which is what the fire-and-forget ingest writer needs: it races
+   * evictToCap() by construction, and losing that race is normal operation,
+   * not a fault worth logging.
+   */
+  async saveEmbedding(resourceKey: string, embedding: number[]): Promise<void> {
+    await this.run(() =>
+      this.client.execute({
+        sql: "UPDATE entry SET embedding = ? WHERE resource_key = ?",
+        args: [JSON.stringify(embedding), resourceKey] as InArgs,
+      }),
+    );
+  }
+
+  async getEntriesWithoutEmbeddings(): Promise<Array<{ resource_key: string; payload: string }>> {
+    const res = await this.run(() =>
+      this.client.execute("SELECT resource_key, payload FROM entry WHERE embedding IS NULL"),
+    );
+    return res.rows.map((r) => {
+      const key = r.resource_key;
+      const payload = r.payload;
+      if (typeof key !== "string" || typeof payload !== "string") {
+        throw new StoreInvalidError(new Error("entry row has a non-string resource_key/payload"));
+      }
+      return { resource_key: key, payload };
+    });
+  }
+
+  /**
+   * Every stored vector, parsed.
+   *
+   * A row that will not parse is SKIPPED WITH A WARNING rather than thrown on,
+   * which is a deliberate departure from how loadEntries() treats a bad row.
+   * The difference is what the data is load-bearing for: an unparseable entry
+   * payload is a resource the catalog would otherwise serve wrongly, so it
+   * fails closed. An unparseable embedding costs only that resource's place in
+   * the VECTOR ranking, and it remains fully findable lexically. Failing the
+   * whole load would take semantic search down for every resource because one
+   * row was written by an older model, which is a far worse trade than ranking
+   * one resource by lexical score alone.
+   */
+  async loadEmbeddings(): Promise<Array<{ resource_key: string; embedding: number[] }>> {
+    const res = await this.run(() =>
+      this.client.execute("SELECT resource_key, embedding FROM entry WHERE embedding IS NOT NULL"),
+    );
+    const out: Array<{ resource_key: string; embedding: number[] }> = [];
+    for (const r of res.rows) {
+      const key = r.resource_key;
+      const raw = r.embedding;
+      if (typeof key !== "string" || typeof raw !== "string") continue;
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed) || parsed.length === 0) continue;
+        if (!parsed.every((n) => typeof n === "number" && Number.isFinite(n))) continue;
+        out.push({ resource_key: key, embedding: parsed as number[] });
+      } catch {
+        console.warn(`[store] skipping unparseable embedding for ${key} — it will rank lexically only`);
+      }
+    }
+    return out;
   }
 
   async close(): Promise<void> {


### PR DESCRIPTION
Adds semantic search to the Bazaar catalog **alongside** the existing lexical scorer, fused with Reciprocal Rank Fusion. Lexical search is not replaced: it already answers its own eval well, and replacing it would risk regressing exactly the queries it gets right.

With `VOYAGE_API_KEY` unset the vector path is skipped entirely and results are identical to today.

## Measured results

Same 19 entry catalog, same scorer, changing only whether `VOYAGE_API_KEY` is set.

| Query set | Metric | Lexical | Hybrid | Change |
| --- | --- | --- | --- | --- |
| Original 10 | top-1 | 9/10 | 9/10 | unchanged |
| Original 10 | MRR | 0.950 | 0.950 | unchanged |
| Original 10 | NDCG@3 | 0.963 | 0.963 | unchanged |
| Semantic 10 | top-1 | 2/10 | **5/10** | +3 |
| Semantic 10 | MRR | 0.264 | **0.717** | +0.453 |
| Semantic 10 | NDCG@3 | 0.263 | **0.789** | +0.526 |

**The original set not moving is the result that mattered most.** The risk of adding a second ranking signal is that it degrades what the first already answers. It does not move at all.

**On the semantic set, lexical scores 2/10 and that is the point of the comparison.** Four of the ten (`secure login credential`, `when does this job run`, `filler text for design`, `imperial to metric`) return results with the answer nowhere in the top 10, because `scoreResource` returns 0 for a query sharing no token with any listing and `search` drops zeros entirely. The two it does get are accidents of vocabulary, not understanding: `change color format` hits `/color`'s tag `convert`, `render documentation` hits `/markdown`'s tag `render`. Several misses return a confidently wrong first result (`barcode for a link` returns `/weather`), which is worse for an agent than returning nothing.

**What is still not fixed.** Under hybrid, all ten semantic queries reach the top 3, but only five reach first place, which is why NDCG@3 roughly triples while top-1 goes 2 to 5. `find pattern in string` still ranks `/cron` above `/regex`; `parse spreadsheet data` still ranks `/weather` above `/csv`. That is a reranking gap, not a retrieval one.

Caveat: the 19 entry corpus was authored for this eval. The relative movement is the meaningful part; absolute numbers will shift as real endpoints land.

## The sync vs async decision

**`search()` stays synchronous.** It has 12 call sites in tests plus `server.ts:797`, and making it async is cheap at those call sites since the handler is already async. The cost that does not show up in a diff is the real one: it would put a Voyage round trip on the request path of every discovery search, turning a vendor outage into a hung endpoint rather than a degraded ranking.

Instead:
- **Document vectors** live in an in-memory map, loaded once at boot and maintained fire and forget on ingest. 1024 floats is ~8KB, so even at the `MAX_ENTRIES` cap this is single digit megabytes.
- **Query vectors** are cached in a bounded map (1000 entries, oldest out). Bounded because the key is attacker supplied text on a public endpoint.

The tradeoff, stated plainly rather than buried: **the first search for a novel query returns lexical only and warms the vector in the background; the next identical query is hybrid.** This is acceptable because the lexical path is not a degraded fallback here, it is a ranking that already scores 9-10/10.

## Backfill

`npm run backfill-embeddings`. Idempotent: entries that already carry a vector are not selected, so a re-run after a partial failure costs only what still needs doing.

**Result: 19/19 entries embedded, 0 skipped, 0 failed.** This ran against a locally seeded 19 entry libSQL catalog, not the hosted Turso database, because this environment's `.env` carries no `CATALOG_DB_URL` or `CATALOG_DB_AUTH_TOKEN`. **Someone with the Turso credentials still needs to run it against the live database before this helps production.** Until then existing entries have no vector and rank lexically, which is the designed degradation.

Two things the run surfaced:
- A Voyage account with no payment method is limited to **3 requests/minute**, and the first run hit a 429 on its second batch. The script now retries a 429 with backoff and fails fast on anything else, mirroring how `classifyStoreError` splits transient from deterministic.
- The backfill reads `CATALOG_DB_URL` **directly rather than through `loadConfig()`**, which throws unless `SPONSOR_SECRET_KEY` and 50 funded channel account secrets are present. Routing a read mostly maintenance job through it would mean needing production signing keys to embed a text column.

## Schema

`entry.embedding TEXT` holding a JSON float array, added with the same `PRAGMA table_info` + `ALTER TABLE` pattern already used for `ownership.verified_at`. TEXT rather than `F32_BLOB` because `@libsql/client` is 0.17.4 and the column is only ever read in full and compared in process. Nullable, so an entry written before the backfill simply ranks lexically.

An unparseable stored vector is **skipped with a warning** rather than throwing, deliberately unlike how `loadEntries` treats a bad row: a bad entry payload is a resource we would serve wrongly so it fails closed, while a bad embedding costs only that resource its place in the vector ranking.

## Tests

**635 passed, 4 skipped, up from a 613 passed / 4 skipped baseline. 22 added, 0 regressed.**

New coverage: the migration against a genuinely pre-migration database, backfill idempotence, `saveEmbedding` as a no-op when the entry was evicted (the fire and forget writer races `evictToCap` by construction), unparseable and non-finite vectors, RRF ordering properties, and cosine similarity edge cases including the zero vector that would otherwise produce a NaN score and sort unpredictably.

## Review notes

- `rrfScore` fuses **ranks, not scores**, deliberately. A lexical score is an unbounded sum of field weights; a cosine similarity is bounded and tightly clustered. Summing the raw numbers would let whichever has the larger spread silently dominate.
- `buildEmbeddingText` repeats fields at the lexical scorer's own weights (serviceName x4, tags x3, description x2, url x1) so both halves of the hybrid agree on which field matters.
- Empty queries skip the vector path: they rank by trust rather than text and have nothing meaningful to embed.
- `VOYAGE_API_KEY` is read at call time, never logged, and is not committed.
