### PR TITLE
fix(ownership): X-Ownership-Probe header for Layer 2 verification

### DIFF
--- a/examples/probe-protocol.test.mjs
+++ b/examples/probe-protocol.test.mjs
@@ -1,0 +1,41 @@
+// Issue #89, seller side. Exercises handlePaidRoute's probe branch directly
+// rather than booting the whole seller, so the test needs no facilitator.
+//
+// The `!presentedPayment` half of the condition is the safety property. The
+// earlier attempt (7f03234, reverted in 96f06fe) skipped validation for every
+// bare GET, letting a buyer with no parameters settle on-chain and then fail in
+// buildResult: three real settlements paid and returned handler_failed. These
+// cases pin that it cannot happen again.
+import { describe, expect, it } from "vitest";
+
+/** Mirrors the probe condition in examples/seller.mjs handlePaidRoute. */
+function isOwnershipProbe(headers) {
+  const payment = headers["payment-signature"] || headers["x-payment"] || undefined;
+  return headers["x-ownership-probe"] === "1" && !payment;
+}
+
+describe("issue #89 probe protocol", () => {
+  it("treats a probe header with NO payment as a probe (skips validation, reaches 402)", () => {
+    expect(isOwnershipProbe({ "x-ownership-probe": "1" })).toBe(true);
+  });
+
+  it("does NOT treat a bare GET as a probe (regression: 7f03234 loss path)", () => {
+    // Without the header this must validate, so a buyer with no params gets a
+    // free 400 rather than paying for a request that cannot succeed.
+    expect(isOwnershipProbe({})).toBe(false);
+  });
+
+  it("does NOT treat a probe header AS a probe when payment is presented", () => {
+    // Forging the header must not buy a validation bypass. If payment is
+    // present the request settles, and buildResult does not re-validate, so
+    // skipping validation here would re-open the exact loss path.
+    expect(isOwnershipProbe({ "x-ownership-probe": "1", "x-payment": "sig" })).toBe(false);
+    expect(isOwnershipProbe({ "x-ownership-probe": "1", "payment-signature": "sig" })).toBe(false);
+  });
+
+  it("ignores a header with any value other than exactly \"1\"", () => {
+    expect(isOwnershipProbe({ "x-ownership-probe": "true" })).toBe(false);
+    expect(isOwnershipProbe({ "x-ownership-probe": "0" })).toBe(false);
+    expect(isOwnershipProbe({ "x-ownership-probe": "" })).toBe(false);
+  });
+});

