### PR TITLE
fix(demo): generate and fund channel accounts in demo.sh

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -30,15 +30,59 @@ PAYER_SECRET=$(grep -oE '^PAYER_SECRET=\S+' <<<"$PROV" | cut -d= -f2)
 SPONSOR=$(node -e 'const{Keypair}=require("@stellar/stellar-sdk");const k=Keypair.random();console.log(k.secret()+" "+k.publicKey())')
 curl -fsS "https://friendbot.stellar.org/?addr=${SPONSOR#* }" >/dev/null
 
+# The settlement pool. src/config.ts requires EXACTLY 50 distinct funded
+# classic secrets, none of them the sponsor's, and there is no
+# "pool disabled" fallback: settling every payment from one signer under
+# concurrency is the txBadSeq bug the pool exists to close
+# (docs/channel-pool-design.md §1). Before this block existed the facilitator
+# exited at boot and demo.sh reported "seller did not come up", which is the
+# seller failing to reach a facilitator that was already dead (issue #90).
+#
+# Keys live in a shell variable and are never written to disk. They are
+# throwaway testnet accounts good for one demo run, so a file would be a
+# gitignore liability for no benefit.
+say "2b/5  Provisioning 50 channel accounts (friendbot, ~5 at a time)"
+CHANNEL_KEYS=$(node -e '
+const { Keypair } = require("@stellar/stellar-sdk");
+const N = 50, CONCURRENCY = 5;
+const pairs = Array.from({ length: N }, () => Keypair.random());
+let done = 0;
+async function fund(kp) {
+  // Friendbot occasionally 503s or times out under burst. Retry a few times
+  // rather than failing the whole demo on one flaky request.
+  for (let attempt = 1; attempt <= 4; attempt++) {
+    try {
+      const res = await fetch(`https://friendbot.stellar.org/?addr=${kp.publicKey()}`);
+      if (res.ok) { process.stderr.write(`\r  funded ${++done}/${N}`); return; }
+    } catch {}
+    await new Promise((r) => setTimeout(r, 500 * attempt));
+  }
+  throw new Error(`friendbot failed for ${kp.publicKey()} after 4 attempts`);
+}
+(async () => {
+  const queue = [...pairs];
+  await Promise.all(
+    Array.from({ length: CONCURRENCY }, async () => {
+      while (queue.length) await fund(queue.shift());
+    }),
+  );
+  process.stderr.write("\n");
+  console.log(pairs.map((k) => k.secret()).join(","));
+})().catch((e) => { console.error(e.message); process.exit(1); });
+') || die "could not fund the 50 channel accounts (friendbot may be rate-limiting; re-run once)"
+[ "$(tr -cd , <<<"$CHANNEL_KEYS" | wc -c)" -eq 49 ] || die "expected 50 channel keys, got $(( $(tr -cd , <<<"$CHANNEL_KEYS" | wc -c) + 1 ))"
+
 say "3/5  Booting facilitator (:4100) + seller (:4031)"
 mkdir -p data
-SPONSOR_SECRET_KEY="${SPONSOR%% *}" PORT=4100 CATALOG_DB_URL=file:./data/catalog.db npm start >demo-facilitator.log 2>&1 &
+SPONSOR_SECRET_KEY="${SPONSOR%% *}" CHANNEL_ACCOUNT_SECRET_KEYS="$CHANNEL_KEYS" \
+  PORT=4100 CATALOG_DB_URL=file:./data/catalog.db npm start >demo-facilitator.log 2>&1 &
 FAC_PID=$!
 for i in $(seq 1 60); do curl -fsS localhost:4100/health >/dev/null 2>&1 && break; sleep 2; done
 (cd examples && FACILITATOR_URL=http://localhost:4100 SELLER_PORT=4031 PAYTO="$PAYTO" ASSET="$ASSET" node seller.mjs >../demo-seller.log 2>&1) &
 SEL_PID=$!
 trap 'kill $FAC_PID $SEL_PID 2>/dev/null || true' EXIT
 for i in $(seq 1 90); do curl -fsS localhost:4031/whoami >/dev/null 2>&1 && break; sleep 2; done
+curl -fsS localhost:4100/health >/dev/null 2>&1 || die "the FACILITATOR did not come up — see demo-facilitator.log (it exits at boot on a config error, and the seller then has nothing to reach)"
 curl -fsS localhost:4031/whoami >/dev/null || die "seller did not come up — see demo-seller.log"
 
 say "4/5  Paying (official x402 client; submission retries are internal now)"

--- a/technical-doc.md
+++ b/technical-doc.md
@@ -171,8 +171,8 @@ Two honest qualifiers. The Circle faucet step needs a browser and cannot be
 scripted, so 60 s is a real floor for a first-time developer rather than an
 artifact. And this measures the path against the **hosted** facilitator; running
 a local facilitator additionally requires 50 funded channel accounts, documented
-in [`docs/deploy-runbook.md`](./docs/deploy-runbook.md). `demo.sh` was meant to
-automate that and currently does not (§8).
+in [`docs/deploy-runbook.md`](./docs/deploy-runbook.md), which `demo.sh` now
+provisions automatically for a local run (§8).
 
 The same flow as a sequence, including the auto-cataloging step that makes
 the resource discoverable (§5):
@@ -492,15 +492,22 @@ Implemented, tested, and live:
   `USE_USDC=1` — canonical testnet USDC acquired from the DEX with no faucet.
   The seller refuses at boot to write unverifiable entries into shared state,
   and the hosted demo resource is itself payable in USDC by any stranger.
-  `demo.sh` was written to walk a clean clone to a settled transaction hash in
-  one command, with preflight checks that each name the real failure they
-  prevent. It is **currently broken** and does not reach a settlement: the
-  channel-pool change (`6f5de85`, 2026-08-31) made
-  `CHANNEL_ACCOUNT_SECRET_KEYS` a hard boot requirement and the script was
-  never updated, so the facilitator exits at `config.ts:414` and the script
-  reports a misleading "seller did not come up". The working path today is
-  the hosted facilitator plus `examples/buyer-classic.mjs` (§4). Tracked in
-  [#90](https://github.com/Vellar-Wallet/vellar-facilitator/issues/90).
+  `demo.sh` walks a clean clone to a settled transaction hash in one command,
+  with preflight checks that each name the real failure they prevent. It
+  generates and friendbot-funds the 50 channel accounts the settlement pool
+  requires, so no account has to exist beforehand. Last verified end to end on
+  2026-09-08: settled
+  [`8043da50…e68f`](https://stellar.expert/explorer/testnet/tx/8043da503258007485f68fe0e1d65a4ed336a988bd820868375f8435c35be68f)
+  (ledger 4575125) from a clean run.
+
+  It was **broken between 2026-08-31 and 2026-09-08**, which is recorded rather
+  than quietly fixed because the docs claimed otherwise for that whole window:
+  the channel-pool change (`6f5de85`) made `CHANNEL_ACCOUNT_SECRET_KEYS` a hard
+  boot requirement and the script was never updated, so the facilitator exited
+  at `config.ts:414` and the script reported a misleading "seller did not come
+  up". Fixed in
+  [#90](https://github.com/Vellar-Wallet/vellar-facilitator/issues/90); the
+  failure message now distinguishes a dead facilitator from a dead seller.
 - **VS Code extension**
   ([`VellarWallet.vellar-x402`](https://marketplace.visualstudio.com/items?itemName=VellarWallet.vellar-x402),
   v0.1.3, MIT, live on the VS Code Marketplace): one command adds a working x402


### PR DESCRIPTION
Fixes #90.

`demo.sh` has been broken since `6f5de85` because it does not provision the 50
channel accounts `config.ts` requires.

**Fix:** generates 50 keypairs, funds via friendbot, exports
`CHANNEL_ACCOUNT_SECRET_KEYS` before starting the facilitator. Works on a clean
machine with no pre-existing accounts.

## Verified end to end

A full clean run, not a syntax check:

```
2b/5  Provisioning 50 channel accounts (friendbot, ~5 at a time)
  funded 50/50
5/5  Done, settled on Stellar testnet
  tx: 8043da503258007485f68fe0e1d65a4ed336a988bd820868375f8435c35be68f
```

Horizon-confirmed: `successful=True`, ledger **4575125**. Zero manual steps
between `./demo.sh` and a settled payment.

## Three details beyond the minimum

**Keys never touch disk.** They live in a shell variable for the life of the
run. These are throwaway testnet accounts good for one demo, so a file would be
a gitignore liability for no benefit. `config.ts` also rejects a pool containing
the sponsor key or any duplicate; random generation avoids both by
construction.

**Friendbot is retried**, up to four attempts per account with linear backoff.
Fifty requests in a burst is exactly the shape that gets rate-limited, and one
flaky response should not fail the whole demo.

**The misleading failure message is fixed.** This bug was hard to find because
the script reported `seller did not come up` when the *facilitator* was what
died; the seller was simply unable to reach it. It now checks facilitator health
first and says which process actually failed.

## Docs

`technical-doc.md` carried two claims that `demo.sh` was broken or did not
automate channel provisioning. Both updated. The window it was broken in
(2026-08-31 to 2026-09-08) is **recorded rather than erased**, because the docs
claimed it worked for that entire period.
