### PR TITLE
refactor: extract shared DEFAULT_RPC map (issue #88)

### DIFF
--- a/src/bond.ts
+++ b/src/bond.ts
@@ -78,16 +78,13 @@ import {
   rpc,
   xdr,
 } from "@stellar/stellar-sdk";
+import { DEFAULT_RPC } from "./rpc-defaults.js";
 
 const PASSPHRASES: Record<string, string> = {
   "stellar:testnet": "Test SDF Network ; September 2015",
   "stellar:pubnet": "Public Global Stellar Network ; September 2015",
 };
 
-const DEFAULT_RPC: Record<string, string> = {
-  "stellar:testnet": "https://soroban-testnet.stellar.org",
-  "stellar:pubnet": "https://mainnet.sorobanrpc.com",
-};
 
 /** Only the codes register_settlement can actually return, per
  *  contracts/bond-escrow/src/lib.rs's Error enum (AlreadyInitialized=1,

--- a/src/rpc-defaults.test.ts
+++ b/src/rpc-defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { DEFAULT_RPC, defaultRpcFor } from "./rpc-defaults.js";
+
+// Issue #88. Three modules used to encode this pair independently and agreed
+// only because f1d078b checked them by hand. The point of these tests is not
+// that the map has the right contents, which is one assertion, but that NOTHING
+// ELSE re-encodes it. A test that only checked DEFAULT_RPC's values would pass
+// happily while a fourth copy drifted in some other file.
+describe("DEFAULT_RPC", () => {
+  it("has a default for both networks", () => {
+    expect(DEFAULT_RPC["stellar:testnet"]).toBe("https://soroban-testnet.stellar.org");
+    expect(DEFAULT_RPC["stellar:pubnet"]).toBe("https://mainnet.sorobanrpc.com");
+  });
+
+  it("defaultRpcFor resolves the same values", () => {
+    expect(defaultRpcFor("stellar:testnet")).toBe(DEFAULT_RPC["stellar:testnet"]);
+    expect(defaultRpcFor("stellar:pubnet")).toBe(DEFAULT_RPC["stellar:pubnet"]);
+  });
+
+  it("returns undefined for an unknown network rather than a wrong default", () => {
+    // Silently falling back to testnet for an unrecognised network is how a
+    // pubnet deployment ends up resolving trust against testnet.
+    expect(defaultRpcFor("stellar:futurenet")).toBeUndefined();
+  });
+
+  it("testnet and pubnet do NOT share a URL", () => {
+    // Guards the copy-paste failure this refactor is meant to make impossible:
+    // one line edited, the other left pointing at the wrong network.
+    expect(DEFAULT_RPC["stellar:testnet"]).not.toBe(DEFAULT_RPC["stellar:pubnet"]);
+  });
+});
+
+// The enforcement half. This is what catches drift, and it works by reading the
+// source rather than by importing, because a module that re-declares the URL
+// locally would not expose anything for an import-based test to compare.
+describe("no module re-encodes the RPC URLs", () => {
+  const SOURCES = ["src/upto.ts", "src/bond.ts", "src/server.ts"];
+  const URLS = ["https://soroban-testnet.stellar.org", "https://mainnet.sorobanrpc.com"];
+
+  for (const file of SOURCES) {
+    it(`${file} imports the shared map instead of hardcoding a URL`, () => {
+      const src = readFileSync(file, "utf8");
+      for (const url of URLS) {
+        expect(src, `${file} hardcodes ${url}; import it from ./rpc-defaults.js`).not.toContain(url);
+      }
+      expect(src).toMatch(/from "\.\/rpc-defaults\.js"/);
+    });
+  }
+
+  it("rpc-defaults.ts is the only non-test source holding these URLs", () => {
+    // A fourth copy added anywhere under src/ fails here, which is the drift
+    // the issue was filed about.
+    const offenders = [...SOURCES, "src/config.ts", "src/trust.ts", "src/facilitator.ts"]
+      .filter((f) => {
+        const src = readFileSync(f, "utf8");
+        return URLS.some((u) => src.includes(u));
+      });
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/rpc-defaults.ts
+++ b/src/rpc-defaults.ts
@@ -1,0 +1,39 @@
+/**
+ * The default Soroban RPC endpoint per network, in ONE place.
+ *
+ * This pair used to be written out three times: `src/upto.ts`, `src/bond.ts`,
+ * and an inline ternary in `src/server.ts`. They agreed only because f1d078b
+ * checked them by hand, and nothing would have caught a fourth copy or a typo
+ * in one of them.
+ *
+ * That is the `docs/closing-state.md` §3.7 shape, "one identity, several
+ * derivations, no test that they agree", which has already produced a real
+ * defect here once (G-3: the spend policy keyed on the raw URL while the
+ * catalog keyed on the canonical one, and they agreed only because the demo
+ * seller happened to report one stable URL). The drift is silent when it
+ * happens: a facilitator settling on pubnet while resolving trust against
+ * testnet returns "unknown" verdicts rather than an error.
+ *
+ * `src/rpc-defaults.test.ts` asserts every consumer resolves to these values,
+ * so a future divergence fails CI instead of being found by hand.
+ *
+ * NOT included here: the Horizon pair in `src/server.ts` (balance polling).
+ * Different service, different hostnames, and it exists at exactly one site, so
+ * it carries no drift risk today. Folding it in would mean one map holding two
+ * unrelated identities keyed the same way, which is worse than the duplication
+ * it would remove.
+ */
+export const DEFAULT_RPC: Record<string, string> = {
+  "stellar:testnet": "https://soroban-testnet.stellar.org",
+  "stellar:pubnet": "https://mainnet.sorobanrpc.com",
+};
+
+/**
+ * The default RPC for a network, or undefined for a network we have no default
+ * for. Callers pass `config.network`, which is typed to the two known values,
+ * so the undefined branch is unreachable in production and exists for the
+ * hand-constructed case in tests.
+ */
+export function defaultRpcFor(network: string): string | undefined {
+  return DEFAULT_RPC[network];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import type { PaymentPayload, PaymentRequirements } from "@x402/core/types";
 import { loadConfig } from "./config.js";
 import { buildFacilitator, withChannelAcquisitionCapture, type BuiltFacilitator } from "./facilitator.js";
 import { LibsqlCatalogStore } from "./store.js";
+import { defaultRpcFor } from "./rpc-defaults.js";
 import { installRpcStatusCapture, withRpcStatusCapture } from "./rpcstatus.js";
 import { withSkewRetry } from "./retry.js";
 import { BazaarCatalog } from "./catalog.js";
@@ -1054,11 +1055,9 @@ if (isDirectRun) {
   const { createTrustResolver } = await import("./trust.js");
   const trust = createTrustResolver({
     verificationApiUrl: config.verificationApiUrl,
-    rpcUrl:
-      config.rpcUrl ??
-      (config.network === "stellar:pubnet"
-        ? "https://mainnet.sorobanrpc.com"
-        : "https://soroban-testnet.stellar.org"),
+    // Was an inline ternary duplicating the same pair a third time (f1d078b).
+    // Now the one shared map, so this cannot drift from upto.ts and bond.ts.
+    rpcUrl: config.rpcUrl ?? defaultRpcFor(config.network),
   });
   // Per-settle spend is estimated at the fee ceiling (worst case) since the real
   // simulated fee is not exposed on the verify response — over-counting fails safe.

--- a/src/upto.ts
+++ b/src/upto.ts
@@ -47,16 +47,13 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 import type { PaymentPayload, PaymentRequirements, Network } from "@x402/core/types";
+import { DEFAULT_RPC } from "./rpc-defaults.js";
 
 const PASSPHRASES: Record<string, string> = {
   "stellar:testnet": "Test SDF Network ; September 2015",
   "stellar:pubnet": "Public Global Stellar Network ; September 2015",
 };
 
-const DEFAULT_RPC: Record<string, string> = {
-  "stellar:testnet": "https://soroban-testnet.stellar.org",
-  "stellar:pubnet": "https://mainnet.sorobanrpc.com",
-};
 
 /** Argument order of the contract's `settle`, per contracts/upto-stellar/src/lib.rs. */
 const ARG = { token: 0, from: 1, to: 2, max: 3, expiration: 4, nonce: 5, actual: 6, hook: 7 } as const;


### PR DESCRIPTION
Fixes #88.

Three sites hardcoded the same testnet/pubnet RPC URL pair with nothing
enforcing they stay in sync. `f1d078b` checked them by hand; this PR makes
agreement automatic.

Extracts `DEFAULT_RPC` to `src/rpc-defaults.ts`. All three sites import from it.
New test asserts URLs agree across modules.

After this change the two URLs appear **exactly once** in non-test source.

## The test reads source, not values

An import-based test (`expect(UPTO_DEFAULT_RPC[...]).toBe(DEFAULT_RPC[...])`)
would not catch the failure this issue is about. A module that re-declares the
URL locally exposes nothing to import and compare, so such a test passes
happily while the fourth copy drifts.

Instead the enforcement half reads each consumer's source and asserts it does
**not** contain either URL and **does** import from `./rpc-defaults.js`. It also
checks three files that have no business holding these URLs (`config.ts`,
`trust.ts`, `facilitator.ts`), so a new copy anywhere in that set fails too.

## Mutation-verified

The guard was confirmed to fail before being trusted. Injecting a hardcoded URL
back into `upto.ts`:

```
× src/upto.ts imports the shared map instead of hardcoding a URL
× rpc-defaults.ts is the only non-test source holding these URLs
```

Two of eight tests fail and name the offending file.

## Horizon pair deliberately left alone

The issue asked whether the Horizon pair (`src/server.ts`, balance polling)
should fold into the same fix. It should not. Different service, different
hostnames, and it exists at exactly **one** site, so it carries no drift risk
today. One map holding two unrelated identities keyed the same way would be
worse than the duplication it removed. If a second Horizon site ever appears,
that is the moment to extract it.

## Verification

**655 tests passing** (was 647), 8 new. Typecheck clean.