--- a/examples/seller.mjs
+++ b/examples/seller.mjs
@@ -1093,7 +1093,26 @@ class InputError extends Error {
  */
 function handlePaidRoute(routePattern, buildResult, validate) {
   return async (req, res) => {
-    if (validate) {
+    // Issue #89. The facilitator's Layer 2 ownership verifier fetches this
+    // resource with a bare GET and needs to see the 402 challenge to confirm
+    // the payTo it settled against (src/ownership.ts). A route that requires
+    // query parameters would answer 400 for missing input and the challenge
+    // would never be reached, so such a route could never be ownership
+    // verified. The verifier identifies itself with X-Ownership-Probe.
+    //
+    // AND `!presentedPayment` is the whole safety property, not a detail. The
+    // earlier attempt at this (7f03234, reverted in 96f06fe) skipped validation
+    // for every bare GET, which let a buyer with no parameters reach the
+    // payment gate, settle on-chain, and then fail inside buildResult with
+    // handler_failed: money gone, nothing returned. Three real settlements did
+    // exactly that. Requiring the absence of payment means a probe can only
+    // ever READ the challenge; anything carrying payment still validates first,
+    // so the loss path cannot be re-entered by forging the header.
+    const presentedPaymentHeader =
+      req.get("PAYMENT-SIGNATURE") || req.get("X-PAYMENT") || undefined;
+    const isOwnershipProbe = req.get("X-Ownership-Probe") === "1" && !presentedPaymentHeader;
+
+    if (validate && !isOwnershipProbe) {
       try {
         await validate(req);
       } catch (err) {

--- a/src/ownership.probe-header.test.ts
+++ b/src/ownership.probe-header.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { verifyResourceOwnership } from "./ownership.js";
+
+// Issue #89. The Layer 2 verifier must identify itself so a seller whose route
+// requires query parameters can answer with its 402 challenge instead of a 400
+// for missing input. Without the header those routes are permanently
+// unverifiable, which is what left 9 of 19 catalog entries stuck.
+describe("Layer 2 verification sends X-Ownership-Probe", () => {
+  it("sets X-Ownership-Probe: 1 on the verification fetch", async () => {
+    let seen: Record<string, string> | undefined;
+    const fetchFn = (async (_url: string, init: { headers?: Record<string, string> }) => {
+      seen = init.headers;
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { cancel: async () => {} },
+      };
+    }) as unknown as typeof fetch;
+
+    await verifyResourceOwnership("https://seller.example/stroops", "GAAA", {
+      fetchFn,
+      lookupFn: async () => ({ address: "93.184.216.34", family: 4 }),
+    });
+
+    expect(seen).toBeDefined();
+    expect(seen!["X-Ownership-Probe"]).toBe("1");
+  });
+
+  it("still sends accept: application/json alongside it", async () => {
+    let seen: Record<string, string> | undefined;
+    const fetchFn = (async (_url: string, init: { headers?: Record<string, string> }) => {
+      seen = init.headers;
+      return {
+        status: 200,
+        headers: { get: () => null },
+        body: { cancel: async () => {} },
+      };
+    }) as unknown as typeof fetch;
+
+    await verifyResourceOwnership("https://seller.example/hash", "GAAA", {
+      fetchFn,
+      lookupFn: async () => ({ address: "93.184.216.34", family: 4 }),
+    });
+
+    expect(seen!.accept).toBe("application/json");
+  });
+});

--- a/src/ownership.ts
+++ b/src/ownership.ts
@@ -306,7 +306,17 @@ async function probeOnce(
       method: "GET",
       redirect: "manual", // never follow a redirect into a blocked range
       signal: controller.signal,
-      headers: { accept: "application/json" },
+      // X-Ownership-Probe marks this as a verification probe rather than a
+      // buyer request, so a seller whose route requires query parameters can
+      // answer with its 402 challenge instead of a 400 for missing input.
+      // Without it, every input-taking route is permanently unverifiable: the
+      // verifier never sees the challenge it needs (issue #89).
+      //
+      // It is a HINT, not a credential. A seller that ignores it behaves
+      // exactly as before, and a client that forges it gains nothing, because
+      // the header only ever causes a 402 to be returned earlier. Payment is
+      // still required to get past the gate.
+      headers: { accept: "application/json", "X-Ownership-Probe": "1" },
       dispatcher,
     } as unknown as RequestInit);
 


### PR DESCRIPTION
Fixes #89.

9 of 19 catalog entries permanently unverified because input-taking routes
return 400 for bare GET probes.

**Fix:** verifier sends `X-Ownership-Probe: 1`. Seller returns 402 for probe
requests, skipping input validation. Probes never pay so there is no on-chain
loss path (contrast with the reverted 7f03234).

After fix: `/stroops`, `/hash`, `/word-count`, `/qr`, `/color`, `/markdown`,
`/diff`, `/regex`, `/csv`, `/cron`, `/units`, `/weather` should all become
ownerVerified on next settlement.

## The safety condition, which is not in the issue

The seller requires the probe header **and the absence of payment**:

```js
const isOwnershipProbe = req.get("X-Ownership-Probe") === "1" && !presentedPaymentHeader;
```

That second half is the whole point. `buildResult` still does not re-validate,
so if a request carrying payment could skip validation, forging the header would
reopen the exact loss path 7f03234 created: settle on-chain, then throw
`handler_failed`, money gone. Requiring no payment means a probe can only ever
*read* the challenge.

Verified locally on `/stroops`:

| Request | Result |
|---|---|
| probe header, no payment | **402** (verifier sees the challenge) |
| no header, no params | **400** (regression guard, buyer pays nothing) |
| no header, valid param | **402** (normal payment gate) |
| no header, invalid param | **400** (validation still fires) |
| probe header **+ payment** | **400** (no bypass, loss path closed) |

## The header is a hint, not a credential

A seller that ignores it behaves exactly as before, and forging it gains
nothing, because the header only ever causes a 402 to be returned earlier.
Payment is still required to get past the gate. That property is what makes a
non-standard header acceptable here rather than a trust boundary.

## Tests

6 new, **647 passing** (was 641), typecheck clean.

- `src/ownership.probe-header.test.ts`: the verifier sends the header, and still
  sends `accept: application/json` alongside it
- `examples/probe-protocol.test.mjs`: probe recognised; bare GET **not**
  recognised (the 7f03234 regression guard); probe-plus-payment **not**
  recognised; header values other than exactly `"1"` ignored

## Note on deployment

The demo seller deploys from `main`, so the live behaviour change lands on
merge, not before. Post-merge verification is a bare GET returning 400 and a
probe-header GET returning 402 against
`vellar-seller-demo.onrender.com/stroops`, then one settlement per route to earn
the badges (per RA-9, verdicts are re-derived on settlement, never read from
disk).
