### PR TITLE
fix(hardening): XFF keyGenerator for rate-limit under fastify 5.12.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@x402/core": "^2.20.0",
         "@x402/extensions": "^2.20.0",
         "@x402/stellar": "^2.20.0",
-        "fastify": "^5.2.0",
+        "fastify": "^5.12.1",
         "prom-client": "^15.1.3",
         "undici": "^8.10.0",
         "voyageai": "^0.4.0",
@@ -2592,9 +2592,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.11.0.tgz",
-      "integrity": "sha512-Y/Ecx1yt0hYzrQR+QVLbxaUN8wCX+MQzMevh29r5RRvlOIArmi4+WAXXaGl5Hw5gBr2wduZpZaT3gRCnXoyVgA==",
+      "version": "5.12.3",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.3.tgz",
+      "integrity": "sha512-reZ8wce5VNCcufIt9AVtzZa3L4u1j8esikn7OEgHWLVpRpL5R7Y2+Xzj70OUkv5zDfzUAxXZT6cu4Rt0zr3EKA==",
       "funding": [
         {
           "type": "github",
@@ -2617,7 +2617,7 @@
         "find-my-way": "^9.6.0",
         "light-my-request": "^6.0.0",
         "pino": "^9.14.0 || ^10.1.0",
-        "process-warning": "^5.0.0",
+        "process-warning": "^5.1.0",
         "rfdc": "^1.3.1",
         "secure-json-parse": "^4.0.0",
         "semver": "^7.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@x402/core": "^2.20.0",
     "@x402/extensions": "^2.20.0",
     "@x402/stellar": "^2.20.0",
-    "fastify": "^5.2.0",
+    "fastify": "^5.12.1",
     "prom-client": "^15.1.3",
     "undici": "^8.10.0",
     "voyageai": "^0.4.0",

--- a/src/server.ratelimit-key.test.ts
+++ b/src/server.ratelimit-key.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { rateLimitKeyFor } from "./server.js";
+
+// D4, the keyGenerator half. The existing hardening.test.ts D4 case proves two
+// distinct clients get distinct buckets, but it sends a SINGLE-value
+// X-Forwarded-For, where leftmost and rightmost are the same string. These
+// cases cover what that one cannot: the forged-prefix attack that makes
+// rightmost-vs-leftmost a security property rather than a style choice.
+describe("rateLimitKeyFor — rightmost X-Forwarded-For wins", () => {
+  it("uses the only entry when the header has one", () => {
+    expect(rateLimitKeyFor("203.0.113.1", "10.0.0.1")).toBe("203.0.113.1");
+  });
+
+  it("IGNORES a client-forged prefix and takes the rightmost entry", () => {
+    // The attack: a client sends its own X-Forwarded-For, Render APPENDS the
+    // address it observed. Taking the leftmost would let anyone mint a fresh
+    // bucket per request by varying the forged value.
+    expect(rateLimitKeyFor("evil, 203.0.113.1", "10.0.0.1")).toBe("203.0.113.1");
+    expect(rateLimitKeyFor("1.1.1.1, 2.2.2.2, 203.0.113.9", "10.0.0.1")).toBe("203.0.113.9");
+  });
+
+  it("cannot be evaded by varying the forged prefix", () => {
+    const a = rateLimitKeyFor("attacker-1, 203.0.113.1", "10.0.0.1");
+    const b = rateLimitKeyFor("attacker-2, 203.0.113.1", "10.0.0.1");
+    expect(a).toBe(b);
+  });
+
+  it("falls back to req.ip when the header is absent or empty", () => {
+    expect(rateLimitKeyFor(undefined, "1.2.3.4")).toBe("1.2.3.4");
+    expect(rateLimitKeyFor("", "1.2.3.4")).toBe("1.2.3.4");
+    expect(rateLimitKeyFor("   ", "1.2.3.4")).toBe("1.2.3.4");
+  });
+
+  it("takes the last element of a repeated header, for the same reason", () => {
+    expect(rateLimitKeyFor(["a, b", "c, 203.0.113.7"], "10.0.0.1")).toBe("203.0.113.7");
+  });
+
+  it("strips a port from IPv4 and bracketed IPv6, and leaves a bare IPv6 alone", () => {
+    expect(rateLimitKeyFor("203.0.113.1:9999", "10.0.0.1")).toBe("203.0.113.1");
+    expect(rateLimitKeyFor("[2001:db8::1]:443", "10.0.0.1")).toBe("2001:db8::1");
+    // A bare IPv6 is all colons and has no port to strip. Splitting on the
+    // first colon here would corrupt the address into "2001".
+    expect(rateLimitKeyFor("2001:db8::1", "10.0.0.1")).toBe("2001:db8::1");
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,40 @@ export interface HardeningOptions {
   bodyLimitBytes?: number;
 }
 
+/**
+ * Rate-limit bucket key: the rightmost X-Forwarded-For entry, which on Render is
+ * the address its proxy observed and appended, and is therefore the one part of
+ * the header a client cannot forge. Exported for the D4 tests.
+ *
+ * `xff` is whatever Node parsed the header into: a string, an array when the
+ * header appeared more than once, or undefined. All three are handled, and the
+ * array case takes the last element of the last header for the same
+ * rightmost-wins reason.
+ */
+export function rateLimitKeyFor(xff: string | string[] | undefined, fallback: string): string {
+  const raw = Array.isArray(xff) ? xff[xff.length - 1] : xff;
+  if (typeof raw === "string" && raw.trim() !== "") {
+    const parts = raw.split(",");
+    const rightmost = parts[parts.length - 1]!.trim();
+    if (rightmost !== "") return stripPort(rightmost);
+  }
+  return stripPort(fallback);
+}
+
+/**
+ * Drop a trailing port. IPv4 and hostname forms carry it as `addr:port`; a
+ * bracketed IPv6 carries it as `[addr]:port`. A BARE IPv6 (`2001:db8::1`) is
+ * all colons and has no port to strip, so it must be returned untouched, which
+ * is what the bracket and single-colon checks below distinguish.
+ */
+function stripPort(addr: string): string {
+  const bracketed = /^\[(.+)\](?::\d+)?$/.exec(addr);
+  if (bracketed) return bracketed[1]!;
+  const colons = addr.split(":").length - 1;
+  if (colons === 1) return addr.slice(0, addr.indexOf(":"));
+  return addr;
+}
+
 const DEFAULT_RATE_MAX = 60;
 const DEFAULT_BODY_LIMIT = 32 * 1024;
 
@@ -119,14 +153,24 @@ export async function buildServer(
   // one noisy client 429s everyone and an IP-rotating attacker is never
   // partitioned.
   //
-  // Trust exactly ONE hop, never `true`. X-Forwarded-For is client-writable and
-  // Render's proxy APPENDS the true client after whatever the client sent, so
-  // `true` would take the attacker-controlled leftmost entry — letting anyone
-  // mint a fresh rate-limit bucket per request and evade the limit entirely
-  // (strictly worse than the shared-bucket bug). Trusting one hop makes the
-  // address Render's proxy actually observed authoritative. Raise this number
-  // only if you add more trusted proxies in front of the service.
-  const app = Fastify({ logger: true, bodyLimit, trustProxy: 1 });
+  // `trustProxy: 1` USED to be set here, and fastify 5.12.x removed `number`
+  // from the accepted type at the same time as it changed what a hop count
+  // resolves `req.ip` to. Both halves of that change point the same way: a hop
+  // COUNT is no longer a reliable way to get the forwarded client.
+  //
+  // The rate limiter no longer depends on it either way. Its `keyGenerator`
+  // below reads the rightmost X-Forwarded-For entry from the header directly,
+  // which is the value Render's proxy appended and the one a client cannot
+  // forge, so the D4 partitioning property is now owned by that function rather
+  // than by Fastify's ip resolution.
+  //
+  // `trustProxy` stays UNSET (the default, false) rather than being set to
+  // `true`. `true` would make `req.ip` the attacker-controlled LEFTMOST entry,
+  // which is strictly worse than the shared-bucket bug it would appear to fix:
+  // anyone could mint a fresh rate-limit bucket per request. With it unset,
+  // `req.ip` is the proxy address, which is only ever used as the fallback when
+  // no X-Forwarded-For header is present at all, i.e. a direct connection.
+  const app = Fastify({ logger: true, bodyLimit });
   registerBazaar(facilitator, catalog);
 
   // Fix 2: security headers (helmet), an explicit CORS policy, and per-IP rate
@@ -157,6 +201,26 @@ export async function buildServer(
     // gauges, a duration histogram, never an address or a key), so this is
     // about compute-cost/abuse posture, not confidentiality.
     allowList: (req) => req.url === "/health",
+    // D4, second half. `trustProxy: 1` above tells Fastify which hop to trust,
+    // but fastify 5.12.x changed how a hop COUNT resolves `req.ip`: with
+    // `trustProxy: 1` it now returns the PROXY's address for every request
+    // rather than the forwarded client, which silently collapses every client
+    // behind Render into ONE rate-limit bucket. That is precisely the D4
+    // failure the test in src/hardening.test.ts exists to prevent, and it
+    // produces no error, only a wrong bucket.
+    //
+    // So the key is derived from the header directly rather than from whatever
+    // `req.ip` currently resolves to. RIGHTMOST, not leftmost, and the
+    // difference is the whole security property: X-Forwarded-For is
+    // client-writable and Render's proxy APPENDS the address it actually
+    // observed, so the last entry is the one a client cannot forge. Taking the
+    // leftmost would let anyone mint a fresh bucket per request by sending
+    // `X-Forwarded-For: <random>`, which is strictly worse than the shared
+    // bucket (see the trustProxy comment above).
+    //
+    // Falls back to `req.ip` when the header is absent, which is the local and
+    // direct-connection case.
+    keyGenerator: (req) => rateLimitKeyFor(req.headers["x-forwarded-for"], req.ip),
     // vellar_rate_limit_rejections_total (src/metrics.ts) — onExceeded is
     // the correct hook (confirmed against @fastify/rate-limit's own type
     // definitions): it fires exactly when a request is ACTUALLY rejected

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,13 +201,13 @@ export async function buildServer(
     // gauges, a duration histogram, never an address or a key), so this is
     // about compute-cost/abuse posture, not confidentiality.
     allowList: (req) => req.url === "/health",
-    // D4, second half. `trustProxy: 1` above tells Fastify which hop to trust,
-    // but fastify 5.12.x changed how a hop COUNT resolves `req.ip`: with
-    // `trustProxy: 1` it now returns the PROXY's address for every request
-    // rather than the forwarded client, which silently collapses every client
-    // behind Render into ONE rate-limit bucket. That is precisely the D4
-    // failure the test in src/hardening.test.ts exists to prevent, and it
-    // produces no error, only a wrong bucket.
+    // D4, second half. This USED to rely on `trustProxy: 1` (see the Fastify()
+    // call above, where it is now deliberately unset). fastify 5.12.x changed
+    // how a hop COUNT resolves `req.ip`: it began returning the PROXY's address
+    // for every request rather than the forwarded client, which silently
+    // collapses every client behind Render into ONE rate-limit bucket. That is
+    // precisely the D4 failure the test in src/hardening.test.ts exists to
+    // prevent, and it produces no error, only a wrong bucket.
     //
     // So the key is derived from the header directly rather than from whatever
     // `req.ip` currently resolves to. RIGHTMOST, not leftmost, and the


### PR DESCRIPTION
Fixes #87.

fastify 5.12.x changed `trustProxy: 1` resolution. With the old code every
client behind Render's proxy shared one rate-limit bucket, the D4 failure
`hardening.test.ts` was written to prevent.

**Fix:** an explicit `keyGenerator` reads the rightmost `X-Forwarded-For` entry
(Render appends the true client IP as rightmost, which is not client-writable).
Falls back to `req.ip` when the header is absent.

Also bumps fastify `^5.2.0` to `^5.12.1`, closing 2 moderate Dependabot
advisories. `npm audit` now reports **0 vulnerabilities**.

D4 test passes. Full suite passes: **641 passed, 4 skipped** (was 635/4).

## Two things beyond the brief

**`trustProxy` is now unset, not `1`.** fastify 5.12.x also removed `number`
from the accepted type, so `trustProxy: 1` no longer typechecks. Setting `true`
instead would be *worse than the bug*: `req.ip` would become the
attacker-controlled **leftmost** entry, letting anyone mint a fresh rate-limit
bucket per request by varying a forged prefix. With it unset, `req.ip` is the
proxy address and is only reached as the fallback when no `X-Forwarded-For`
exists at all, which is the direct-connection case. The partitioning property
now lives in the `keyGenerator` rather than in Fastify's ip resolution, which is
the actual fix rather than a workaround.

**Added `src/server.ratelimit-key.test.ts`, 6 cases.** The existing D4 test
sends a single-value `X-Forwarded-For`, where leftmost and rightmost are the
same string, so it passes under either reading and cannot prove the security
property. The new cases cover what it cannot:

| Case | Why |
|---|---|
| `evil, 203.0.113.1` returns `203.0.113.1` | the forged-prefix attack |
| varying the prefix yields the same key | proves evasion is not possible |
| repeated header, last of last | same rightmost-wins rule |
| `203.0.113.1:9999` returns `203.0.113.1` | port stripping |
| `[2001:db8::1]:443` returns `2001:db8::1` | bracketed IPv6 with port |
| `2001:db8::1` returns `2001:db8::1` | bare IPv6 must NOT be cut at its first colon |

That last one is the trap in this function: splitting on the first colon to
strip a port corrupts every bare IPv6 address into `2001`.
